### PR TITLE
Feat: Typed seed data operations on MigrationBuilder

### DIFF
--- a/src/Quarry.Shared/Sql/SqlFormatting.cs
+++ b/src/Quarry.Shared/Sql/SqlFormatting.cs
@@ -254,6 +254,53 @@ internal static partial class SqlFormatting
     }
 
     /// <summary>
+    /// Formats a CLR value as a dialect-specific SQL literal for embedding in migration SQL.
+    /// </summary>
+    public static string FormatLiteral(SqlDialect dialect, object? value)
+    {
+        if (value is null || value is DBNull)
+            return "NULL";
+
+        return value switch
+        {
+            bool b => FormatBoolean(dialect, b),
+            byte n => n.ToString(),
+            short n => n.ToString(),
+            int n => n.ToString(),
+            long n => n.ToString(),
+            float f => f.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            double d => d.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            decimal m => m.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            string s => $"'{EscapeStringLiteral(s)}'",
+            DateTime dt => $"'{dt.ToString("yyyy-MM-dd HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture)}'",
+            DateTimeOffset dto => $"'{dto.ToString("yyyy-MM-dd HH:mm:ss.fffffffzzz", System.Globalization.CultureInfo.InvariantCulture)}'",
+            Guid g => $"'{g}'",
+            byte[] bytes => FormatBinaryLiteral(dialect, bytes),
+            Enum e => Convert.ToInt64(e, System.Globalization.CultureInfo.InvariantCulture).ToString(),
+            _ => $"'{EscapeStringLiteral(value.ToString()!)}'"
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string EscapeStringLiteral(string value)
+    {
+        return value.Replace("'", "''");
+    }
+
+    private static string FormatBinaryLiteral(SqlDialect dialect, byte[] bytes)
+    {
+        var hex = new StringBuilder(bytes.Length * 2);
+        foreach (var b in bytes)
+            hex.Append(b.ToString("X2"));
+
+        return dialect switch
+        {
+            SqlDialect.PostgreSQL => $"'\\x{hex}'",
+            _ => $"X'{hex}'" // SQLite, MySQL, SqlServer
+        };
+    }
+
+    /// <summary>
     /// Gets the dialect-specific SQL type name for a CLR type.
     /// Dispatches to per-dialect partial file implementations.
     /// </summary>

--- a/src/Quarry.Tests/Migration/MigrationBuilderDataOperationTests.cs
+++ b/src/Quarry.Tests/Migration/MigrationBuilderDataOperationTests.cs
@@ -1,0 +1,517 @@
+using Quarry.Migration;
+
+namespace Quarry.Tests.Migration;
+
+public class MigrationBuilderDataOperationTests
+{
+    // --- InsertData ---
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void InsertData_SingleRow_GeneratesInsert(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.InsertData("users", new { UserName = "admin", Email = "admin@example.com" });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("INSERT INTO"));
+        Assert.That(sql, Does.Contain("'admin'"));
+        Assert.That(sql, Does.Contain("'admin@example.com'"));
+    }
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void InsertData_MultipleRows_GeneratesMultiRowValues(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.InsertData("users", new object[]
+        {
+            new { UserName = "admin", Email = "admin@example.com" },
+            new { UserName = "system", Email = "system@example.com" }
+        });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("INSERT INTO"));
+        Assert.That(sql, Does.Contain("'admin'"));
+        Assert.That(sql, Does.Contain("'system'"));
+        Assert.That(sql, Does.Contain("VALUES"));
+    }
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void InsertData_WithSchema_IncludesSchema(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.InsertData("users", new { Id = 1 }, schema: "dbo");
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("INSERT INTO"));
+        Assert.That(sql, Does.Contain("dbo"));
+    }
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void InsertData_WithNullValue_GeneratesNull(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.InsertData("users", new { UserName = "admin", Email = (string?)null });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("NULL"));
+    }
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void InsertData_WithBoolValue_FormatsPerDialect(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.InsertData("users", new { IsActive = true });
+
+        var sql = builder.BuildSql(dialect);
+
+        if (dialectType == SqlDialect.PostgreSQL)
+            Assert.That(sql, Does.Contain("TRUE"));
+        else
+            Assert.That(sql, Does.Contain("1"));
+    }
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void InsertData_WithIntValue_FormatsAsLiteral(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.InsertData("users", new { Id = 42, Name = "test" });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("42"));
+    }
+
+    [Test]
+    public void InsertData_EmptyRows_ThrowsArgumentException()
+    {
+        var builder = new MigrationBuilder();
+        Assert.Throws<ArgumentException>(() => builder.InsertData("users", Array.Empty<object>()));
+    }
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void InsertData_QuotesColumnNames(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.InsertData("users", new { user_name = "admin" });
+
+        var sql = builder.BuildSql(dialect);
+
+        // Column name should be quoted per dialect
+        switch (dialectType)
+        {
+            case SqlDialect.MySQL:
+                Assert.That(sql, Does.Contain("`user_name`"));
+                break;
+            case SqlDialect.SqlServer:
+                Assert.That(sql, Does.Contain("[user_name]"));
+                break;
+            default: // SQLite, PostgreSQL
+                Assert.That(sql, Does.Contain("\"user_name\""));
+                break;
+        }
+    }
+
+    // --- UpdateData ---
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void UpdateData_GeneratesUpdate(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.UpdateData("users",
+            set: new { IsActive = false },
+            where: new { UserName = "legacy" });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("UPDATE"));
+        Assert.That(sql, Does.Contain("SET"));
+        Assert.That(sql, Does.Contain("WHERE"));
+        Assert.That(sql, Does.Contain("'legacy'"));
+    }
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void UpdateData_MultipleSetColumns_GeneratesCommaSeparated(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.UpdateData("users",
+            set: new { IsActive = false, Email = "updated@example.com" },
+            where: new { Id = 1 });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("'updated@example.com'"));
+
+        if (dialectType == SqlDialect.PostgreSQL)
+            Assert.That(sql, Does.Contain("FALSE"));
+        else
+            Assert.That(sql, Does.Contain("0"));
+    }
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void UpdateData_MultipleWhereConditions_UsesAnd(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.UpdateData("users",
+            set: new { IsActive = false },
+            where: new { UserName = "legacy", TenantId = 5 });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("AND"));
+    }
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void UpdateData_WithSchema_IncludesSchema(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.UpdateData("users",
+            set: new { IsActive = false },
+            where: new { Id = 1 },
+            schema: "dbo");
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("dbo"));
+    }
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void UpdateData_SetNull_GeneratesNull(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.UpdateData("users",
+            set: new { Email = (string?)null },
+            where: new { Id = 1 });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("= NULL"));
+    }
+
+    // --- DeleteData ---
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void DeleteData_GeneratesDelete(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.DeleteData("users",
+            where: new { UserName = "legacy" });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("DELETE FROM"));
+        Assert.That(sql, Does.Contain("WHERE"));
+        Assert.That(sql, Does.Contain("'legacy'"));
+    }
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void DeleteData_WithSchema_IncludesSchema(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.DeleteData("users",
+            where: new { Id = 1 },
+            schema: "dbo");
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("dbo"));
+    }
+
+    [TestCase(SqlDialect.SQLite)]
+    [TestCase(SqlDialect.PostgreSQL)]
+    [TestCase(SqlDialect.MySQL)]
+    [TestCase(SqlDialect.SqlServer)]
+    public void DeleteData_NullWhereValue_UsesIsNull(SqlDialect dialectType)
+    {
+        var dialect = SqlDialectFactory.GetDialect(dialectType);
+        var builder = new MigrationBuilder();
+
+        builder.DeleteData("users",
+            where: new { Email = (string?)null });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("IS NULL"));
+        Assert.That(sql, Does.Not.Contain("= NULL"));
+    }
+
+    // --- Fluent chaining ---
+
+    [Test]
+    public void DataOperations_SupportFluentChaining()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.PostgreSQL);
+        var builder = new MigrationBuilder();
+
+        var result = builder
+            .InsertData("users", new { Id = 1, Name = "admin" })
+            .UpdateData("users", set: new { Name = "superadmin" }, where: new { Id = 1 })
+            .DeleteData("users", where: new { Id = 99 });
+
+        Assert.That(result, Is.SameAs(builder));
+
+        var sql = builder.BuildSql(dialect);
+        Assert.That(sql, Does.Contain("INSERT INTO"));
+        Assert.That(sql, Does.Contain("UPDATE"));
+        Assert.That(sql, Does.Contain("DELETE FROM"));
+    }
+
+    [Test]
+    public void DataOperations_SupportSuppressTransaction()
+    {
+        var builder = new MigrationBuilder();
+        builder.InsertData("users", new { Id = 1 }).SuppressTransaction();
+
+        var ops = builder.GetOperations();
+        Assert.That(ops[0].SuppressTransaction, Is.True);
+    }
+
+    // --- Specific SQL format verification ---
+
+    [Test]
+    public void InsertData_PostgreSQL_GeneratesCorrectSql()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.PostgreSQL);
+        var builder = new MigrationBuilder();
+
+        builder.InsertData("users", new object[]
+        {
+            new { user_name = "admin", email = "admin@example.com", is_active = true },
+            new { user_name = "system", email = "system@example.com", is_active = true }
+        });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("INSERT INTO \"users\" (\"user_name\", \"email\", \"is_active\") VALUES"));
+        Assert.That(sql, Does.Contain("('admin', 'admin@example.com', TRUE)"));
+        Assert.That(sql, Does.Contain("('system', 'system@example.com', TRUE)"));
+    }
+
+    [Test]
+    public void UpdateData_PostgreSQL_GeneratesCorrectSql()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.PostgreSQL);
+        var builder = new MigrationBuilder();
+
+        builder.UpdateData("users",
+            set: new { is_active = false },
+            where: new { user_name = "legacy" });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("UPDATE \"users\" SET \"is_active\" = FALSE WHERE \"user_name\" = 'legacy';"));
+    }
+
+    [Test]
+    public void DeleteData_PostgreSQL_GeneratesCorrectSql()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.PostgreSQL);
+        var builder = new MigrationBuilder();
+
+        builder.DeleteData("users",
+            where: new { user_name = "legacy" });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("DELETE FROM \"users\" WHERE \"user_name\" = 'legacy';"));
+    }
+
+    [Test]
+    public void InsertData_SqlServer_GeneratesCorrectSql()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.SqlServer);
+        var builder = new MigrationBuilder();
+
+        builder.InsertData("users", new { Id = 1, UserName = "admin", IsActive = true });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("INSERT INTO [users] ([Id], [UserName], [IsActive]) VALUES"));
+        Assert.That(sql, Does.Contain("(1, 'admin', 1)"));
+    }
+
+    [Test]
+    public void InsertData_MySQL_GeneratesCorrectSql()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.MySQL);
+        var builder = new MigrationBuilder();
+
+        builder.InsertData("users", new { Id = 1, UserName = "admin" });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("INSERT INTO `users` (`Id`, `UserName`) VALUES"));
+        Assert.That(sql, Does.Contain("(1, 'admin')"));
+    }
+
+    // --- Value type formatting ---
+
+    [Test]
+    public void InsertData_DateTimeValue_FormatsAsString()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.PostgreSQL);
+        var builder = new MigrationBuilder();
+
+        builder.InsertData("events", new { CreatedAt = new DateTime(2026, 1, 15, 10, 30, 0) });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("'2026-01-15 10:30:00'"));
+    }
+
+    [Test]
+    public void InsertData_GuidValue_FormatsAsString()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.PostgreSQL);
+        var builder = new MigrationBuilder();
+        var guid = new Guid("12345678-1234-1234-1234-123456789abc");
+
+        builder.InsertData("users", new { Id = guid });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("'12345678-1234-1234-1234-123456789abc'"));
+    }
+
+    [Test]
+    public void InsertData_DecimalValue_FormatsAsLiteral()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.PostgreSQL);
+        var builder = new MigrationBuilder();
+
+        builder.InsertData("products", new { Price = 19.99m });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("19.99"));
+    }
+
+    [Test]
+    public void InsertData_StringWithSingleQuote_Escapes()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.PostgreSQL);
+        var builder = new MigrationBuilder();
+
+        builder.InsertData("users", new { Name = "O'Brien" });
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("'O''Brien'"));
+    }
+
+    // --- Mixed with DDL operations ---
+
+    [Test]
+    public void DataOperations_InterleavedWithDdl_AllRendered()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.PostgreSQL);
+        var builder = new MigrationBuilder();
+
+        builder.CreateTable("users", null, t =>
+        {
+            t.Column("id", c => c.ClrType("int").Identity().NotNull());
+            t.Column("name", c => c.ClrType("string").Length(100).NotNull());
+            t.PrimaryKey("PK_users", "id");
+        });
+        builder.InsertData("users", new { name = "admin" });
+        builder.AddColumn("users", "email", c => c.ClrType("string").Length(255).Nullable());
+
+        var sql = builder.BuildSql(dialect);
+
+        Assert.That(sql, Does.Contain("CREATE TABLE"));
+        Assert.That(sql, Does.Contain("INSERT INTO"));
+        Assert.That(sql, Does.Contain("ALTER TABLE"));
+    }
+
+    // --- BuildPartitionedSql with data operations ---
+
+    [Test]
+    public void DataOperations_PartitionedSql_SuppressedGoesToNonTransactional()
+    {
+        var builder = new MigrationBuilder();
+        builder.InsertData("users", new { Id = 1 });
+        builder.InsertData("logs", new { Id = 1 }).SuppressTransaction();
+
+        var (txSql, nonTxSql, allSql) = builder.BuildPartitionedSql(SqlDialect.PostgreSQL);
+
+        Assert.That(txSql, Does.Contain("\"users\""));
+        Assert.That(txSql, Does.Not.Contain("\"logs\""));
+        Assert.That(nonTxSql, Does.Contain("\"logs\""));
+        Assert.That(nonTxSql, Does.Not.Contain("\"users\""));
+        Assert.That(allSql, Does.Contain("\"users\""));
+        Assert.That(allSql, Does.Contain("\"logs\""));
+    }
+}

--- a/src/Quarry/Migration/DdlRenderer.cs
+++ b/src/Quarry/Migration/DdlRenderer.cs
@@ -73,6 +73,15 @@ internal static class DdlRenderer
             case DropIndexOperation di:
                 RenderDropIndex(sb, di, dialect, idempotent);
                 break;
+            case InsertDataOperation ins:
+                RenderInsertData(sb, ins, dialect);
+                break;
+            case UpdateDataOperation upd:
+                RenderUpdateData(sb, upd, dialect);
+                break;
+            case DeleteDataOperation del:
+                RenderDeleteData(sb, del, dialect);
+                break;
             case RawSqlOperation raw:
                 sb.AppendLine(raw.Sql);
                 break;
@@ -513,6 +522,68 @@ internal static class DdlRenderer
             default:
                 sb.Append("DROP INDEX ").Append(SqlFormatting.QuoteIdentifier(dialect, op.Name)).AppendLine(";");
                 break;
+        }
+    }
+
+    // --- Data operations ---
+
+    private static void RenderInsertData(StringBuilder sb, InsertDataOperation op, SqlDialect dialect)
+    {
+        sb.Append("INSERT INTO ").Append(FormatTable(op.Table, op.Schema, dialect)).Append(" (");
+        for (var i = 0; i < op.Columns.Length; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append(SqlFormatting.QuoteIdentifier(dialect, op.Columns[i]));
+        }
+        sb.Append(") VALUES");
+
+        for (var r = 0; r < op.Rows.Length; r++)
+        {
+            if (r > 0) sb.Append(",");
+            sb.AppendLine();
+            sb.Append("    (");
+            var row = op.Rows[r];
+            for (var c = 0; c < row.Length; c++)
+            {
+                if (c > 0) sb.Append(", ");
+                sb.Append(SqlFormatting.FormatLiteral(dialect, row[c]));
+            }
+            sb.Append(")");
+        }
+        sb.AppendLine(";");
+    }
+
+    private static void RenderUpdateData(StringBuilder sb, UpdateDataOperation op, SqlDialect dialect)
+    {
+        sb.Append("UPDATE ").Append(FormatTable(op.Table, op.Schema, dialect)).Append(" SET ");
+        for (var i = 0; i < op.SetColumns.Length; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append(SqlFormatting.QuoteIdentifier(dialect, op.SetColumns[i]));
+            sb.Append(" = ").Append(SqlFormatting.FormatLiteral(dialect, op.SetValues[i]));
+        }
+        AppendWhereClause(sb, op.WhereColumns, op.WhereValues, dialect);
+        sb.AppendLine(";");
+    }
+
+    private static void RenderDeleteData(StringBuilder sb, DeleteDataOperation op, SqlDialect dialect)
+    {
+        sb.Append("DELETE FROM ").Append(FormatTable(op.Table, op.Schema, dialect));
+        AppendWhereClause(sb, op.WhereColumns, op.WhereValues, dialect);
+        sb.AppendLine(";");
+    }
+
+    private static void AppendWhereClause(StringBuilder sb, string[] columns, object?[] values, SqlDialect dialect)
+    {
+        sb.Append(" WHERE ");
+        for (var i = 0; i < columns.Length; i++)
+        {
+            if (i > 0) sb.Append(" AND ");
+            sb.Append(SqlFormatting.QuoteIdentifier(dialect, columns[i]));
+            if (values[i] is null || values[i] is DBNull)
+                sb.Append(" IS NULL");
+            else
+                sb.Append(" = ").Append(SqlFormatting.FormatLiteral(dialect, values[i]));
         }
     }
 

--- a/src/Quarry/Migration/MigrationBuilder.cs
+++ b/src/Quarry/Migration/MigrationBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Quarry.Migration;
 
@@ -85,10 +86,64 @@ public sealed class MigrationBuilder
         return this;
     }
 
+    public MigrationBuilder InsertData(string table, object row, string? schema = null)
+    {
+        return InsertData(table, new[] { row }, schema);
+    }
+
+    public MigrationBuilder InsertData(string table, object[] rows, string? schema = null)
+    {
+        if (rows.Length == 0)
+            throw new ArgumentException("At least one row must be provided.", nameof(rows));
+
+        var (columns, firstValues) = ExtractProperties(rows[0]);
+        var allRows = new object?[rows.Length][];
+        allRows[0] = firstValues;
+
+        for (var i = 1; i < rows.Length; i++)
+        {
+            var (cols, vals) = ExtractProperties(rows[i]);
+            if (cols.Length != columns.Length)
+                throw new InvalidOperationException($"Row {i} has {cols.Length} columns but expected {columns.Length}.");
+            allRows[i] = vals;
+        }
+
+        _operations.Add(new InsertDataOperation(table, schema, columns, allRows));
+        return this;
+    }
+
+    public MigrationBuilder UpdateData(string table, object set, object where, string? schema = null)
+    {
+        var (setCols, setVals) = ExtractProperties(set);
+        var (whereCols, whereVals) = ExtractProperties(where);
+        _operations.Add(new UpdateDataOperation(table, schema, setCols, setVals, whereCols, whereVals));
+        return this;
+    }
+
+    public MigrationBuilder DeleteData(string table, object where, string? schema = null)
+    {
+        var (whereCols, whereVals) = ExtractProperties(where);
+        _operations.Add(new DeleteDataOperation(table, schema, whereCols, whereVals));
+        return this;
+    }
+
     public MigrationBuilder Sql(string sql)
     {
         _operations.Add(new RawSqlOperation(sql));
         return this;
+    }
+
+    private static (string[] Columns, object?[] Values) ExtractProperties(object obj)
+    {
+        var properties = obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var columns = new string[properties.Length];
+        var values = new object?[properties.Length];
+        for (var i = 0; i < properties.Length; i++)
+        {
+            columns[i] = properties[i].Name;
+            values[i] = properties[i].GetValue(obj);
+        }
+        return (columns, values);
     }
 
     public MigrationBuilder Online()

--- a/src/Quarry/Migration/MigrationOperations.cs
+++ b/src/Quarry/Migration/MigrationOperations.cs
@@ -141,6 +141,32 @@ internal sealed class DropIndexOperation(string Name, string Table, string? Sche
     public string? Schema { get; } = Schema;
 }
 
+internal sealed class InsertDataOperation(string Table, string? Schema, string[] Columns, object?[][] Rows) : MigrationOperation
+{
+    public string Table { get; } = Table;
+    public string? Schema { get; } = Schema;
+    public string[] Columns { get; } = Columns;
+    public object?[][] Rows { get; } = Rows;
+}
+
+internal sealed class UpdateDataOperation(string Table, string? Schema, string[] SetColumns, object?[] SetValues, string[] WhereColumns, object?[] WhereValues) : MigrationOperation
+{
+    public string Table { get; } = Table;
+    public string? Schema { get; } = Schema;
+    public string[] SetColumns { get; } = SetColumns;
+    public object?[] SetValues { get; } = SetValues;
+    public string[] WhereColumns { get; } = WhereColumns;
+    public object?[] WhereValues { get; } = WhereValues;
+}
+
+internal sealed class DeleteDataOperation(string Table, string? Schema, string[] WhereColumns, object?[] WhereValues) : MigrationOperation
+{
+    public string Table { get; } = Table;
+    public string? Schema { get; } = Schema;
+    public string[] WhereColumns { get; } = WhereColumns;
+    public object?[] WhereValues { get; } = WhereValues;
+}
+
 internal sealed class RawSqlOperation(string Sql) : MigrationOperation
 {
     public string Sql { get; } = Sql;


### PR DESCRIPTION
## Summary
- Closes #40
- Adds `InsertData()`, `UpdateData()`, and `DeleteData()` methods to `MigrationBuilder` for type-safe, dialect-aware data migrations

## Reason for Change
Currently, seed data requires raw SQL via `builder.Sql()`, which is error-prone and not dialect-portable. These new methods accept anonymous objects and generate properly quoted, dialect-specific SQL literals.

## Impact
- **MigrationBuilder** — 3 new public methods: `InsertData`, `UpdateData`, `DeleteData`
- **MigrationOperations** — 3 new internal operation types: `InsertDataOperation`, `UpdateDataOperation`, `DeleteDataOperation`
- **DdlRenderer** — rendering logic for the 3 new operation types, plus shared `AppendWhereClause` helper
- **SqlFormatting** — new `FormatLiteral()` and `EscapeStringLiteral()` methods for dialect-aware SQL literal formatting (bool, int, string, DateTime, Guid, byte[], enums, etc.)

## Plan items implemented as specified
- `InsertData()` with single-row and multi-row overloads, anonymous object → column mapping via reflection
- `UpdateData()` with `set` and `where` anonymous objects
- `DeleteData()` with `where` anonymous object
- Dialect-specific identifier quoting (all 4 dialects)
- Dialect-specific value formatting (booleans, binary literals, etc.)
- NULL handling (`IS NULL` in WHERE clauses, `NULL` literal in SET/VALUES)
- Schema support on all three operations
- String escaping (single quotes)
- Bulk INSERT with multi-row VALUES tuples
- Integration with existing modifiers (`SuppressTransaction`, `Batched`, etc.)

## Deviations from plan implemented
- Used SQL literals instead of parameterized queries (confirmed with maintainer)
- Skipped `MigrationCodeGenerator` changes since data operations are hand-written in migrations, not auto-generated from schema diffs (confirmed with maintainer)

## Gaps in original plan implemented
None — all core functionality from the issue is implemented.

## Migration Steps
No migration steps needed — this is a new additive API.

## Performance Considerations
- Reflection is used to extract property names/values from anonymous objects; this runs at migration-apply time (not hot path), so performance is acceptable
- Multi-row INSERT uses a single statement with multiple value tuples for efficiency

## Security Considerations
- String values are escaped via `EscapeStringLiteral()` (single-quote doubling) to prevent SQL injection
- Identifier quoting via existing `QuoteIdentifier()` prevents injection through column/table names

## Breaking Changes
- Consumer-facing: None — purely additive API
- Internal: None — new operation types added without modifying existing ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)