### PR TITLE
Feat: Enable ToSql-terminated chains for PrebuiltDispatch grouping

### DIFF
--- a/src/Quarry.Generator/QuarryGenerator.cs
+++ b/src/Quarry.Generator/QuarryGenerator.cs
@@ -1161,8 +1161,7 @@ public sealed class QuarryGenerator : IIncrementalGenerator
                     return QueryKind.Delete;
                 if (executionSite.BuilderTypeName.Contains("UpdateBuilder"))
                     return QueryKind.Update;
-                if (executionSite.BuilderTypeName.Contains("QueryBuilder")
-                    || executionSite.BuilderTypeName.Contains("JoinedQueryBuilder"))
+                if (executionSite.BuilderTypeName.Contains("QueryBuilder"))
                     return QueryKind.Select;
                 return null; // IEntityAccessor — trivial db.Users().ToSql(), no clauses to optimize
 

--- a/src/Quarry.Tests/Generation/CarrierGenerationTests.cs
+++ b/src/Quarry.Tests/Generation/CarrierGenerationTests.cs
@@ -286,9 +286,9 @@ public partial class TestDbContext : QuarryContext
 
 public static class Queries
 {
-    public static string Test(TestDbContext db, bool active)
+    public static string Test(TestDbContext db, int id)
     {
-        return db.Users().DeleteWhere(u => u.IsActive == active).ToSql();
+        return db.Users().Delete().Where(u => u.UserId == id).ToSql();
     }
 }
 ";
@@ -312,7 +312,10 @@ public static class Queries
         }
 
         var code = interceptorsTree!.GetText().ToString();
-        Assert.That(code.Length, Is.GreaterThan(100), "Should have generated interceptor content for Delete ToSql");
+        Assert.That(code, Does.Contain("Chain_"),
+            "Delete ToSql chain should be grouped into a carrier chain");
+        Assert.That(code, Does.Contain("DELETE"),
+            "Delete ToSql chain should contain prebuilt DELETE SQL");
     }
 
     [Test]
@@ -327,9 +330,9 @@ public partial class TestDbContext : QuarryContext
 
 public static class Queries
 {
-    public static string Test(TestDbContext db, bool active)
+    public static string Test(TestDbContext db, int userId, string newName)
     {
-        return db.Users().Set(u => u.IsActive, active).UpdateWhere(u => u.UserId == 1).ToSql();
+        return db.Users().Update().Set(u => u.UserName, newName).Where(u => u.UserId == userId).ToSql();
     }
 }
 ";
@@ -353,7 +356,8 @@ public static class Queries
         }
 
         var code = interceptorsTree!.GetText().ToString();
-        Assert.That(code.Length, Is.GreaterThan(100), "Should have generated interceptor content for Update ToSql");
+        Assert.That(code, Does.Contain("UPDATE"),
+            "Update ToSql chain should contain prebuilt UPDATE SQL");
     }
 
     [Test]
@@ -377,11 +381,21 @@ public static class Queries
 ";
 
         var compilation = CreateCompilation(source);
-        var (_, diagnostics) = RunGeneratorWithDiagnostics(compilation);
+        var (result, diagnostics) = RunGeneratorWithDiagnostics(compilation);
 
         // Should not produce QRY errors — the chain is valid, just not optimizable
         var qryErrors = diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error && d.Id.StartsWith("QRY")).ToList();
         Assert.That(qryErrors, Is.Empty, "Bare IEntityAccessor ToSql should not produce errors");
+
+        // Verify no carrier class was generated for this trivial chain
+        var interceptorsTree = result.GeneratedTrees
+            .FirstOrDefault(t => t.FilePath.Contains("Interceptors") && t.FilePath.EndsWith(".g.cs"));
+        if (interceptorsTree != null)
+        {
+            var code = interceptorsTree.GetText().ToString();
+            Assert.That(code, Does.Not.Contain("file sealed class Chain_"),
+                "Bare IEntityAccessor ToSql should not produce carrier class");
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Closes #13
- Adds `InterceptorKind.ToSql` case to `DetermineQueryKind()` so ToSql-terminated chains are grouped into carrier-optimized PrebuiltDispatch chains

## Reason for Change
`ToSql()`-terminated query chains (e.g., `db.Users().Where(u => u.IsActive).ToSql()`) were never grouped into PrebuiltDispatch chains because `DetermineQueryKind()` had no `case InterceptorKind.ToSql:`. The switch fell through to `default: return null`, causing `BuildPrebuiltChainInfo` to bail out and leave all member sites as standalone interceptors.

## Impact
- Select, Delete, and Update chains terminated with `.ToSql()` now receive the same carrier-class PrebuiltDispatch optimization as their `Execute*` counterparts
- Bare `IEntityAccessor` ToSql chains (e.g., `db.Users().ToSql()`) are correctly excluded — they have zero clauses and already produce correct standalone interceptors

## Migration Steps
None — this is a purely additive optimization. Existing code continues to work; chains that previously fell back to standalone interceptors will now be optimized.

## Performance Considerations
Positive — ToSql chains now benefit from prebuilt SQL dispatch, avoiding runtime SQL construction.

## Security Considerations
None.

## Breaking Changes
- Consumer-facing: None
- Internal: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)