### PR TITLE
Fix CS8629/CS8604 nullable warnings in generated enum interceptors

### DIFF
--- a/src/Quarry.Generator/CodeGen/CarrierEmitter.cs
+++ b/src/Quarry.Generator/CodeGen/CarrierEmitter.cs
@@ -875,7 +875,7 @@ internal static class CarrierEmitter
             {
                 if (param.EntityPropertyExpression != null)
                     sb.AppendLine($"{indent}ParameterLog.Bound(__opId, {i}, ((object?){param.EntityPropertyExpression})?.ToString() ?? \"null\");");
-                else if (IsNonNullableValueType(param.ClrType) || param.IsEnum)
+                else if (IsNonNullableValueType(param.ClrType))
                     sb.AppendLine($"{indent}ParameterLog.Bound(__opId, {i}, __c.P{i}.ToString());");
                 else
                     sb.AppendLine($"{indent}ParameterLog.Bound(__opId, {i}, __c.P{i}?.ToString() ?? \"null\");");

--- a/src/Quarry.Generator/CodeGen/TerminalEmitHelpers.cs
+++ b/src/Quarry.Generator/CodeGen/TerminalEmitHelpers.cs
@@ -618,13 +618,12 @@ internal static class TerminalEmitHelpers
         if (param.TypeMappingClass != null)
             return $"(object?){InterceptorCodeGenerator.GetMappingFieldName(param.TypeMappingClass)}.ToDb(__c.P{index}) ?? DBNull.Value";
 
-        // Enum with known underlying type: inline cast to underlying integral type
+        // Enum with known underlying type: inline cast to underlying integral type.
+        // Carrier fields for enum types are always nullable — NormalizeFieldType
+        // does not recognize enums as value types and appends '?'.
+        // Always emit the null-safe HasValue path to avoid CS8629.
         if (param.IsEnum && param.EnumUnderlyingType != null)
         {
-            if (!param.ClrType.EndsWith("?"))
-                return $"(object)({param.EnumUnderlyingType})__c.P{index}";
-
-            // Nullable enum: HasValue check + underlying cast
             return $"__c.P{index}.HasValue ? (object)({param.EnumUnderlyingType})__c.P{index}.Value : DBNull.Value";
         }
 

--- a/src/Quarry.Tests/Generation/CarrierGenerationTests.cs
+++ b/src/Quarry.Tests/Generation/CarrierGenerationTests.cs
@@ -988,6 +988,60 @@ public static class Queries
     }
 
     [Test]
+    public void CarrierGeneration_WhereEnumParameter_EmitsNullSafeBindingAndLogging()
+    {
+        var source = @"
+using Quarry;
+namespace TestApp;
+
+public enum OrderPriority { Low, Normal, High }
+
+public class TicketSchema : Schema
+{
+    public static string Table => ""tickets"";
+    public Key<int> TicketId => Identity();
+    public Col<string> Subject => Length(200);
+    public Col<OrderPriority> Priority { get; }
+}
+
+[QuarryContext(Dialect = SqlDialect.SQLite)]
+public partial class TestDbContext : QuarryContext
+{
+    public partial IEntityAccessor<Ticket> Tickets();
+}
+
+public static class Queries
+{
+    public static async Task Test(TestDbContext db)
+    {
+        var p = OrderPriority.High;
+        await db.Tickets().Where(t => t.Priority == p).Select(t => t).ExecuteFetchAllAsync();
+    }
+}
+";
+
+        var compilation = CreateCompilation(source);
+        var result = RunGenerator(compilation);
+
+        var interceptorsTree = result.GeneratedTrees
+            .FirstOrDefault(t => t.FilePath.Contains(".Interceptors.") && t.FilePath.EndsWith(".g.cs"));
+        Assert.That(interceptorsTree, Is.Not.Null, "Should generate interceptors file");
+
+        var code = interceptorsTree!.GetText().ToString();
+
+        // Carrier field for enum should be nullable (NormalizeFieldType treats enums
+        // as reference types), so parameter binding must use HasValue null guard.
+        Assert.That(code, Does.Contain(".HasValue").And.Contain(".Value"),
+            "Enum parameter binding should use HasValue null guard (CS8629 fix)");
+        Assert.That(code, Does.Not.Contain("(object)(int)__c.P0;"),
+            "Should not directly cast nullable enum field without null guard");
+
+        // Parameter logging should use null-safe ToString pattern, not bare .ToString()
+        Assert.That(code, Does.Contain("?.ToString()").And.Contain(@"?? ""null"""),
+            "Enum parameter logging should use null-safe ToString (CS8604 fix)");
+    }
+
+    [Test]
     public void CarrierGeneration_DateTimeParameter_NoNullConditional()
     {
         var source = @"


### PR DESCRIPTION
## Summary
- Closes #92

## Reason for Change
The source generator emits code that produces CS8629 (nullable value type may be null) and CS8604 (possible null reference argument) warnings in generated interceptor files for enum parameters. This occurs because `CarrierAnalyzer.NormalizeFieldType` does not recognize enum types as value types, so carrier fields for enums are always nullable (`OrderPriority?`), but the emitters generated non-null-safe code against these fields.

## Impact
- Eliminates all 10 CS8629 and 6 CS8604 warnings across 8 generated interceptor files
- Affects all 4 dialects (SQLite, PostgreSQL, MySQL, SqlServer)
- Generated code now uses `HasValue`/`.Value` null guards for enum parameter binding and `?.ToString() ?? "null"` for enum parameter logging

## Plan items implemented as specified
- Fixed parameter binding emission in `TerminalEmitHelpers.GetParameterValueExpression` to always use nullable-safe `HasValue` path for enum types
- Fixed parameter logging emission in `CarrierEmitter.EmitInlineParameterLogging` to route enum parameters through `?.ToString() ?? "null"` instead of bare `.ToString()`
- Added generator unit test `CarrierGeneration_WhereEnumParameter_EmitsNullSafeBindingAndLogging` validating both patterns

## Deviations from plan implemented
None

## Gaps in original plan implemented
- Added generator-level unit test for WHERE clause enum parameter pattern, which was a test coverage gap

## Migration Steps
None — changes are to generated code output only. Regenerated interceptors will automatically use the fixed patterns.

## Performance Considerations
The `HasValue` check adds a trivial branch for enum parameter binding. For non-nullable enum parameters the `HasValue` is always true at runtime, so the branch is fully predictable and has no measurable impact.

## Security Considerations
None

## Breaking Changes
- Consumer-facing: None
- Internal: Generated interceptor code patterns change for enum parameters (null-safe wrappers added), but runtime behavior is identical