### PR TITLE
Fix EntityReader delegation test for identity projections

### DIFF
--- a/src/Quarry.Tests/GeneratorTests.cs
+++ b/src/Quarry.Tests/GeneratorTests.cs
@@ -840,7 +840,6 @@ public partial class TestDbContext : QuarryContext
     }
 
     [Test]
-    [Ignore("EntityReader delegation not wired for identity projections in inline compilation — requires generator investigation")]
     public void Generator_WithValidEntityReader_EmitsReaderDelegation()
     {
         var source = @"
@@ -884,7 +883,7 @@ public static class Queries
 {
     public static async Task Test(TestDbContext db)
     {
-        await db.Users().ExecuteFetchAllAsync();
+        await db.Users().Select(u => u).ExecuteFetchAllAsync();
     }
 }
 ";


### PR DESCRIPTION
## Summary
- Closes #74

## Reason for Change
The `Generator_WithValidEntityReader_EmitsReaderDelegation` test was `[Ignore]`d because it appeared that EntityReader delegation wasn't wired for identity projections. Investigation revealed the generator's delegation pipeline was already correct — the test itself used an invalid API that couldn't compile, preventing the generator from discovering the call site.

The test called `db.Users().ExecuteFetchAllAsync()`, but `ExecuteFetchAllAsync` is only defined on `IQueryBuilder<TEntity, TResult>`, not on `IEntityAccessor<T>`. This caused a `CS1061` compilation error in the test compilation, so the source generator never discovered the call site and emitted no interceptors.

## Impact
- Test-only change. No generator or runtime code modified.
- Removes the `[Ignore]` attribute and enables the previously-skipped test.
- All 1845 tests pass (including QRY026/QRY027 EntityReader diagnostic tests).

## Plan items implemented as specified
- `Generator_WithValidEntityReader_EmitsReaderDelegation` test passes (removed `[Ignore]`)
- Generated interceptor code for identity projection with `[EntityReader]` uses `_entityReader_...Read(r)` instead of inline initializer
- No regressions in existing EntityReader diagnostic tests (QRY026, QRY027)

## Deviations from plan implemented
- The issue hypothesized a data flow bug where `CustomEntityReaderClass` was lost between `EntityRef` and `ProjectionInfo`. The actual root cause was simpler: the test used an API that doesn't exist on `IEntityAccessor<T>`, so the test compilation had errors and the generator never ran the identity projection path.

## Gaps in original plan implemented
- None — the fix is minimal and targeted.

## Migration Steps
None required.

## Performance Considerations
None — test-only change.

## Security Considerations
None.

## Breaking Changes
- Consumer-facing: None
- Internal: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)