### PR TITLE
Fix NU5128 pack warning for analyzer project

### DIFF
--- a/src/Quarry.Analyzers/Quarry.Analyzers.csproj
+++ b/src/Quarry.Analyzers/Quarry.Analyzers.csproj
@@ -7,6 +7,7 @@
     <IsRoslynComponent>true</IsRoslynComponent>
     <BuildOutputTargetFolder>analyzers/dotnet/cs</BuildOutputTargetFolder>
     <IsPackable>true</IsPackable>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);RS2008</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Suppress NU5128 NuGet warning when packing `Quarry.Analyzers` by adding `SuppressDependenciesWhenPacking=true`

## Reason for Change
The CI build produces a `NU5128` warning because the analyzer package declares a `netstandard2.0` dependency group (from `PackageReference` items) but outputs to `analyzers/dotnet/cs` instead of `lib/netstandard2.0`. NuGet flags the mismatch between the dependency group and the missing `lib` folder.

## Impact
- Eliminates the `NU5128` warning during `dotnet pack`
- The analyzer's dependencies (`Microsoft.CodeAnalysis.*`) are already `PrivateAssets="all"`, so suppressing the dependency group from the nuspec is correct — Roslyn loads analyzer assemblies directly with no runtime dependency resolution

## Migration Steps
- None

## Performance Considerations
- None

## Security Considerations
- None

## Breaking Changes
- **Consumer-facing**: None
- **Internal**: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)