### PR TITLE
Refactor: Eliminate redundant variable re-tracing in ExtractBatchInsertColumnNamesFromChain

### DIFF
--- a/src/Quarry.Generator/Parsing/UsageSiteDiscovery.cs
+++ b/src/Quarry.Generator/Parsing/UsageSiteDiscovery.cs
@@ -1022,20 +1022,12 @@ internal static class UsageSiteDiscovery
         if (root is IdentifierNameSyntax)
         {
             var traceResult = VariableTracer.TraceToChainRoot(root, semanticModel, ct, maxHops: 2);
-            if (traceResult.Traced)
+            if (traceResult.Traced && traceResult.Initializers != null)
             {
-                // Find the declarator of the first variable to get its full initializer
-                // (not just the root — we need the whole chain including InsertBatch)
-                var currentRoot = root;
-                for (int i = 0; i < traceResult.Hops; i++)
+                // Iterate the initializers already collected by TraceToChainRoot
+                // instead of re-resolving declarators.
+                foreach (var initializer in traceResult.Initializers)
                 {
-                    if (currentRoot is not IdentifierNameSyntax ident)
-                        break;
-                    var declarator = VariableTracer.TryResolveDeclarator(ident, semanticModel, ct);
-                    var initializer = declarator != null ? VariableTracer.GetInitializerExpression(declarator) : null;
-                    if (initializer == null)
-                        break;
-
                     // Try walking this initializer's chain for InsertBatch
                     if (initializer is InvocationExpressionSyntax initInvoc)
                     {
@@ -1051,8 +1043,6 @@ internal static class UsageSiteDiscovery
                             return ExtractBatchInsertColumnNames(initInvoc);
                         }
                     }
-
-                    currentRoot = VariableTracer.WalkFluentChainRoot(initializer);
                 }
             }
         }

--- a/src/Quarry.Generator/Parsing/VariableTracer.cs
+++ b/src/Quarry.Generator/Parsing/VariableTracer.cs
@@ -72,6 +72,7 @@ internal static class VariableTracer
         var root = receiver;
         string? firstVariableName = null;
         int hops = 0;
+        List<ExpressionSyntax>? initializers = null;
 
         for (int i = 0; i < maxHops; i++)
         {
@@ -98,11 +99,14 @@ internal static class VariableTracer
             // ChainId that GetAssignedVariableName produces for the root statement.
             firstVariableName = declarator.Identifier.Text;
 
+            initializers ??= new List<ExpressionSyntax>();
+            initializers.Add(initializer);
+
             root = WalkFluentChainRoot(initializer);
             hops++;
         }
 
-        return new TraceResult(root, hops, hops > 0, firstVariableName);
+        return new TraceResult(root, hops, hops > 0, firstVariableName, initializers);
     }
 
     /// <summary>
@@ -150,13 +154,21 @@ internal static class VariableTracer
         /// Used by ComputeChainId to link all sites in a variable-split chain.
         /// </summary>
         public string? FirstVariableName { get; }
+        /// <summary>
+        /// The initializer expressions encountered at each hop during tracing, in order.
+        /// Allows callers to inspect intermediate initializers without re-resolving declarators.
+        /// Null when no hops were taken.
+        /// </summary>
+        public IReadOnlyList<ExpressionSyntax>? Initializers { get; }
 
-        public TraceResult(ExpressionSyntax root, int hops, bool traced, string? firstVariableName)
+        public TraceResult(ExpressionSyntax root, int hops, bool traced, string? firstVariableName,
+            IReadOnlyList<ExpressionSyntax>? initializers = null)
         {
             Root = root;
             Hops = hops;
             Traced = traced;
             FirstVariableName = firstVariableName;
+            Initializers = initializers;
         }
     }
 }

--- a/src/Quarry.Tests/Parsing/VariableTracerTests.cs
+++ b/src/Quarry.Tests/Parsing/VariableTracerTests.cs
@@ -1,0 +1,178 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Quarry.Generators.Parsing;
+
+namespace Quarry.Tests.Parsing;
+
+/// <summary>
+/// Unit tests for <see cref="VariableTracer"/>, focusing on
+/// TraceToChainRoot's Initializers collection.
+/// </summary>
+[TestFixture]
+public class VariableTracerTests
+{
+    /// <summary>
+    /// Creates a minimal compilation with stub builder types that match
+    /// VariableTracer.IsBuilderType, without depending on the source generator.
+    /// </summary>
+    private static CSharpCompilation CreateCompilation(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        var references = new MetadataReference[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+        };
+
+        return CSharpCompilation.Create(
+            "TestAssembly",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+    }
+
+    /// <summary>
+    /// Stub source that defines types whose display names match IsBuilderType checks.
+    /// </summary>
+    private const string StubTypes = @"
+namespace Stubs
+{
+    public class QueryBuilder<T>
+    {
+        public QueryBuilder<T> Where(string predicate) => this;
+        public QueryBuilder<T> Select(string columns) => this;
+        public string ToDiagnostics() => """";
+    }
+
+    public class Db
+    {
+        public QueryBuilder<int> Users() => new QueryBuilder<int>();
+    }
+}
+";
+
+    [Test]
+    public void TraceToChainRoot_SingleHop_ReturnsOneInitializer()
+    {
+        var source = StubTypes + @"
+namespace TestApp
+{
+    public class Service
+    {
+        public void Test()
+        {
+            var db = new Stubs.Db();
+            var query = db.Users().Where(""active"");
+            query.Select(""name"").ToDiagnostics();
+        }
+    }
+}
+";
+
+        var compilation = CreateCompilation(source);
+        var tree = compilation.SyntaxTrees.First();
+        var semanticModel = compilation.GetSemanticModel(tree);
+
+        // Find the 'query' identifier in 'query.Select("name")'
+        var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToList();
+        var selectInvocation = invocations.First(inv =>
+            inv.Expression is MemberAccessExpressionSyntax ma && ma.Name.Identifier.ValueText == "Select");
+
+        var receiver = ((MemberAccessExpressionSyntax)selectInvocation.Expression).Expression;
+        var root = VariableTracer.WalkFluentChainRoot(receiver);
+
+        var traceResult = VariableTracer.TraceToChainRoot(root, semanticModel, CancellationToken.None, maxHops: 2);
+
+        Assert.That(traceResult.Traced, Is.True);
+        Assert.That(traceResult.Hops, Is.EqualTo(1));
+        Assert.That(traceResult.Initializers, Is.Not.Null);
+        Assert.That(traceResult.Initializers!, Has.Count.EqualTo(1));
+        // The initializer should be the Where invocation expression
+        Assert.That(traceResult.Initializers![0], Is.InstanceOf<InvocationExpressionSyntax>());
+        Assert.That(traceResult.Initializers[0].ToString(), Does.Contain("Where"));
+    }
+
+    [Test]
+    public void TraceToChainRoot_TwoHops_ReturnsTwoInitializers()
+    {
+        var source = StubTypes + @"
+namespace TestApp
+{
+    public class Service
+    {
+        public void Test()
+        {
+            var db = new Stubs.Db();
+            var query = db.Users().Where(""active"");
+            var filtered = query.Select(""name"");
+            filtered.ToDiagnostics();
+        }
+    }
+}
+";
+
+        var compilation = CreateCompilation(source);
+        var tree = compilation.SyntaxTrees.First();
+        var semanticModel = compilation.GetSemanticModel(tree);
+
+        // Find 'filtered' identifier in 'filtered.ToDiagnostics()'
+        var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToList();
+        var terminalInvocation = invocations.First(inv =>
+            inv.Expression is MemberAccessExpressionSyntax ma && ma.Name.Identifier.ValueText == "ToDiagnostics");
+
+        var receiver = ((MemberAccessExpressionSyntax)terminalInvocation.Expression).Expression;
+        var root = VariableTracer.WalkFluentChainRoot(receiver);
+
+        var traceResult = VariableTracer.TraceToChainRoot(root, semanticModel, CancellationToken.None, maxHops: 2);
+
+        Assert.That(traceResult.Traced, Is.True);
+        Assert.That(traceResult.Hops, Is.EqualTo(2));
+        Assert.That(traceResult.Initializers, Is.Not.Null);
+        Assert.That(traceResult.Initializers!, Has.Count.EqualTo(2));
+        // First initializer (hop 1): query.Select("name")
+        Assert.That(traceResult.Initializers[0].ToString(), Does.Contain("Select"));
+        // Second initializer (hop 2): db.Users().Where("active")
+        Assert.That(traceResult.Initializers[1].ToString(), Does.Contain("Where"));
+    }
+
+    [Test]
+    public void TraceToChainRoot_NoHops_InitializersIsNull()
+    {
+        var source = StubTypes + @"
+namespace TestApp
+{
+    public class Service
+    {
+        public void Test()
+        {
+            var db = new Stubs.Db();
+            // Direct fluent chain — no variable hop
+            db.Users().Select(""name"").ToDiagnostics();
+        }
+    }
+}
+";
+
+        var compilation = CreateCompilation(source);
+        var tree = compilation.SyntaxTrees.First();
+        var semanticModel = compilation.GetSemanticModel(tree);
+
+        // Find the ToDiagnostics invocation
+        var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToList();
+        var terminalInvocation = invocations.First(inv =>
+            inv.Expression is MemberAccessExpressionSyntax ma && ma.Name.Identifier.ValueText == "ToDiagnostics");
+
+        var receiver = ((MemberAccessExpressionSyntax)terminalInvocation.Expression).Expression;
+        var root = VariableTracer.WalkFluentChainRoot(receiver);
+
+        var traceResult = VariableTracer.TraceToChainRoot(root, semanticModel, CancellationToken.None, maxHops: 2);
+
+        Assert.That(traceResult.Traced, Is.False);
+        Assert.That(traceResult.Hops, Is.EqualTo(0));
+        Assert.That(traceResult.Initializers, Is.Null);
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #63

## Reason for Change
`ExtractBatchInsertColumnNamesFromChain` called `TraceToChainRoot` to find the chain origin, then immediately re-walked each hop in a manual for-loop calling `TryResolveDeclarator` and `GetInitializerExpression` — duplicating the declarator resolution work that `TraceToChainRoot` already performed.

## Impact
Low — purely eliminates architectural redundancy. No functional change. The semantic model likely caches these lookups, so real-world perf impact is minimal.

## Plan items implemented as specified
- Added `IReadOnlyList<ExpressionSyntax>? Initializers` property to `TraceResult`
- Modified `TraceToChainRoot` to collect initializer expressions encountered during tracing
- Simplified `ExtractBatchInsertColumnNamesFromChain` to iterate collected initializers via `foreach` instead of re-resolving declarators

## Deviations from plan implemented
- Used a default parameter (`initializers = null`) on the `TraceResult` constructor instead of adding a new overload, keeping all existing call sites unchanged with zero modification

## Gaps in original plan implemented
- Added unit tests (`VariableTracerTests`) that directly verify `TraceResult.Initializers` population for 0-hop, 1-hop, and 2-hop scenarios using lightweight Roslyn compilations with stub builder types

## Migration Steps
None — internal refactor only.

## Performance Considerations
Eliminates redundant `GetSymbolInfo` + `DeclaringSyntaxReferences[0].GetSyntax()` calls per hop in batch insert chain analysis. The `List<ExpressionSyntax>` allocation is lazy (only created when hops > 0).

## Security Considerations
None.

## Breaking Changes
- Consumer-facing: None
- Internal: `TraceResult` struct has a new `Initializers` property. Constructor has a new optional parameter. All existing callers are source-compatible.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)