### PR TITLE
Feat: Implement batched data migration execution

### DIFF
--- a/src/Quarry.Tests/Migration/DdlRendererDialectTests.cs
+++ b/src/Quarry.Tests/Migration/DdlRendererDialectTests.cs
@@ -268,6 +268,22 @@ public class DdlRendererDialectTests
     }
 
     [Test]
+    public void Batched_ZeroBatchSize_Throws()
+    {
+        var builder = new MigrationBuilder();
+        builder.Sql("SELECT 1");
+        Assert.Throws<ArgumentOutOfRangeException>(() => builder.Batched(0));
+    }
+
+    [Test]
+    public void Batched_NegativeBatchSize_Throws()
+    {
+        var builder = new MigrationBuilder();
+        builder.Sql("SELECT 1");
+        Assert.Throws<ArgumentOutOfRangeException>(() => builder.Batched(-5));
+    }
+
+    [Test]
     public void BatchedRawSql_SqlServer_EmitsWhileLoop()
     {
         var dialect = SqlDialectFactory.GetDialect(SqlDialect.SqlServer);
@@ -299,17 +315,21 @@ public class DdlRendererDialectTests
     }
 
     [Test]
-    public void BatchedRawSql_MySQL_EmitsLoop()
+    public void BatchedRawSql_MySQL_EmitsStoredProcedureLoop()
     {
         var dialect = SqlDialectFactory.GetDialect(SqlDialect.MySQL);
         var builder = new MigrationBuilder();
         builder.Sql("UPDATE users SET status = 'active' WHERE status IS NULL LIMIT 5000");
         builder.Batched(5000);
         var sql = builder.BuildSql(dialect);
+        Assert.That(sql, Does.Contain("DROP PROCEDURE IF EXISTS _quarry_batch;"));
+        Assert.That(sql, Does.Contain("CREATE PROCEDURE _quarry_batch()"));
         Assert.That(sql, Does.Contain("repeat_loop: LOOP"));
         Assert.That(sql, Does.Contain("UPDATE users"));
         Assert.That(sql, Does.Contain("IF ROW_COUNT() = 0 THEN LEAVE repeat_loop; END IF;"));
         Assert.That(sql, Does.Contain("END LOOP;"));
+        Assert.That(sql, Does.Contain("CALL _quarry_batch();"));
+        Assert.That(sql, Does.Contain("DROP PROCEDURE _quarry_batch;"));
     }
 
     [Test]
@@ -322,6 +342,40 @@ public class DdlRendererDialectTests
         var sql = builder.BuildSql(dialect);
         Assert.That(sql, Does.Contain("-- Batched execution is not supported for SQLite"));
         Assert.That(sql, Does.Contain("UPDATE users SET status = 'active'"));
+    }
+
+    [Test]
+    public void BatchedRawSql_WithoutBatchSize_RendersNormally()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.SqlServer);
+        var builder = new MigrationBuilder();
+        builder.Sql("UPDATE users SET status = 'active' WHERE status IS NULL");
+        var sql = builder.BuildSql(dialect);
+        Assert.That(sql, Does.Not.Contain("WHILE"));
+        Assert.That(sql, Does.Contain("UPDATE users"));
+    }
+
+    [Test]
+    public void BatchedRawSql_TrailingSemicolon_NotDuplicated()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.SqlServer);
+        var builder = new MigrationBuilder();
+        builder.Sql("UPDATE TOP (100) users SET status = 'active' WHERE status IS NULL;");
+        builder.Batched(100);
+        var sql = builder.BuildSql(dialect);
+        Assert.That(sql, Does.Not.Contain(";;"));
+        Assert.That(sql, Does.Contain("WHERE status IS NULL;"));
+    }
+
+    [Test]
+    public void BatchedRawSql_NoTrailingSemicolon_AddsSemicolon()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.PostgreSQL);
+        var builder = new MigrationBuilder();
+        builder.Sql("DELETE FROM logs WHERE id < 100");
+        builder.Batched(100);
+        var sql = builder.BuildSql(dialect);
+        Assert.That(sql, Does.Contain("WHERE id < 100;"));
     }
 
     [Test]
@@ -361,14 +415,120 @@ public class DdlRendererDialectTests
     }
 
     [Test]
-    public void BatchedRawSql_WithoutBatchSize_RendersNormally()
+    public void BatchedInsertData_ExactBatchSize_ProducesOneBatch()
     {
         var dialect = SqlDialectFactory.GetDialect(SqlDialect.SqlServer);
         var builder = new MigrationBuilder();
-        builder.Sql("UPDATE users SET status = 'active' WHERE status IS NULL");
+        builder.InsertData("users", new object[]
+        {
+            new { id = 1, name = "a" },
+            new { id = 2, name = "b" },
+            new { id = 3, name = "c" },
+            new { id = 4, name = "d" },
+        });
+        builder.Batched(4);
         var sql = builder.BuildSql(dialect);
-        Assert.That(sql, Does.Not.Contain("WHILE"));
-        Assert.That(sql, Does.Contain("UPDATE users"));
+        var insertCount = System.Text.RegularExpressions.Regex.Matches(sql, "INSERT INTO").Count;
+        Assert.That(insertCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void BatchedInsertData_SingleRow_ProducesOneBatch()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.SqlServer);
+        var builder = new MigrationBuilder();
+        builder.InsertData("users", new { id = 1, name = "only" });
+        builder.Batched(5);
+        var sql = builder.BuildSql(dialect);
+        var insertCount = System.Text.RegularExpressions.Regex.Matches(sql, "INSERT INTO").Count;
+        Assert.That(insertCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void BatchedInsertData_SchemaQualified_IncludesSchemaPerBatch()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.SqlServer);
+        var builder = new MigrationBuilder();
+        builder.InsertData("users", new object[]
+        {
+            new { id = 1, name = "a" },
+            new { id = 2, name = "b" },
+            new { id = 3, name = "c" },
+        }, schema: "dbo");
+        builder.Batched(2);
+        var sql = builder.BuildSql(dialect);
+        // 2 INSERT statements, each must reference the schema
+        var insertCount = System.Text.RegularExpressions.Regex.Matches(sql, "INSERT INTO").Count;
+        Assert.That(insertCount, Is.EqualTo(2));
+        var schemaCount = System.Text.RegularExpressions.Regex.Matches(sql, @"\[dbo\]\.\[users\]").Count;
+        Assert.That(schemaCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void BatchedInsertData_MySQL_UsesBacktickQuoting()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.MySQL);
+        var builder = new MigrationBuilder();
+        builder.InsertData("users", new object[]
+        {
+            new { id = 1, name = "a" },
+            new { id = 2, name = "b" },
+            new { id = 3, name = "c" },
+        });
+        builder.Batched(2);
+        var sql = builder.BuildSql(dialect);
+        Assert.That(sql, Does.Contain("`users`"));
+        Assert.That(sql, Does.Contain("`id`"));
+        Assert.That(sql, Does.Contain("`name`"));
+    }
+
+    [Test]
+    public void BatchedInsertData_NullValues_FormattedCorrectly()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.SqlServer);
+        var builder = new MigrationBuilder();
+        builder.InsertData("users", new object[]
+        {
+            new { id = 1, name = (string?)null },
+            new { id = 2, name = "b" },
+            new { id = 3, name = (string?)null },
+        });
+        builder.Batched(2);
+        var sql = builder.BuildSql(dialect);
+        var nullCount = System.Text.RegularExpressions.Regex.Matches(sql, @"\bNULL\b").Count;
+        Assert.That(nullCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void BatchedRawSql_WithSuppressTransaction_RendersInNonTxPartition()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.SqlServer);
+        var builder = new MigrationBuilder();
+        builder.Sql("UPDATE TOP (1000) users SET status = 'active' WHERE status IS NULL");
+        builder.Batched(1000);
+        builder.SuppressTransaction();
+        var (txSql, nonTxSql, _) = builder.BuildPartitionedSql(dialect);
+        Assert.That(txSql, Is.Empty);
+        Assert.That(nonTxSql, Does.Contain("WHILE 1 = 1"));
+    }
+
+    [Test]
+    public void BatchedInsertData_WithSuppressTransaction_RendersInNonTxPartition()
+    {
+        var dialect = SqlDialectFactory.GetDialect(SqlDialect.PostgreSQL);
+        var builder = new MigrationBuilder();
+        builder.InsertData("users", new object[]
+        {
+            new { id = 1, name = "a" },
+            new { id = 2, name = "b" },
+            new { id = 3, name = "c" },
+        });
+        builder.Batched(2);
+        builder.SuppressTransaction();
+        var (txSql, nonTxSql, _) = builder.BuildPartitionedSql(dialect);
+        Assert.That(txSql, Is.Empty);
+        var insertCount = System.Text.RegularExpressions.Regex.Matches(nonTxSql, "INSERT INTO").Count;
+        Assert.That(insertCount, Is.EqualTo(2));
     }
 
     #endregion

--- a/src/Quarry/Migration/DdlRenderer.cs
+++ b/src/Quarry/Migration/DdlRenderer.cs
@@ -613,28 +613,7 @@ internal static class DdlRenderer
 
     private static void RenderInsertData(StringBuilder sb, InsertDataOperation op, SqlDialect dialect)
     {
-        sb.Append("INSERT INTO ").Append(FormatTable(op.Table, op.Schema, dialect)).Append(" (");
-        for (var i = 0; i < op.Columns.Length; i++)
-        {
-            if (i > 0) sb.Append(", ");
-            sb.Append(SqlFormatting.QuoteIdentifier(dialect, op.Columns[i]));
-        }
-        sb.Append(") VALUES");
-
-        for (var r = 0; r < op.Rows.Length; r++)
-        {
-            if (r > 0) sb.Append(",");
-            sb.AppendLine();
-            sb.Append("    (");
-            var row = op.Rows[r];
-            for (var c = 0; c < row.Length; c++)
-            {
-                if (c > 0) sb.Append(", ");
-                sb.Append(SqlFormatting.FormatLiteral(dialect, row[c]));
-            }
-            sb.Append(")");
-        }
-        sb.AppendLine(";");
+        RenderInsertRows(sb, op, dialect, 0, op.Rows.Length);
     }
 
     private static void RenderUpdateData(StringBuilder sb, UpdateDataOperation op, SqlDialect dialect)
@@ -657,6 +636,32 @@ internal static class DdlRenderer
         sb.AppendLine(";");
     }
 
+    private static void RenderInsertRows(StringBuilder sb, InsertDataOperation op, SqlDialect dialect, int startRow, int endRow)
+    {
+        sb.Append("INSERT INTO ").Append(FormatTable(op.Table, op.Schema, dialect)).Append(" (");
+        for (var i = 0; i < op.Columns.Length; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append(SqlFormatting.QuoteIdentifier(dialect, op.Columns[i]));
+        }
+        sb.Append(") VALUES");
+
+        for (var r = startRow; r < endRow; r++)
+        {
+            if (r > startRow) sb.Append(",");
+            sb.AppendLine();
+            sb.Append("    (");
+            var row = op.Rows[r];
+            for (var c = 0; c < row.Length; c++)
+            {
+                if (c > 0) sb.Append(", ");
+                sb.Append(SqlFormatting.FormatLiteral(dialect, row[c]));
+            }
+            sb.Append(")");
+        }
+        sb.AppendLine(";");
+    }
+
     // --- Batched operations ---
 
     private static void RenderBatchedInsertData(StringBuilder sb, InsertDataOperation op, SqlDialect dialect)
@@ -665,28 +670,7 @@ internal static class DdlRenderer
         for (var offset = 0; offset < op.Rows.Length; offset += batchSize)
         {
             var end = Math.Min(offset + batchSize, op.Rows.Length);
-            sb.Append("INSERT INTO ").Append(FormatTable(op.Table, op.Schema, dialect)).Append(" (");
-            for (var i = 0; i < op.Columns.Length; i++)
-            {
-                if (i > 0) sb.Append(", ");
-                sb.Append(SqlFormatting.QuoteIdentifier(dialect, op.Columns[i]));
-            }
-            sb.Append(") VALUES");
-
-            for (var r = offset; r < end; r++)
-            {
-                if (r > offset) sb.Append(",");
-                sb.AppendLine();
-                sb.Append("    (");
-                var row = op.Rows[r];
-                for (var c = 0; c < row.Length; c++)
-                {
-                    if (c > 0) sb.Append(", ");
-                    sb.Append(SqlFormatting.FormatLiteral(dialect, row[c]));
-                }
-                sb.Append(")");
-            }
-            sb.AppendLine(";");
+            RenderInsertRows(sb, op, dialect, offset, end);
         }
     }
 
@@ -712,10 +696,16 @@ internal static class DdlRenderer
                 break;
 
             case SqlDialect.MySQL:
-                sb.AppendLine("repeat_loop: LOOP");
-                sb.Append("    ").AppendLine(op.Sql.TrimEnd().TrimEnd(';') + ";");
-                sb.AppendLine("    IF ROW_COUNT() = 0 THEN LEAVE repeat_loop; END IF;");
-                sb.AppendLine("END LOOP;");
+                sb.AppendLine("DROP PROCEDURE IF EXISTS _quarry_batch;");
+                sb.AppendLine("CREATE PROCEDURE _quarry_batch()");
+                sb.AppendLine("BEGIN");
+                sb.AppendLine("    repeat_loop: LOOP");
+                sb.Append("        ").AppendLine(op.Sql.TrimEnd().TrimEnd(';') + ";");
+                sb.AppendLine("        IF ROW_COUNT() = 0 THEN LEAVE repeat_loop; END IF;");
+                sb.AppendLine("    END LOOP;");
+                sb.AppendLine("END;");
+                sb.AppendLine("CALL _quarry_batch();");
+                sb.AppendLine("DROP PROCEDURE _quarry_batch;");
                 break;
 
             case SqlDialect.SQLite:

--- a/src/Quarry/Migration/MigrationBuilder.cs
+++ b/src/Quarry/Migration/MigrationBuilder.cs
@@ -200,6 +200,8 @@ public sealed class MigrationBuilder
     {
         if (_operations.Count == 0)
             throw new InvalidOperationException("Batched() must be called after an operation has been added to the builder.");
+        if (batchSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batchSize), batchSize, "Batch size must be greater than zero.");
         _operations[^1].BatchSize = batchSize;
         return this;
     }


### PR DESCRIPTION
## Summary
- Closes #45
- Implements `BatchSize` rendering in `DdlRenderer` for `RawSqlOperation` and `InsertDataOperation`, which were previously stored but silently ignored. The `.Batched(batchSize)` modifier now produces real SQL output across all four supported dialects.

## Reason for Change
The `.Batched(batchSize)` modifier existed on the `MigrationBuilder` API and the `BatchSize` property was stored on `MigrationOperation`, but `DdlRenderer.Render()` never read it — making the feature a silent no-op.

## Impact
- **RawSqlOperation** with `BatchSize` set now renders dialect-specific batching loops:
  - **SQL Server**: `WHILE 1=1 BEGIN ... IF @@ROWCOUNT = 0 BREAK; END`
  - **PostgreSQL**: `DO $$ ... LOOP ... GET DIAGNOSTICS ... EXIT WHEN ... END LOOP; END $$;`
  - **MySQL**: `CREATE PROCEDURE _quarry_batch() BEGIN ... LOOP ... END LOOP; END; CALL _quarry_batch(); DROP PROCEDURE _quarry_batch;` (wrapped in stored procedure since MySQL procedural statements cannot execute standalone)
  - **SQLite**: Warning comment (batched loops not supported), falls back to single execution
- **InsertDataOperation** with `BatchSize` set splits rows into multiple INSERT statements, each containing at most `batchSize` rows
- **Validation**: `Batched()` now throws `ArgumentOutOfRangeException` for `batchSize <= 0`
- Operations without `BatchSize` set are completely unaffected
- Shared `RenderInsertRows` helper extracted to eliminate duplication between batched and non-batched INSERT rendering

## Plan items implemented as specified
- Dialect-specific loop SQL for SQL Server, PostgreSQL, MySQL per the issue's proposed implementation
- SQLite fallback with warning comment
- Focus on `Sql()` (raw SQL) operations as the primary use case

## Deviations from plan implemented
- **MySQL rendering**: The issue proposed bare `LOOP` syntax, but MySQL requires procedural statements to be inside a stored procedure. Implemented as `CREATE PROCEDURE`/`CALL`/`DROP PROCEDURE` to produce valid executable SQL, consistent with the existing MySQL `PREPARE`/`EXECUTE` patterns in `DdlRenderer`.
- **Batch size not injected into user SQL**: The user is responsible for including batch-limiting clauses (e.g., `TOP(N)`, `LIMIT N`) in their raw SQL. The loop mechanism handles the repetition.
- **Transaction behavior**: Batched operations run within the migration's existing transaction (DB loop within transaction), not with independent commits per batch.

## Gaps in original plan implemented
- **InsertData batching**: The issue focused on raw SQL, but `InsertDataOperation` with `BatchSize` now splits rows into chunks — useful for large seed data.
- **Input validation**: Added `ArgumentOutOfRangeException` for `batchSize <= 0` since the renderer checks `is > 0` — without validation, invalid values silently no-op.
- **Code deduplication**: Extracted `RenderInsertRows(sb, op, dialect, startRow, endRow)` shared by both `RenderInsertData` and `RenderBatchedInsertData`.

## Migration Steps
No migration needed — this is a new rendering capability for an existing API.

## Performance Considerations
- Batched INSERT splits large row sets into smaller statements, reducing memory pressure on the DB parser
- Batched raw SQL loops execute repeatedly until 0 rows affected, suitable for large UPDATE/DELETE operations
- No performance impact on non-batched operations (guarded by `BatchSize is > 0` check)

## Security Considerations
- No new attack surface. Raw SQL is already user-provided; the batching wrapper only adds loop control flow around it.
- MySQL stored procedure uses a fixed name `_quarry_batch` — no user input in procedure name.

## Breaking Changes
- Consumer-facing: None. Existing code using `.Batched()` will now produce batched SQL instead of being silently ignored — this is the intended/correct behavior. `Batched(0)` or `Batched(-1)` will now throw where it previously silently stored the value.
- Internal: `RenderInsertData` now delegates to `RenderInsertRows` — same output, refactored internals only.

---
19 batched tests covering: all 4 dialects for raw SQL, INSERT chunking (split/exact/single-row/schema-qualified/null values/backtick quoting), validation (zero/negative), semicolon normalization, and SuppressTransaction partitioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
