### PR TITLE
Feat: Runtime pre/post hooks on MigrationRunner

### DIFF
--- a/src/Quarry.Tests/Migration/MigrationRunnerIntegrationTests.cs
+++ b/src/Quarry.Tests/Migration/MigrationRunnerIntegrationTests.cs
@@ -1899,4 +1899,207 @@ public class MigrationRunnerIntegrationTests
         var result = await cmd.ExecuteScalarAsync();
         Assert.That(result, Is.EqualTo("users"));
     }
+
+    [Test]
+    public async Task RunAsync_BeforeEachAndAfterEach_CalledDuringUpgrade()
+    {
+        var beforeCalls = new List<(int Version, string Name)>();
+        var afterCalls = new List<(int Version, string Name, TimeSpan Elapsed)>();
+
+        var migrations = new (int, string, Action<MigrationBuilder>, Action<MigrationBuilder>, Action<MigrationBuilder>)[]
+        {
+            (1, "CreateUsers",
+                b => b.CreateTable("users", null, t =>
+                {
+                    t.Column("id", c => c.ClrType("int").NotNull());
+                    t.PrimaryKey("PK_users", "id");
+                }),
+                b => b.DropTable("users"),
+                _ => { }),
+            (2, "CreatePosts",
+                b => b.CreateTable("posts", null, t =>
+                {
+                    t.Column("id", c => c.ClrType("int").NotNull());
+                    t.PrimaryKey("PK_posts", "id");
+                }),
+                b => b.DropTable("posts"),
+                _ => { })
+        };
+
+        var options = new MigrationOptions
+        {
+            BeforeEach = (version, name, conn) =>
+            {
+                beforeCalls.Add((version, name));
+                return Task.CompletedTask;
+            },
+            AfterEach = (version, name, elapsed, conn) =>
+            {
+                afterCalls.Add((version, name, elapsed));
+                return Task.CompletedTask;
+            }
+        };
+
+        await MigrationRunner.RunAsync(_connection, _dialect, migrations, options);
+
+        Assert.That(beforeCalls, Has.Count.EqualTo(2));
+        Assert.That(beforeCalls[0].Version, Is.EqualTo(1));
+        Assert.That(beforeCalls[1].Version, Is.EqualTo(2));
+        Assert.That(afterCalls, Has.Count.EqualTo(2));
+        Assert.That(afterCalls[0].Version, Is.EqualTo(1));
+        Assert.That(afterCalls[1].Version, Is.EqualTo(2));
+        Assert.That(afterCalls[0].Elapsed, Is.GreaterThan(TimeSpan.Zero));
+    }
+
+    [Test]
+    public async Task RunAsync_BeforeEachAndAfterEach_CalledDuringRollback()
+    {
+        var migrations = new (int, string, Action<MigrationBuilder>, Action<MigrationBuilder>, Action<MigrationBuilder>)[]
+        {
+            (1, "CreateUsers",
+                b => b.CreateTable("users", null, t =>
+                {
+                    t.Column("id", c => c.ClrType("int").NotNull());
+                    t.PrimaryKey("PK_users", "id");
+                }),
+                b => b.DropTable("users"),
+                _ => { })
+        };
+
+        // First apply the migration
+        await MigrationRunner.RunAsync(_connection, _dialect, migrations);
+
+        // Now rollback with hooks
+        var beforeCalls = new List<(int Version, string Name)>();
+        var afterCalls = new List<(int Version, string Name, TimeSpan Elapsed)>();
+
+        var options = new MigrationOptions
+        {
+            Direction = MigrationDirection.Downgrade,
+            BeforeEach = (version, name, conn) =>
+            {
+                beforeCalls.Add((version, name));
+                return Task.CompletedTask;
+            },
+            AfterEach = (version, name, elapsed, conn) =>
+            {
+                afterCalls.Add((version, name, elapsed));
+                return Task.CompletedTask;
+            }
+        };
+
+        await MigrationRunner.RunAsync(_connection, _dialect, migrations, options);
+
+        Assert.That(beforeCalls, Has.Count.EqualTo(1));
+        Assert.That(beforeCalls[0].Version, Is.EqualTo(1));
+        Assert.That(beforeCalls[0].Name, Is.EqualTo("CreateUsers"));
+        Assert.That(afterCalls, Has.Count.EqualTo(1));
+        Assert.That(afterCalls[0].Version, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task RunAsync_OnError_CalledOnFailure()
+    {
+        var errorCalls = new List<(int Version, string Name, Exception Ex)>();
+
+        var migrations = new (int, string, Action<MigrationBuilder>, Action<MigrationBuilder>, Action<MigrationBuilder>)[]
+        {
+            (1, "BadMigration",
+                b => b.Sql("INVALID SQL STATEMENT THAT WILL FAIL"),
+                b => { },
+                _ => { })
+        };
+
+        var options = new MigrationOptions
+        {
+            OnError = (version, name, ex, conn) =>
+            {
+                errorCalls.Add((version, name, ex));
+                return Task.CompletedTask;
+            }
+        };
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await MigrationRunner.RunAsync(_connection, _dialect, migrations, options));
+
+        Assert.That(errorCalls, Has.Count.EqualTo(1));
+        Assert.That(errorCalls[0].Version, Is.EqualTo(1));
+        Assert.That(errorCalls[0].Name, Is.EqualTo("BadMigration"));
+    }
+
+    [Test]
+    public async Task RunAsync_DryRun_SkipsHooks()
+    {
+        var hookCalled = false;
+
+        var migrations = new (int, string, Action<MigrationBuilder>, Action<MigrationBuilder>, Action<MigrationBuilder>)[]
+        {
+            (1, "CreateUsers",
+                b => b.CreateTable("users", null, t =>
+                {
+                    t.Column("id", c => c.ClrType("int").NotNull());
+                    t.PrimaryKey("PK_users", "id");
+                }),
+                b => b.DropTable("users"),
+                _ => { })
+        };
+
+        var options = new MigrationOptions
+        {
+            DryRun = true,
+            BeforeEach = (version, name, conn) =>
+            {
+                hookCalled = true;
+                return Task.CompletedTask;
+            },
+            AfterEach = (version, name, elapsed, conn) =>
+            {
+                hookCalled = true;
+                return Task.CompletedTask;
+            }
+        };
+
+        await MigrationRunner.RunAsync(_connection, _dialect, migrations, options);
+
+        Assert.That(hookCalled, Is.False);
+    }
+
+    [Test]
+    public async Task RunAsync_OnErrorThrows_RollbackStillHappensAndOriginalExceptionPropagates()
+    {
+        var migrations = new (int, string, Action<MigrationBuilder>, Action<MigrationBuilder>, Action<MigrationBuilder>)[]
+        {
+            (1, "CreateUsers",
+                b => b.CreateTable("users", null, t =>
+                {
+                    t.Column("id", c => c.ClrType("int").NotNull());
+                    t.PrimaryKey("PK_users", "id");
+                }),
+                b => b.DropTable("users"),
+                _ => { }),
+            (2, "BadMigration",
+                b => b.Sql("INVALID SQL STATEMENT THAT WILL FAIL"),
+                b => { },
+                _ => { })
+        };
+
+        var options = new MigrationOptions
+        {
+            OnError = (version, name, ex, conn) =>
+                throw new InvalidOperationException("Hook exploded")
+        };
+
+        var thrown = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await MigrationRunner.RunAsync(_connection, _dialect, migrations, options));
+
+        // Original migration exception propagates, not the hook exception
+        Assert.That(thrown!.Message, Does.Contain("BadMigration"));
+        Assert.That(thrown.Message, Does.Contain("failed during upgrade"));
+
+        // Migration 1 was committed before the failure, so users table should exist
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='users';";
+        var result = await cmd.ExecuteScalarAsync();
+        Assert.That(result, Is.EqualTo("users"));
+    }
 }

--- a/src/Quarry/Migration/MigrationOptions.cs
+++ b/src/Quarry/Migration/MigrationOptions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Data.Common;
+using System.Threading.Tasks;
 
 namespace Quarry.Migration;
 
@@ -27,4 +29,13 @@ public sealed class MigrationOptions
 
     /// <summary>Lock acquisition timeout. Emits SET LOCK_TIMEOUT / SET statement_timeout before DDL.</summary>
     public TimeSpan? LockTimeout { get; set; }
+
+    /// <summary>Called before each migration is applied or rolled back. Parameters: version, name, connection.</summary>
+    public Func<int, string, DbConnection, Task>? BeforeEach { get; set; }
+
+    /// <summary>Called after each migration is successfully applied or rolled back. Parameters: version, name, elapsed time, connection.</summary>
+    public Func<int, string, TimeSpan, DbConnection, Task>? AfterEach { get; set; }
+
+    /// <summary>Called when a migration fails, before rollback. Parameters: version, name, exception, connection.</summary>
+    public Func<int, string, Exception, DbConnection, Task>? OnError { get; set; }
 }

--- a/src/Quarry/Migration/MigrationRunner.cs
+++ b/src/Quarry/Migration/MigrationRunner.cs
@@ -100,6 +100,9 @@ public static class MigrationRunner
             return;
         }
 
+        if (options.BeforeEach != null)
+            await options.BeforeEach(migration.Version, migration.Name, connection);
+
         var sw = Stopwatch.StartNew();
 
         // Phase 1: Transactional operations (including backups and history row)
@@ -137,10 +140,23 @@ public static class MigrationRunner
             await InsertHistoryRowAsync(connection, tx, dialect, migration.Version, migration.Name, checksum, (int)sw.ElapsedMilliseconds, options);
 
             await tx.CommitAsync();
+
+            if (options.AfterEach != null)
+                await options.AfterEach(migration.Version, migration.Name, sw.Elapsed, connection);
         }
         catch (Exception ex)
         {
             MigrationLog.Failed(migration.Version, migration.Name, "upgrade", ex);
+
+            if (options.OnError != null)
+            {
+                try { await options.OnError(migration.Version, migration.Name, ex, connection); }
+                catch (Exception hookEx)
+                {
+                    MigrationLog.Failed(migration.Version, migration.Name, "OnError hook", hookEx);
+                }
+            }
+
             await tx.RollbackAsync();
             throw new InvalidOperationException(
                 $"Migration {migration.Version} ({migration.Name}) failed during upgrade (transactional phase). SQL: {txSql}", ex);
@@ -193,6 +209,9 @@ public static class MigrationRunner
             return;
         }
 
+        if (options.BeforeEach != null)
+            await options.BeforeEach(migration.Version, migration.Name, connection);
+
         var sw = Stopwatch.StartNew();
 
         // Phase 1: Non-transactional operations first during rollback
@@ -234,10 +253,23 @@ public static class MigrationRunner
             sw.Stop();
             MigrationLog.RolledBack(migration.Version);
             await tx.CommitAsync();
+
+            if (options.AfterEach != null)
+                await options.AfterEach(migration.Version, migration.Name, sw.Elapsed, connection);
         }
         catch (Exception ex)
         {
             MigrationLog.Failed(migration.Version, migration.Name, "rollback", ex);
+
+            if (options.OnError != null)
+            {
+                try { await options.OnError(migration.Version, migration.Name, ex, connection); }
+                catch (Exception hookEx)
+                {
+                    MigrationLog.Failed(migration.Version, migration.Name, "OnError hook", hookEx);
+                }
+            }
+
             await tx.RollbackAsync();
             throw new InvalidOperationException(
                 $"Migration {migration.Version} ({migration.Name}) failed during rollback. SQL: {txSql}", ex);


### PR DESCRIPTION
## Summary
Adds runtime async callback hooks (`BeforeEach`, `AfterEach`, `OnError`) to `MigrationOptions`, enabling operational workflows (notifications, health checks, trigger management, replication pausing) during migration execution. These complement the existing compile-time partial hooks which operate on `MigrationBuilder` for DDL injection.

- Closes #37

## Reason for Change
`MigrationRunner` had no runtime callback mechanism. The existing compile-time partial hooks (`BeforeUpgrade`, `AfterUpgrade`, etc.) operate on `MigrationBuilder` to inject DDL — they don't provide access to the connection or execution context at runtime. Runtime hooks fill this gap for operational side-effects.

## Impact
Additive-only change to `MigrationOptions` and `MigrationRunner`. No existing behavior is altered — all hooks are optional (`null` by default). Zero overhead when unconfigured (null checks only).

## Plan items implemented as specified
- `BeforeEach`: `Func<int, string, DbConnection, Task>?` — called before each migration is applied or rolled back
- `AfterEach`: `Func<int, string, TimeSpan, DbConnection, Task>?` — called after each successful migration with elapsed time
- `OnError`: `Func<int, string, Exception, DbConnection, Task>?` — called when a migration fails, before rollback
- Hooks wired into both `ApplyMigrationAsync` and `RollbackMigrationAsync`

## Deviations from plan implemented
- `AfterEach` is called after `CommitAsync()` (not before), ensuring hooks only fire on fully committed migrations
- `BeforeEach` is called before `BeginTransactionAsync()`, keeping hooks outside the transaction boundary (connection-only access as agreed)
- Hooks are skipped during `DryRun` mode to prevent real side-effects during SQL preview
- `OnError` invocations are guarded with try/catch — a throwing hook cannot prevent rollback or mask the original migration exception

## Gaps in original plan implemented
- Added safety guard around `OnError`: if the callback throws, the exception is logged via `MigrationLog` and rollback proceeds normally. The original migration exception always propagates. This was not specified in the issue but prevents a class of bugs where user-provided hook code could leave the database in an inconsistent state.

## Migration Steps
None required — additive API change only.

## Performance Considerations
Zero overhead when hooks are not configured (null checks only). When configured, performance impact depends entirely on the user-provided callback implementation.

## Security Considerations
Hooks receive `DbConnection` but not `DbTransaction`, preventing hook code from interfering with migration transaction atomicity.

## Breaking Changes
- Consumer-facing: None
- Internal: None

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)