### PR TITLE
Feat: Estimated row count warnings before DDL on large tables

### DIFF
--- a/src/Quarry.Tests/Migration/MigrationRunnerLargeTableTests.cs
+++ b/src/Quarry.Tests/Migration/MigrationRunnerLargeTableTests.cs
@@ -1,0 +1,372 @@
+using Microsoft.Data.Sqlite;
+using Quarry.Migration;
+
+namespace Quarry.Tests.Migration;
+
+public class MigrationRunnerLargeTableTests
+{
+    // --- GetAffectedTableNames ---
+
+    [Test]
+    public void GetAffectedTableNames_DropTable_ReturnsTableName()
+    {
+        var builder = new MigrationBuilder();
+        builder.DropTable("users");
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Is.EquivalentTo(new[] { "users" }));
+    }
+
+    [Test]
+    public void GetAffectedTableNames_RenameTable_ReturnsOldName()
+    {
+        var builder = new MigrationBuilder();
+        builder.RenameTable("users", "people");
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Is.EquivalentTo(new[] { "users" }));
+    }
+
+    [Test]
+    public void GetAffectedTableNames_AddColumn_ReturnsTableName()
+    {
+        var builder = new MigrationBuilder();
+        builder.AddColumn("users", "email", c => c.ClrType("string").Length(256));
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Is.EquivalentTo(new[] { "users" }));
+    }
+
+    [Test]
+    public void GetAffectedTableNames_DropColumn_ReturnsTableName()
+    {
+        var builder = new MigrationBuilder();
+        builder.DropColumn("users", "email");
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Is.EquivalentTo(new[] { "users" }));
+    }
+
+    [Test]
+    public void GetAffectedTableNames_RenameColumn_ReturnsTableName()
+    {
+        var builder = new MigrationBuilder();
+        builder.RenameColumn("users", "name", "display_name");
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Is.EquivalentTo(new[] { "users" }));
+    }
+
+    [Test]
+    public void GetAffectedTableNames_AlterColumn_ReturnsTableName()
+    {
+        var builder = new MigrationBuilder();
+        builder.AlterColumn("users", "name", c => c.ClrType("string").Length(200));
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Is.EquivalentTo(new[] { "users" }));
+    }
+
+    [Test]
+    public void GetAffectedTableNames_AddIndex_ReturnsTableName()
+    {
+        var builder = new MigrationBuilder();
+        builder.AddIndex("IX_users_email", "users", new[] { "email" });
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Is.EquivalentTo(new[] { "users" }));
+    }
+
+    [Test]
+    public void GetAffectedTableNames_DropIndex_ReturnsTableName()
+    {
+        var builder = new MigrationBuilder();
+        builder.DropIndex("IX_users_email", "users");
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Is.EquivalentTo(new[] { "users" }));
+    }
+
+    [Test]
+    public void GetAffectedTableNames_AddForeignKey_ReturnsTableName()
+    {
+        var builder = new MigrationBuilder();
+        builder.AddForeignKey("FK_orders_users", "orders", "user_id", "users", "id");
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Is.EquivalentTo(new[] { "orders" }));
+    }
+
+    [Test]
+    public void GetAffectedTableNames_DropForeignKey_ReturnsTableName()
+    {
+        var builder = new MigrationBuilder();
+        builder.DropForeignKey("FK_orders_users", "orders");
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Is.EquivalentTo(new[] { "orders" }));
+    }
+
+    [Test]
+    public void GetAffectedTableNames_CreateTable_ExcludedFromResults()
+    {
+        var builder = new MigrationBuilder();
+        builder.CreateTable("users", null, t =>
+        {
+            t.Column("id", c => c.ClrType("int").NotNull());
+            t.PrimaryKey("PK_users", "id");
+        });
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Is.Empty);
+    }
+
+    [Test]
+    public void GetAffectedTableNames_RawSql_ExcludedFromResults()
+    {
+        var builder = new MigrationBuilder();
+        builder.Sql("UPDATE users SET active = 1;");
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Is.Empty);
+    }
+
+    [Test]
+    public void GetAffectedTableNames_MultipleOperations_DeduplicatesTables()
+    {
+        var builder = new MigrationBuilder();
+        builder.AddColumn("users", "email", c => c.ClrType("string").Length(256));
+        builder.AddColumn("users", "phone", c => c.ClrType("string").Length(20));
+        builder.AddIndex("IX_users_email", "users", new[] { "email" });
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Has.Count.EqualTo(1));
+        Assert.That(tables, Is.EquivalentTo(new[] { "users" }));
+    }
+
+    [Test]
+    public void GetAffectedTableNames_MixedOperations_ReturnsOnlyExistingTableTargets()
+    {
+        var builder = new MigrationBuilder();
+        builder.CreateTable("new_table", null, t =>
+        {
+            t.Column("id", c => c.ClrType("int").NotNull());
+            t.PrimaryKey("PK_new_table", "id");
+        });
+        builder.AddColumn("users", "email", c => c.ClrType("string").Length(256));
+        builder.DropTable("old_table");
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Is.EquivalentTo(new[] { "users", "old_table" }));
+    }
+
+    [Test]
+    public void GetAffectedTableNames_EmptyOperations_ReturnsEmpty()
+    {
+        var builder = new MigrationBuilder();
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Is.Empty);
+    }
+
+    [Test]
+    public void GetAffectedTableNames_CaseInsensitiveDeduplication()
+    {
+        var builder = new MigrationBuilder();
+        builder.AddColumn("Users", "email", c => c.ClrType("string").Length(256));
+        builder.DropColumn("users", "old_field");
+
+        var tables = MigrationRunner.GetAffectedTableNames(builder.GetOperations());
+
+        Assert.That(tables, Has.Count.EqualTo(1));
+    }
+
+    // --- GetEstimatedRowCountSql ---
+
+    [Test]
+    public void GetEstimatedRowCountSql_SqlServer_QueriesSysPartitions()
+    {
+        var sql = MigrationRunner.GetEstimatedRowCountSql(SqlDialect.SqlServer);
+
+        Assert.That(sql, Is.Not.Null);
+        Assert.That(sql, Does.Contain("sys.partitions"));
+        Assert.That(sql, Does.Contain("sys.tables"));
+        Assert.That(sql, Does.Contain("@p0"));
+    }
+
+    [Test]
+    public void GetEstimatedRowCountSql_PostgreSQL_QueriesPgClass()
+    {
+        var sql = MigrationRunner.GetEstimatedRowCountSql(SqlDialect.PostgreSQL);
+
+        Assert.That(sql, Is.Not.Null);
+        Assert.That(sql, Does.Contain("pg_class"));
+        Assert.That(sql, Does.Contain("$1"));
+    }
+
+    [Test]
+    public void GetEstimatedRowCountSql_MySQL_QueriesInformationSchema()
+    {
+        var sql = MigrationRunner.GetEstimatedRowCountSql(SqlDialect.MySQL);
+
+        Assert.That(sql, Is.Not.Null);
+        Assert.That(sql, Does.Contain("information_schema.tables"));
+        Assert.That(sql, Does.Contain("DATABASE()"));
+    }
+
+    [Test]
+    public void GetEstimatedRowCountSql_SQLite_ReturnsNull()
+    {
+        var sql = MigrationRunner.GetEstimatedRowCountSql(SqlDialect.SQLite);
+
+        Assert.That(sql, Is.Null);
+    }
+
+    // --- Integration: WarnOnLargeTable with SQLite (no-op) ---
+
+    [Test]
+    public async Task RunAsync_WarnOnLargeTable_SQLite_SkipsWithoutError()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        var migrations = new (int, string, Action<MigrationBuilder>, Action<MigrationBuilder>, Action<MigrationBuilder>)[]
+        {
+            (1, "CreateUsers",
+                b => b.CreateTable("users", null, t =>
+                {
+                    t.Column("id", c => c.ClrType("int").NotNull());
+                    t.Column("name", c => c.ClrType("string").Length(100).NotNull());
+                    t.PrimaryKey("PK_users", "id");
+                }),
+                b => b.DropTable("users"),
+                _ => { })
+        };
+
+        var options = new MigrationOptions
+        {
+            WarnOnLargeTable = true,
+            LargeTableThreshold = 100
+        };
+
+        // Should not throw — SQLite large table warning is silently skipped
+        await MigrationRunner.RunAsync(connection, SqlDialect.SQLite, migrations, options);
+
+        // Verify the migration still applied successfully
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='users';";
+        var result = await cmd.ExecuteScalarAsync();
+        Assert.That(result, Is.EqualTo("users"));
+    }
+
+    [Test]
+    public async Task RunAsync_WarnOnLargeTable_SQLite_AlterTable_SkipsWithoutError()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        var migrations = new (int, string, Action<MigrationBuilder>, Action<MigrationBuilder>, Action<MigrationBuilder>)[]
+        {
+            (1, "CreateUsers",
+                b => b.CreateTable("users", null, t =>
+                {
+                    t.Column("id", c => c.ClrType("int").NotNull());
+                    t.PrimaryKey("PK_users", "id");
+                }),
+                b => b.DropTable("users"),
+                _ => { }),
+            (2, "AddEmail",
+                b => b.AddColumn("users", "email", c => c.ClrType("string").Length(256)),
+                b => b.DropColumn("users", "email"),
+                _ => { })
+        };
+
+        var options = new MigrationOptions
+        {
+            WarnOnLargeTable = true,
+            LargeTableThreshold = 0 // Even with threshold 0, SQLite should skip without error
+        };
+
+        await MigrationRunner.RunAsync(connection, SqlDialect.SQLite, migrations, options);
+
+        // Verify both migrations applied
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM __quarry_migrations WHERE status = 'applied';";
+        var count = Convert.ToInt32(await cmd.ExecuteScalarAsync());
+        Assert.That(count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task RunAsync_WarnOnLargeTable_Disabled_DoesNotQuery()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        var logOutput = new List<string>();
+        var migrations = new (int, string, Action<MigrationBuilder>, Action<MigrationBuilder>, Action<MigrationBuilder>)[]
+        {
+            (1, "CreateUsers",
+                b => b.CreateTable("users", null, t =>
+                {
+                    t.Column("id", c => c.ClrType("int").NotNull());
+                    t.PrimaryKey("PK_users", "id");
+                }),
+                b => b.DropTable("users"),
+                _ => { }),
+            (2, "AddEmail",
+                b => b.AddColumn("users", "email", c => c.ClrType("string").Length(256)),
+                b => b.DropColumn("users", "email"),
+                _ => { })
+        };
+
+        var options = new MigrationOptions
+        {
+            WarnOnLargeTable = false, // Disabled (default)
+            Logger = msg => logOutput.Add(msg)
+        };
+
+        await MigrationRunner.RunAsync(connection, SqlDialect.SQLite, migrations, options);
+
+        // No large table warnings should appear in log
+        Assert.That(logOutput, Has.None.Contain("WARNING: Table"));
+    }
+
+    [Test]
+    public async Task RunAsync_WarnOnLargeTable_DryRun_StillChecks()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        var migrations = new (int, string, Action<MigrationBuilder>, Action<MigrationBuilder>, Action<MigrationBuilder>)[]
+        {
+            (1, "AddEmail",
+                b => b.AddColumn("users", "email", c => c.ClrType("string").Length(256)),
+                b => b.DropColumn("users", "email"),
+                _ => { })
+        };
+
+        var options = new MigrationOptions
+        {
+            WarnOnLargeTable = true,
+            DryRun = true
+        };
+
+        // Should not throw — dry run + large table warning (SQLite skipped) works fine
+        await MigrationRunner.RunAsync(connection, SqlDialect.SQLite, migrations, options);
+    }
+}

--- a/src/Quarry/Logging/MigrationLog.cs
+++ b/src/Quarry/Logging/MigrationLog.cs
@@ -58,4 +58,10 @@ internal static partial class MigrationLog
 
     [LogMessage(LogLevel.Debug, "Migration {version} status updated to '{status}'")]
     internal static partial void StatusUpdated(int version, string status);
+
+    [LogMessage(LogLevel.Warning, "Table '{table}' has ~{estimatedRows} rows. ALTER TABLE may take a long time and acquire locks.")]
+    internal static partial void LargeTableWarning(string table, long estimatedRows);
+
+    [LogMessage(LogLevel.Warning, "WarnOnLargeTable is not supported for SQLite (no catalog statistics) and will be ignored")]
+    internal static partial void LargeTableSkippedSQLite();
 }

--- a/src/Quarry/Migration/MigrationOptions.cs
+++ b/src/Quarry/Migration/MigrationOptions.cs
@@ -47,6 +47,16 @@ public sealed class MigrationOptions
     /// <summary>Lock acquisition timeout. Emits SET LOCK_TIMEOUT / SET statement_timeout before DDL.</summary>
     public TimeSpan? LockTimeout { get; set; }
 
+    /// <summary>
+    /// When true, queries database catalog statistics before DDL on existing tables
+    /// and logs a warning if the estimated row count exceeds <see cref="LargeTableThreshold"/>.
+    /// Not supported for SQLite (no catalog statistics).
+    /// </summary>
+    public bool WarnOnLargeTable { get; set; }
+
+    /// <summary>Estimated row count above which a warning is logged. Default: 1,000,000.</summary>
+    public long LargeTableThreshold { get; set; } = 1_000_000;
+
     /// <summary>Called before each migration is applied or rolled back. Parameters: version, name, connection.</summary>
     public Func<int, string, DbConnection, Task>? BeforeEach { get; set; }
 

--- a/src/Quarry/Migration/MigrationRunner.cs
+++ b/src/Quarry/Migration/MigrationRunner.cs
@@ -160,6 +160,8 @@ public static class MigrationRunner
             MigrationLog.NonTransactionalSqlGenerated(migration.Version, nonTxSql);
         }
 
+        await WarnLargeTablesAsync(connection, dialect, builder.GetOperations(), options, log);
+
         if (options.DryRun)
         {
             MigrationLog.DryRun(migration.Version);
@@ -523,6 +525,105 @@ public static class MigrationRunner
             SqlDialect.MySQL => $"SET innodb_lock_wait_timeout = {(int)timeout.TotalSeconds};",
             _ => throw new NotSupportedException($"LockTimeout is not supported for dialect {dialect}.")
         };
+    }
+
+    /// <summary>
+    /// Extracts unique table names from operations that perform DDL on existing tables.
+    /// CreateTable and RawSql are excluded since they don't touch existing data.
+    /// </summary>
+    internal static HashSet<string> GetAffectedTableNames(IReadOnlyList<MigrationOperation> operations)
+    {
+        var tables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var op in operations)
+        {
+            var name = op switch
+            {
+                DropTableOperation o => o.Name,
+                RenameTableOperation o => o.OldName,
+                AddColumnOperation o => o.Table,
+                DropColumnOperation o => o.Table,
+                RenameColumnOperation o => o.Table,
+                AlterColumnOperation o => o.Table,
+                AddForeignKeyOperation o => o.Table,
+                DropForeignKeyOperation o => o.Table,
+                AddIndexOperation o => o.Table,
+                DropIndexOperation o => o.Table,
+                _ => null
+            };
+            if (name != null)
+                tables.Add(name);
+        }
+        return tables;
+    }
+
+    /// <summary>
+    /// Returns the dialect-specific catalog query for estimated row count.
+    /// The query must accept a single parameter (table name) at index 0.
+    /// Returns null for SQLite (no catalog statistics).
+    /// </summary>
+    internal static string? GetEstimatedRowCountSql(SqlDialect dialect)
+    {
+        return dialect switch
+        {
+            SqlDialect.SqlServer =>
+                "SELECT SUM(p.rows) FROM sys.partitions p " +
+                "JOIN sys.tables t ON p.object_id = t.object_id " +
+                $"WHERE t.name = {SqlFormatting.FormatParameter(SqlDialect.SqlServer, 0)} AND p.index_id IN (0, 1);",
+            SqlDialect.PostgreSQL =>
+                $"SELECT reltuples::bigint FROM pg_class WHERE relname = {SqlFormatting.FormatParameter(SqlDialect.PostgreSQL, 0)};",
+            SqlDialect.MySQL =>
+                $"SELECT table_rows FROM information_schema.tables WHERE table_name = {SqlFormatting.FormatParameter(SqlDialect.MySQL, 0)} AND table_schema = DATABASE();",
+            _ => null
+        };
+    }
+
+    private static async Task WarnLargeTablesAsync(
+        DbConnection connection,
+        SqlDialect dialect,
+        IReadOnlyList<MigrationOperation> operations,
+        MigrationOptions options,
+        Action<string> log)
+    {
+        if (!options.WarnOnLargeTable)
+            return;
+
+        if (dialect == SqlDialect.SQLite)
+        {
+            MigrationLog.LargeTableSkippedSQLite();
+            return;
+        }
+
+        var tables = GetAffectedTableNames(operations);
+        if (tables.Count == 0)
+            return;
+
+        var querySql = GetEstimatedRowCountSql(dialect)!;
+
+        foreach (var table in tables)
+        {
+            try
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = querySql;
+                AddParameter(cmd, dialect, 0, table);
+                ApplyCommandTimeout(cmd, options);
+
+                var result = await cmd.ExecuteScalarAsync();
+                if (result is null or DBNull)
+                    continue;
+
+                var estimatedRows = Convert.ToInt64(result);
+                if (estimatedRows > options.LargeTableThreshold)
+                {
+                    MigrationLog.LargeTableWarning(table, estimatedRows);
+                    log($"WARNING: Table '{table}' has ~{estimatedRows} rows. ALTER TABLE may take a long time and acquire locks.");
+                }
+            }
+            catch
+            {
+                // Catalog query failed — swallow and continue (best-effort warning)
+            }
+        }
     }
 
     internal static string ComputeChecksum(string sql)


### PR DESCRIPTION
## Summary
- Closes #41
- Adds opt-in `WarnOnLargeTable` and `LargeTableThreshold` options to `MigrationOptions`
- Queries database catalog statistics (sys.partitions, pg_class, information_schema) before DDL on existing tables and logs warnings when estimated rows exceed the threshold

## Reason for Change
DDL operations (ALTER TABLE, DROP TABLE, etc.) on large tables can take a long time and acquire locks, causing downtime. Operators need advance warning before these operations execute so they can plan accordingly.

## Impact
- **MigrationOptions**: Two new public properties (`WarnOnLargeTable`, `LargeTableThreshold`)
- **MigrationRunner**: Three new internal methods (`GetAffectedTableNames`, `GetEstimatedRowCountSql`, `WarnLargeTablesAsync`) 
- **MigrationLog**: Two new warning-level log messages (`LargeTableWarning`, `LargeTableSkippedSQLite`)
- Warning-only — does not block execution

## Plan items implemented as specified
- Dialect-specific catalog queries for SQL Server, PostgreSQL, MySQL
- SQLite skipped with warning (no catalog statistics)
- Operation type introspection to identify DDL targeting existing tables (excludes CreateTable, RawSql)
- Warning format matches spec: `WARNING: Table 'users' has ~50,000,000 rows. ALTER TABLE may take a long time and acquire locks.`
- Integration point: after SQL generation, before execution in `ApplyMigrationAsync`
- Configurable threshold with 1M default

## Deviations from plan implemented
None

## Gaps in original plan implemented
- Warnings also fire during DryRun mode (informational value before reviewing generated SQL)
- Catalog query failures are silently swallowed (best-effort — doesn't block migration)
- Case-insensitive table name deduplication for operations targeting the same table

## Migration Steps
None required — additive change with opt-in behavior.

## Performance Considerations
- One lightweight catalog query per unique affected table per migration (only when enabled)
- No performance impact when `WarnOnLargeTable = false` (default)

## Security Considerations
- Catalog queries use parameterized SQL — no injection risk

## Breaking Changes
- Consumer-facing: None (new opt-in properties with safe defaults)
- Internal: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)