### PR TITLE
Standardize cross-dialect test structure for integration-ready pattern

### DIFF
--- a/src/Quarry.Tests/SqlOutput/CrossDialectAggregateTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectAggregateTests.cs
@@ -17,20 +17,21 @@ internal class CrossDialectAggregateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count())).Prepare();
+        var lt = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count())).Prepare();
+        var pg = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count())).Prepare();
+        var my = My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count())).Prepare();
+        var ss = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count())).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count())).ToDiagnostics(),
-            My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count())).ToDiagnostics(),
-            Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count())).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"Status\", COUNT(*) AS \"Item2\" FROM \"orders\" GROUP BY \"Status\"",
             pg:     "SELECT \"Status\", COUNT(*) AS \"Item2\" FROM \"orders\" GROUP BY \"Status\"",
             mysql:  "SELECT `Status`, COUNT(*) AS `Item2` FROM `orders` GROUP BY `Status`",
             ss:     "SELECT [Status], COUNT(*) AS [Item2] FROM [orders] GROUP BY [Status]");
 
         // Seed has 2 "Shipped" orders and 1 "Pending" — verify "Shipped" count = 2
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         var shipped = results.First(r => r.Item1 == "Shipped");
         Assert.That(shipped.Item2, Is.EqualTo(2));
     }
@@ -45,20 +46,21 @@ internal class CrossDialectAggregateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 5).Select(o => (o.Status, Sql.Count())).Prepare();
+        var lt = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 5).Select(o => (o.Status, Sql.Count())).Prepare();
+        var pg = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 5).Select(o => (o.Status, Sql.Count())).Prepare();
+        var my = My.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 5).Select(o => (o.Status, Sql.Count())).Prepare();
+        var ss = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 5).Select(o => (o.Status, Sql.Count())).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 5).Select(o => (o.Status, Sql.Count())).ToDiagnostics(),
-            My.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 5).Select(o => (o.Status, Sql.Count())).ToDiagnostics(),
-            Ss.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 5).Select(o => (o.Status, Sql.Count())).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"Status\", COUNT(*) AS \"Item2\" FROM \"orders\" GROUP BY \"Status\" HAVING COUNT(*) > 5",
             pg:     "SELECT \"Status\", COUNT(*) AS \"Item2\" FROM \"orders\" GROUP BY \"Status\" HAVING COUNT(*) > 5",
             mysql:  "SELECT `Status`, COUNT(*) AS `Item2` FROM `orders` GROUP BY `Status` HAVING COUNT(*) > 5",
             ss:     "SELECT [Status], COUNT(*) AS [Item2] FROM [orders] GROUP BY [Status] HAVING COUNT(*) > 5");
 
         // No status has count > 5 with only 3 orders — 0 rows returned
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0));
     }
 
@@ -72,20 +74,21 @@ internal class CrossDialectAggregateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total))).Prepare();
+        var lt = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total))).Prepare();
+        var pg = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total))).Prepare();
+        var my = My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total))).Prepare();
+        var ss = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total))).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total))).ToDiagnostics(),
-            My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total))).ToDiagnostics(),
-            Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total))).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"Status\", COUNT(*) AS \"Item2\", SUM(\"Total\") AS \"Item3\" FROM \"orders\" GROUP BY \"Status\"",
             pg:     "SELECT \"Status\", COUNT(*) AS \"Item2\", SUM(\"Total\") AS \"Item3\" FROM \"orders\" GROUP BY \"Status\"",
             mysql:  "SELECT `Status`, COUNT(*) AS `Item2`, SUM(\"Total\") AS `Item3` FROM `orders` GROUP BY `Status`",
             ss:     "SELECT [Status], COUNT(*) AS [Item2], SUM(\"Total\") AS [Item3] FROM [orders] GROUP BY [Status]");
 
         // "Shipped" has orders 250.00 + 150.00 = 400.00
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         var shipped = results.First(r => r.Item1 == "Shipped");
         Assert.That(shipped.Item2, Is.EqualTo(2));
         Assert.That(shipped.Item3, Is.EqualTo(400.00m).Within(0.01m));
@@ -101,20 +104,21 @@ internal class CrossDialectAggregateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).Prepare();
+        var lt = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).Prepare();
+        var pg = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).Prepare();
+        var my = My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).Prepare();
+        var ss = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).ToDiagnostics(),
-            My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).ToDiagnostics(),
-            Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"Status\", AVG(\"Total\") AS \"Item2\" FROM \"orders\" GROUP BY \"Status\"",
             pg:     "SELECT \"Status\", AVG(\"Total\") AS \"Item2\" FROM \"orders\" GROUP BY \"Status\"",
             mysql:  "SELECT `Status`, AVG(\"Total\") AS `Item2` FROM `orders` GROUP BY `Status`",
             ss:     "SELECT [Status], AVG(\"Total\") AS [Item2] FROM [orders] GROUP BY [Status]");
 
         // "Shipped" avg = (250 + 150) / 2 = 200.00
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         var shipped = results.First(r => r.Item1 == "Shipped");
         Assert.That(shipped.Item2, Is.EqualTo(200.00m).Within(0.01m));
     }
@@ -125,20 +129,21 @@ internal class CrossDialectAggregateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).Prepare();
+        var lt = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).Prepare();
+        var pg = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).Prepare();
+        var my = My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).Prepare();
+        var ss = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).ToDiagnostics(),
-            My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).ToDiagnostics(),
-            Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"Status\", MIN(\"Total\") AS \"Item2\" FROM \"orders\" GROUP BY \"Status\"",
             pg:     "SELECT \"Status\", MIN(\"Total\") AS \"Item2\" FROM \"orders\" GROUP BY \"Status\"",
             mysql:  "SELECT `Status`, MIN(\"Total\") AS `Item2` FROM `orders` GROUP BY `Status`",
             ss:     "SELECT [Status], MIN(\"Total\") AS [Item2] FROM [orders] GROUP BY [Status]");
 
         // "Shipped" min = 150.00
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         var shipped = results.First(r => r.Item1 == "Shipped");
         Assert.That(shipped.Item2, Is.EqualTo(150.00m).Within(0.01m));
     }
@@ -149,20 +154,21 @@ internal class CrossDialectAggregateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).Prepare();
+        var lt = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).Prepare();
+        var pg = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).Prepare();
+        var my = My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).Prepare();
+        var ss = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).ToDiagnostics(),
-            My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).ToDiagnostics(),
-            Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"Status\", MAX(\"Total\") AS \"Item2\" FROM \"orders\" GROUP BY \"Status\"",
             pg:     "SELECT \"Status\", MAX(\"Total\") AS \"Item2\" FROM \"orders\" GROUP BY \"Status\"",
             mysql:  "SELECT `Status`, MAX(\"Total\") AS `Item2` FROM `orders` GROUP BY `Status`",
             ss:     "SELECT [Status], MAX(\"Total\") AS [Item2] FROM [orders] GROUP BY [Status]");
 
         // "Shipped" max = 250.00
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         var shipped = results.First(r => r.Item1 == "Shipped");
         Assert.That(shipped.Item2, Is.EqualTo(250.00m).Within(0.01m));
     }
@@ -173,20 +179,21 @@ internal class CrossDialectAggregateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count())).Prepare();
+        var lt = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count())).Prepare();
+        var pg = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count())).Prepare();
+        var my = My.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count())).Prepare();
+        var ss = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count())).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count())).ToDiagnostics(),
-            My.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count())).ToDiagnostics(),
-            Ss.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count())).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"Status\", COUNT(*) AS \"Item2\" FROM \"orders\" GROUP BY \"Status\" HAVING COUNT(*) > 1",
             pg:     "SELECT \"Status\", COUNT(*) AS \"Item2\" FROM \"orders\" GROUP BY \"Status\" HAVING COUNT(*) > 1",
             mysql:  "SELECT `Status`, COUNT(*) AS `Item2` FROM `orders` GROUP BY `Status` HAVING COUNT(*) > 1",
             ss:     "SELECT [Status], COUNT(*) AS [Item2] FROM [orders] GROUP BY [Status] HAVING COUNT(*) > 1");
 
         // Only "Shipped" has count > 1 (2 orders), "Pending" has only 1
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].Item1, Is.EqualTo("Shipped"));
         Assert.That(results[0].Item2, Is.EqualTo(2));

--- a/src/Quarry.Tests/SqlOutput/CrossDialectBatchInsertTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectBatchInsertTests.cs
@@ -16,13 +16,13 @@ internal class CrossDialectBatchInsertTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new User { UserName = "a", IsActive = true } }).Prepare();
-        var pg   = Pg.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new Pg.User { UserName = "a", IsActive = true } }).Prepare();
-        var my   = My.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new My.User { UserName = "a", IsActive = true } }).Prepare();
-        var ss   = Ss.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new Ss.User { UserName = "a", IsActive = true } }).Prepare();
+        var lt = Lite.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new User { UserName = "a", IsActive = true } }).Prepare();
+        var pg = Pg.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new Pg.User { UserName = "a", IsActive = true } }).Prepare();
+        var my = My.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new My.User { UserName = "a", IsActive = true } }).Prepare();
+        var ss = Ss.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new Ss.User { UserName = "a", IsActive = true } }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "INSERT INTO \"users\" (\"UserName\", \"IsActive\") VALUES (@p0, @p1) RETURNING \"UserId\"",
             pg:     "INSERT INTO \"users\" (\"UserName\", \"IsActive\") VALUES ($1, $2) RETURNING \"UserId\"",
@@ -36,13 +36,13 @@ internal class CrossDialectBatchInsertTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().InsertBatch(u => u.UserName).Values(new[] { new User { UserName = "a" } }).Prepare();
-        var pg   = Pg.Users().InsertBatch(u => u.UserName).Values(new[] { new Pg.User { UserName = "a" } }).Prepare();
-        var my   = My.Users().InsertBatch(u => u.UserName).Values(new[] { new My.User { UserName = "a" } }).Prepare();
-        var ss   = Ss.Users().InsertBatch(u => u.UserName).Values(new[] { new Ss.User { UserName = "a" } }).Prepare();
+        var lt = Lite.Users().InsertBatch(u => u.UserName).Values(new[] { new User { UserName = "a" } }).Prepare();
+        var pg = Pg.Users().InsertBatch(u => u.UserName).Values(new[] { new Pg.User { UserName = "a" } }).Prepare();
+        var my = My.Users().InsertBatch(u => u.UserName).Values(new[] { new My.User { UserName = "a" } }).Prepare();
+        var ss = Ss.Users().InsertBatch(u => u.UserName).Values(new[] { new Ss.User { UserName = "a" } }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "INSERT INTO \"users\" (\"UserName\") VALUES (@p0) RETURNING \"UserId\"",
             pg:     "INSERT INTO \"users\" (\"UserName\") VALUES ($1) RETURNING \"UserId\"",
@@ -60,26 +60,23 @@ internal class CrossDialectBatchInsertTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var users = new[] { new User { UserName = "a", IsActive = true }, new User { UserName = "b", IsActive = false } };
+        var now = DateTime.UtcNow;
+        var users = new[] { new User { UserName = "a", IsActive = true, CreatedAt = now }, new User { UserName = "b", IsActive = false, CreatedAt = now } };
 
-        var liteSql = Lite.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(users).Prepare();
-        var pg      = Pg.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(users.Select(u => new Pg.User { UserName = u.UserName, IsActive = u.IsActive })).Prepare();
-        var my      = My.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(users.Select(u => new My.User { UserName = u.UserName, IsActive = u.IsActive })).Prepare();
-        var ss      = Ss.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(users.Select(u => new Ss.User { UserName = u.UserName, IsActive = u.IsActive })).Prepare();
+        var lt = Lite.Users().InsertBatch(u => (u.UserName, u.IsActive, u.CreatedAt)).Values(users).Prepare();
+        var pg = Pg.Users().InsertBatch(u => (u.UserName, u.IsActive, u.CreatedAt)).Values(users.Select(u => new Pg.User { UserName = u.UserName, IsActive = u.IsActive, CreatedAt = u.CreatedAt })).Prepare();
+        var my = My.Users().InsertBatch(u => (u.UserName, u.IsActive, u.CreatedAt)).Values(users.Select(u => new My.User { UserName = u.UserName, IsActive = u.IsActive, CreatedAt = u.CreatedAt })).Prepare();
+        var ss = Ss.Users().InsertBatch(u => (u.UserName, u.IsActive, u.CreatedAt)).Values(users.Select(u => new Ss.User { UserName = u.UserName, IsActive = u.IsActive, CreatedAt = u.CreatedAt })).Prepare();
 
         QueryTestHarness.AssertDialects(
-            liteSql.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
-            sqlite: "INSERT INTO \"users\" (\"UserName\", \"IsActive\") VALUES (@p0, @p1) RETURNING \"UserId\"",
-            pg:     "INSERT INTO \"users\" (\"UserName\", \"IsActive\") VALUES ($1, $2) RETURNING \"UserId\"",
-            mysql:  "INSERT INTO `users` (`UserName`, `IsActive`) VALUES (?, ?); SELECT LAST_INSERT_ID()",
-            ss:     "INSERT INTO [users] ([UserName], [IsActive]) VALUES (@p0, @p1) OUTPUT INSERTED.[UserId]");
+            sqlite: "INSERT INTO \"users\" (\"UserName\", \"IsActive\", \"CreatedAt\") VALUES (@p0, @p1, @p2) RETURNING \"UserId\"",
+            pg:     "INSERT INTO \"users\" (\"UserName\", \"IsActive\", \"CreatedAt\") VALUES ($1, $2, $3) RETURNING \"UserId\"",
+            mysql:  "INSERT INTO `users` (`UserName`, `IsActive`, `CreatedAt`) VALUES (?, ?, ?); SELECT LAST_INSERT_ID()",
+            ss:     "INSERT INTO [users] ([UserName], [IsActive], [CreatedAt]) VALUES (@p0, @p1, @p2) OUTPUT INSERTED.[UserId]");
 
-        // Verify real execution against SQLite — include CreatedAt to satisfy NOT NULL constraint
-        var now = DateTime.UtcNow;
-        var liteUsers = new[] { new User { UserName = "a", IsActive = true, CreatedAt = now }, new User { UserName = "b", IsActive = false, CreatedAt = now } };
-        var lite = Lite.Users().InsertBatch(u => (u.UserName, u.IsActive, u.CreatedAt)).Values(liteUsers).Prepare();
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(2));
     }
 
@@ -89,24 +86,23 @@ internal class CrossDialectBatchInsertTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var liteSql = Lite.Users().InsertBatch(u => u.UserName).Values(new[] { new User { UserName = "a" }, new User { UserName = "b" }, new User { UserName = "c" } }).Prepare();
-        var pg      = Pg.Users().InsertBatch(u => u.UserName).Values(new[] { new Pg.User { UserName = "a" }, new Pg.User { UserName = "b" }, new Pg.User { UserName = "c" } }).Prepare();
-        var my      = My.Users().InsertBatch(u => u.UserName).Values(new[] { new My.User { UserName = "a" }, new My.User { UserName = "b" }, new My.User { UserName = "c" } }).Prepare();
-        var ss      = Ss.Users().InsertBatch(u => u.UserName).Values(new[] { new Ss.User { UserName = "a" }, new Ss.User { UserName = "b" }, new Ss.User { UserName = "c" } }).Prepare();
+        var now = DateTime.UtcNow;
+        var users = new[] { new User { UserName = "a", CreatedAt = now }, new User { UserName = "b", CreatedAt = now }, new User { UserName = "c", CreatedAt = now } };
+
+        var lt = Lite.Users().InsertBatch(u => (u.UserName, u.CreatedAt)).Values(users).Prepare();
+        var pg = Pg.Users().InsertBatch(u => (u.UserName, u.CreatedAt)).Values(users.Select(u => new Pg.User { UserName = u.UserName, CreatedAt = u.CreatedAt })).Prepare();
+        var my = My.Users().InsertBatch(u => (u.UserName, u.CreatedAt)).Values(users.Select(u => new My.User { UserName = u.UserName, CreatedAt = u.CreatedAt })).Prepare();
+        var ss = Ss.Users().InsertBatch(u => (u.UserName, u.CreatedAt)).Values(users.Select(u => new Ss.User { UserName = u.UserName, CreatedAt = u.CreatedAt })).Prepare();
 
         QueryTestHarness.AssertDialects(
-            liteSql.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
-            sqlite: "INSERT INTO \"users\" (\"UserName\") VALUES (@p0) RETURNING \"UserId\"",
-            pg:     "INSERT INTO \"users\" (\"UserName\") VALUES ($1) RETURNING \"UserId\"",
-            mysql:  "INSERT INTO `users` (`UserName`) VALUES (?); SELECT LAST_INSERT_ID()",
-            ss:     "INSERT INTO [users] ([UserName]) VALUES (@p0) OUTPUT INSERTED.[UserId]");
+            sqlite: "INSERT INTO \"users\" (\"UserName\", \"CreatedAt\") VALUES (@p0, @p1) RETURNING \"UserId\"",
+            pg:     "INSERT INTO \"users\" (\"UserName\", \"CreatedAt\") VALUES ($1, $2) RETURNING \"UserId\"",
+            mysql:  "INSERT INTO `users` (`UserName`, `CreatedAt`) VALUES (?, ?); SELECT LAST_INSERT_ID()",
+            ss:     "INSERT INTO [users] ([UserName], [CreatedAt]) VALUES (@p0, @p1) OUTPUT INSERTED.[UserId]");
 
-        // Verify real execution against SQLite — include required columns
-        var now = DateTime.UtcNow;
-        var liteUsers = new[] { new User { UserName = "a", CreatedAt = now }, new User { UserName = "b", CreatedAt = now }, new User { UserName = "c", CreatedAt = now } };
-        var lite = Lite.Users().InsertBatch(u => (u.UserName, u.CreatedAt)).Values(liteUsers).Prepare();
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(3));
     }
 
@@ -120,22 +116,20 @@ internal class CrossDialectBatchInsertTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var liteSql = Lite.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new User { UserName = "a", IsActive = true } }).Prepare();
-        var pg      = Pg.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new Pg.User { UserName = "a", IsActive = true } }).Prepare();
-        var my      = My.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new My.User { UserName = "a", IsActive = true } }).Prepare();
-        var ss      = Ss.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new Ss.User { UserName = "a", IsActive = true } }).Prepare();
+        var lt = Lite.Users().InsertBatch(u => (u.UserName, u.IsActive, u.CreatedAt)).Values(new[] { new User { UserName = "a", IsActive = true, CreatedAt = DateTime.UtcNow } }).Prepare();
+        var pg = Pg.Users().InsertBatch(u => (u.UserName, u.IsActive, u.CreatedAt)).Values(new[] { new Pg.User { UserName = "a", IsActive = true, CreatedAt = DateTime.UtcNow } }).Prepare();
+        var my = My.Users().InsertBatch(u => (u.UserName, u.IsActive, u.CreatedAt)).Values(new[] { new My.User { UserName = "a", IsActive = true, CreatedAt = DateTime.UtcNow } }).Prepare();
+        var ss = Ss.Users().InsertBatch(u => (u.UserName, u.IsActive, u.CreatedAt)).Values(new[] { new Ss.User { UserName = "a", IsActive = true, CreatedAt = DateTime.UtcNow } }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            liteSql.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
-            sqlite: "INSERT INTO \"users\" (\"UserName\", \"IsActive\") VALUES (@p0, @p1) RETURNING \"UserId\"",
-            pg:     "INSERT INTO \"users\" (\"UserName\", \"IsActive\") VALUES ($1, $2) RETURNING \"UserId\"",
-            mysql:  "INSERT INTO `users` (`UserName`, `IsActive`) VALUES (?, ?); SELECT LAST_INSERT_ID()",
-            ss:     "INSERT INTO [users] ([UserName], [IsActive]) VALUES (@p0, @p1) OUTPUT INSERTED.[UserId]");
+            sqlite: "INSERT INTO \"users\" (\"UserName\", \"IsActive\", \"CreatedAt\") VALUES (@p0, @p1, @p2) RETURNING \"UserId\"",
+            pg:     "INSERT INTO \"users\" (\"UserName\", \"IsActive\", \"CreatedAt\") VALUES ($1, $2, $3) RETURNING \"UserId\"",
+            mysql:  "INSERT INTO `users` (`UserName`, `IsActive`, `CreatedAt`) VALUES (?, ?, ?); SELECT LAST_INSERT_ID()",
+            ss:     "INSERT INTO [users] ([UserName], [IsActive], [CreatedAt]) VALUES (@p0, @p1, @p2) OUTPUT INSERTED.[UserId]");
 
-        // Verify real execution against SQLite — include CreatedAt to satisfy NOT NULL constraint
-        var lite = Lite.Users().InsertBatch(u => (u.UserName, u.IsActive, u.CreatedAt)).Values(new[] { new User { UserName = "a", IsActive = true, CreatedAt = DateTime.UtcNow } }).Prepare();
-        var newId = await lite.ExecuteScalarAsync<int>();
+        var newId = await lt.ExecuteScalarAsync<int>();
         Assert.That(newId, Is.GreaterThan(0));
     }
 
@@ -149,13 +143,13 @@ internal class CrossDialectBatchInsertTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new User { UserName = "a", IsActive = true } }).Prepare();
-        var pg   = Pg.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new Pg.User { UserName = "a", IsActive = true } }).Prepare();
-        var my   = My.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new My.User { UserName = "a", IsActive = true } }).Prepare();
-        var ss   = Ss.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new Ss.User { UserName = "a", IsActive = true } }).Prepare();
+        var lt = Lite.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new User { UserName = "a", IsActive = true } }).Prepare();
+        var pg = Pg.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new Pg.User { UserName = "a", IsActive = true } }).Prepare();
+        var my = My.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new My.User { UserName = "a", IsActive = true } }).Prepare();
+        var ss = Ss.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(new[] { new Ss.User { UserName = "a", IsActive = true } }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "INSERT INTO \"users\" (\"UserName\", \"IsActive\") VALUES (@p0, @p1) RETURNING \"UserId\"",
             pg:     "INSERT INTO \"users\" (\"UserName\", \"IsActive\") VALUES ($1, $2) RETURNING \"UserId\"",
@@ -170,10 +164,10 @@ internal class CrossDialectBatchInsertTests
         var (Lite, Pg, My, Ss) = t;
 
         var users = new[] { new User { UserName = "a", IsActive = true }, new User { UserName = "b", IsActive = false } };
-        var lite = Lite.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(users).Prepare();
+        var lt = Lite.Users().InsertBatch(u => (u.UserName, u.IsActive)).Values(users).Prepare();
 
         // ToDiagnostics returns the single-row template SQL, not the expanded multi-row SQL
-        Assert.That(lite.ToDiagnostics().Sql, Is.EqualTo(
+        Assert.That(lt.ToDiagnostics().Sql, Is.EqualTo(
             "INSERT INTO \"users\" (\"UserName\", \"IsActive\") VALUES (@p0, @p1) RETURNING \"UserId\""));
     }
 

--- a/src/Quarry.Tests/SqlOutput/CrossDialectComplexTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectComplexTests.cs
@@ -21,20 +21,20 @@ internal class CrossDialectComplexTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.UserId > 10).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.UserId > 10).Select(u => (u.UserId, u.UserName)).Prepare();
-        var my   = My.Users().Where(u => u.UserId > 10).Select(u => (u.UserId, u.UserName)).Prepare();
-        var ss   = Ss.Users().Where(u => u.UserId > 10).Select(u => (u.UserId, u.UserName)).Prepare();
+        var lt= Lite.Users().Where(u => u.UserId > 10).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserId > 10).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserId > 10).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserId > 10).Select(u => (u.UserId, u.UserName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserId\" > 10",
             pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserId\" > 10",
             mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `UserId` > 10",
             ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [UserId] > 10");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0)); // All seeded users have UserId <= 3
     }
 
@@ -48,20 +48,20 @@ internal class CrossDialectComplexTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Email != null).Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Email != null).Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
-        var my   = My.Users().Where(u => u.Email != null).Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
-        var ss   = Ss.Users().Where(u => u.Email != null).Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
+        var lt= Lite.Users().Where(u => u.Email != null).Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
+        var pg = Pg.Users().Where(u => u.Email != null).Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
+        var my = My.Users().Where(u => u.Email != null).Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
+        var ss = Ss.Users().Where(u => u.Email != null).Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserName\", \"Email\" FROM \"users\" WHERE (\"Email\" IS NOT NULL) AND (\"IsActive\" = 1)",
             pg:     "SELECT \"UserName\", \"Email\" FROM \"users\" WHERE (\"Email\" IS NOT NULL) AND (\"IsActive\" = TRUE)",
             mysql:  "SELECT `UserName`, `Email` FROM `users` WHERE (`Email` IS NOT NULL) AND (`IsActive` = 1)",
             ss:     "SELECT [UserName], [Email] FROM [users] WHERE ([Email] IS NOT NULL) AND ([IsActive] = 1)");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1)); // Alice: has email + active
         Assert.That(results[0], Is.EqualTo(("Alice", (string?)"alice@test.com")));
     }
@@ -72,20 +72,20 @@ internal class CrossDialectComplexTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.IsActive).Where(u => u.UserId > 5).Select(u => (u.UserId, u.UserName, u.Email)).Prepare();
-        var pg   = Pg.Users().Where(u => u.IsActive).Where(u => u.UserId > 5).Select(u => (u.UserId, u.UserName, u.Email)).Prepare();
-        var my   = My.Users().Where(u => u.IsActive).Where(u => u.UserId > 5).Select(u => (u.UserId, u.UserName, u.Email)).Prepare();
-        var ss   = Ss.Users().Where(u => u.IsActive).Where(u => u.UserId > 5).Select(u => (u.UserId, u.UserName, u.Email)).Prepare();
+        var lt= Lite.Users().Where(u => u.IsActive).Where(u => u.UserId > 5).Select(u => (u.UserId, u.UserName, u.Email)).Prepare();
+        var pg = Pg.Users().Where(u => u.IsActive).Where(u => u.UserId > 5).Select(u => (u.UserId, u.UserName, u.Email)).Prepare();
+        var my = My.Users().Where(u => u.IsActive).Where(u => u.UserId > 5).Select(u => (u.UserId, u.UserName, u.Email)).Prepare();
+        var ss = Ss.Users().Where(u => u.IsActive).Where(u => u.UserId > 5).Select(u => (u.UserId, u.UserName, u.Email)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"Email\" FROM \"users\" WHERE (\"IsActive\" = 1) AND (\"UserId\" > 5)",
             pg:     "SELECT \"UserId\", \"UserName\", \"Email\" FROM \"users\" WHERE (\"IsActive\" = TRUE) AND (\"UserId\" > 5)",
             mysql:  "SELECT `UserId`, `UserName`, `Email` FROM `users` WHERE (`IsActive` = 1) AND (`UserId` > 5)",
             ss:     "SELECT [UserId], [UserName], [Email] FROM [users] WHERE ([IsActive] = 1) AND ([UserId] > 5)");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0));
     }
 
@@ -99,20 +99,20 @@ internal class CrossDialectComplexTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Distinct().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
-        var pg   = Pg.Users().Distinct().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
-        var my   = My.Users().Distinct().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
-        var ss   = Ss.Users().Distinct().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
+        var lt= Lite.Users().Distinct().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
+        var pg = Pg.Users().Distinct().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
+        var my = My.Users().Distinct().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
+        var ss = Ss.Users().Distinct().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT DISTINCT \"UserName\", \"Email\" FROM \"users\" WHERE \"IsActive\" = 1",
             pg:     "SELECT DISTINCT \"UserName\", \"Email\" FROM \"users\" WHERE \"IsActive\" = TRUE",
             mysql:  "SELECT DISTINCT `UserName`, `Email` FROM `users` WHERE `IsActive` = 1",
             ss:     "SELECT DISTINCT [UserName], [Email] FROM [users] WHERE [IsActive] = 1");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2)); // Alice and Bob are active
     }
 
@@ -126,20 +126,20 @@ internal class CrossDialectComplexTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Limit(10).Offset(20).Prepare();
-        var pg   = Pg.Users().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Limit(10).Offset(20).Prepare();
-        var my   = My.Users().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Limit(10).Offset(20).Prepare();
-        var ss   = Ss.Users().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Limit(10).Offset(20).Prepare();
+        var lt= Lite.Users().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Limit(10).Offset(20).Prepare();
+        var pg = Pg.Users().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Limit(10).Offset(20).Prepare();
+        var my = My.Users().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Limit(10).Offset(20).Prepare();
+        var ss = Ss.Users().Where(u => u.IsActive).Select(u => (u.UserName, u.Email)).Limit(10).Offset(20).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserName\", \"Email\" FROM \"users\" WHERE \"IsActive\" = 1 LIMIT 10 OFFSET 20",
             pg:     "SELECT \"UserName\", \"Email\" FROM \"users\" WHERE \"IsActive\" = TRUE LIMIT 10 OFFSET 20",
             mysql:  "SELECT `UserName`, `Email` FROM `users` WHERE `IsActive` = 1 LIMIT 10 OFFSET 20",
             ss:     "SELECT [UserName], [Email] FROM [users] WHERE [IsActive] = 1 ORDER BY (SELECT NULL) OFFSET 20 ROWS FETCH NEXT 10 ROWS ONLY");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0)); // Offset 20 skips all 2 active users
     }
 
@@ -149,20 +149,20 @@ internal class CrossDialectComplexTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Limit(5).Prepare();
-        var pg   = Pg.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Limit(5).Prepare();
-        var my   = My.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Limit(5).Prepare();
-        var ss   = Ss.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Limit(5).Prepare();
+        var lt= Lite.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Limit(5).Prepare();
+        var pg = Pg.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Limit(5).Prepare();
+        var my = My.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Limit(5).Prepare();
+        var ss = Ss.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Limit(5).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"IsActive\" = 1 LIMIT 5",
             pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"IsActive\" = TRUE LIMIT 5",
             mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `IsActive` = 1 LIMIT 5",
             ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [IsActive] = 1 ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 5 ROWS ONLY");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2)); // Alice and Bob
     }
 
@@ -176,20 +176,20 @@ internal class CrossDialectComplexTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => o.Total > 100).Select(o => (o.OrderId, o.Total, o.Status)).Prepare();
-        var pg   = Pg.Orders().Where(o => o.Total > 100).Select(o => (o.OrderId, o.Total, o.Status)).Prepare();
-        var my   = My.Orders().Where(o => o.Total > 100).Select(o => (o.OrderId, o.Total, o.Status)).Prepare();
-        var ss   = Ss.Orders().Where(o => o.Total > 100).Select(o => (o.OrderId, o.Total, o.Status)).Prepare();
+        var lt= Lite.Orders().Where(o => o.Total > 100).Select(o => (o.OrderId, o.Total, o.Status)).Prepare();
+        var pg = Pg.Orders().Where(o => o.Total > 100).Select(o => (o.OrderId, o.Total, o.Status)).Prepare();
+        var my = My.Orders().Where(o => o.Total > 100).Select(o => (o.OrderId, o.Total, o.Status)).Prepare();
+        var ss = Ss.Orders().Where(o => o.Total > 100).Select(o => (o.OrderId, o.Total, o.Status)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"OrderId\", \"Total\", \"Status\" FROM \"orders\" WHERE \"Total\" > 100",
             pg:     "SELECT \"OrderId\", \"Total\", \"Status\" FROM \"orders\" WHERE \"Total\" > 100",
             mysql:  "SELECT `OrderId`, `Total`, `Status` FROM `orders` WHERE `Total` > 100",
             ss:     "SELECT [OrderId], [Total], [Status] FROM [orders] WHERE [Total] > 100");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2)); // Order 1 (250) and Order 3 (150)
     }
 
@@ -203,20 +203,20 @@ internal class CrossDialectComplexTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var pg   = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var my   = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var ss   = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var lt= Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var pg = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var my = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var ss = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t0\".\"IsActive\" = 1",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t0\".\"IsActive\" = TRUE",
             mysql:  "SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` INNER JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId` WHERE `t0`.`IsActive` = 1",
             ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId] WHERE [t0].[IsActive] = 1");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3)); // Alice's 2 orders + Bob's 1 order (both active)
     }
 
@@ -226,20 +226,20 @@ internal class CrossDialectComplexTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 50).Select((u, o) => (u.UserName, o.Total, o.Status)).Prepare();
-        var pg   = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 50).Select((u, o) => (u.UserName, o.Total, o.Status)).Prepare();
-        var my   = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 50).Select((u, o) => (u.UserName, o.Total, o.Status)).Prepare();
-        var ss   = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 50).Select((u, o) => (u.UserName, o.Total, o.Status)).Prepare();
+        var lt= Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 50).Select((u, o) => (u.UserName, o.Total, o.Status)).Prepare();
+        var pg = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 50).Select((u, o) => (u.UserName, o.Total, o.Status)).Prepare();
+        var my = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 50).Select((u, o) => (u.UserName, o.Total, o.Status)).Prepare();
+        var ss = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 50).Select((u, o) => (u.UserName, o.Total, o.Status)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\", \"t1\".\"Status\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t1\".\"Total\" > 50",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\", \"t1\".\"Status\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t1\".\"Total\" > 50",
             mysql:  "SELECT `t0`.`UserName`, `t1`.`Total`, `t1`.`Status` FROM `users` AS `t0` INNER JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId` WHERE `t1`.`Total` > 50",
             ss:     "SELECT [t0].[UserName], [t1].[Total], [t1].[Status] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId] WHERE [t1].[Total] > 50");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3)); // All 3 orders have Total > 50
     }
 

--- a/src/Quarry.Tests/SqlOutput/CrossDialectCompositionTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectCompositionTests.cs
@@ -23,7 +23,7 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id)
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id)
                 .Where((u, o) => o.Total > 100 && u.IsActive)
                 .OrderBy((u, o) => o.Total, Direction.Descending)
                 .Limit(10).Offset(0)
@@ -49,7 +49,7 @@ internal class CrossDialectCompositionTests
                 .Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\", \"t1\".\"Status\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t1\".\"Total\" > 100 AND \"t0\".\"IsActive\" = 1 ORDER BY \"t1\".\"Total\" DESC LIMIT 10",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\", \"t1\".\"Status\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t1\".\"Total\" > 100 AND \"t0\".\"IsActive\" = TRUE ORDER BY \"t1\".\"Total\" DESC LIMIT 10",
@@ -57,7 +57,7 @@ internal class CrossDialectCompositionTests
             ss:     "SELECT [t0].[UserName], [t1].[Total], [t1].[Status] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId] WHERE [t1].[Total] > 100 AND [t0].[IsActive] = 1 ORDER BY [t1].[Total] DESC OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY");
 
         // Seed: Alice has orders 250 (Shipped) and 75.50 (Pending). Only 250 > 100. Bob has 150 (Shipped) > 100. — 2 results
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo(("Alice", 250.00m, "Shipped")));
         Assert.That(results[1], Is.EqualTo(("Bob", 150.00m, "Shipped")));
@@ -73,7 +73,7 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users()
+        var lt = Lite.Users()
                 .Where(u => u.IsActive && u.Orders.Any(o => o.Total > 500))
                 .OrderBy(u => u.UserName)
                 .Select(u => (u.UserName, u.Email))
@@ -95,7 +95,7 @@ internal class CrossDialectCompositionTests
                 .Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserName\", \"Email\" FROM \"users\" WHERE \"IsActive\" = 1 AND EXISTS (SELECT 1 FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\" AND (\"sq0\".\"Total\" > 500)) ORDER BY \"UserName\" ASC",
             pg:     "SELECT \"UserName\", \"Email\" FROM \"users\" WHERE \"IsActive\" = TRUE AND EXISTS (SELECT 1 FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\" AND (\"sq0\".\"Total\" > 500)) ORDER BY \"UserName\" ASC",
@@ -103,7 +103,7 @@ internal class CrossDialectCompositionTests
             ss:     "SELECT [UserName], [Email] FROM [users] WHERE [IsActive] = 1 AND EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND ([sq0].[Total] > 500)) ORDER BY [UserName] ASC");
 
         // No users have orders > 500 in seed data — 0 results
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0));
     }
 
@@ -117,7 +117,7 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id)
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id)
                 .Join<OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id)
                 .Where((u, o, oi) => oi.UnitPrice > 50.00m)
                 .Select((u, o, oi) => (u.UserName, o.Status, oi.ProductName, oi.Quantity))
@@ -139,7 +139,7 @@ internal class CrossDialectCompositionTests
                 .Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Status\", \"t2\".\"ProductName\", \"t2\".\"Quantity\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" INNER JOIN \"order_items\" AS \"t2\" ON \"t1\".\"OrderId\" = \"t2\".\"OrderId\" WHERE \"t2\".\"UnitPrice\" > 50.00",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Status\", \"t2\".\"ProductName\", \"t2\".\"Quantity\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" INNER JOIN \"order_items\" AS \"t2\" ON \"t1\".\"OrderId\" = \"t2\".\"OrderId\" WHERE \"t2\".\"UnitPrice\" > 50.00",
@@ -147,7 +147,7 @@ internal class CrossDialectCompositionTests
             ss:     "SELECT [t0].[UserName], [t1].[Status], [t2].[ProductName], [t2].[Quantity] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId] INNER JOIN [order_items] AS [t2] ON [t1].[OrderId] = [t2].[OrderId] WHERE [t2].[UnitPrice] > 50.00");
 
         // Seed: Widget UnitPrice=125 (>50) and Gadget UnitPrice=75.50 (>50), Widget UnitPrice=50 (NOT >50) — 2 results
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
     }
 
@@ -161,7 +161,7 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users()
+        var lt = Lite.Users()
                 .Where(u => u.Orders.Any(o => o.Status == "shipped")
                          && u.Orders.All(o => o.Status != "cancelled"))
                 .Select(u => (u.UserId, u.UserName))
@@ -183,7 +183,7 @@ internal class CrossDialectCompositionTests
                 .Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE EXISTS (SELECT 1 FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\" AND (\"sq0\".\"Status\" = 'shipped')) AND NOT EXISTS (SELECT 1 FROM \"orders\" AS \"sq1\" WHERE \"sq1\".\"UserId\" = \"users\".\"UserId\" AND NOT (\"sq1\".\"Status\" <> 'cancelled'))",
             pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE EXISTS (SELECT 1 FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\" AND (\"sq0\".\"Status\" = 'shipped')) AND NOT EXISTS (SELECT 1 FROM \"orders\" AS \"sq1\" WHERE \"sq1\".\"UserId\" = \"users\".\"UserId\" AND NOT (\"sq1\".\"Status\" <> 'cancelled'))",
@@ -191,7 +191,7 @@ internal class CrossDialectCompositionTests
             ss:     "SELECT [UserId], [UserName] FROM [users] WHERE EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND ([sq0].[Status] = 'shipped')) AND NOT EXISTS (SELECT 1 FROM [orders] AS [sq1] WHERE [sq1].[UserId] = [users].[UserId] AND NOT ([sq1].[Status] <> 'cancelled'))");
 
         // Seed: Alice has Shipped+Pending, Bob has Shipped — case-sensitive "shipped" vs "Shipped" means 0 matches
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0));
     }
 
@@ -205,7 +205,7 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users()
+        var lt = Lite.Users()
                 .Where(u => u.Email != null && u.UserName.Contains("john"))
                 .OrderBy(u => u.UserName, Direction.Descending)
                 .Limit(5)
@@ -231,7 +231,7 @@ internal class CrossDialectCompositionTests
                 .Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserName\", \"Email\" FROM \"users\" WHERE \"Email\" IS NOT NULL AND \"UserName\" LIKE '%john%' ORDER BY \"UserName\" DESC LIMIT 5",
             pg:     "SELECT \"UserName\", \"Email\" FROM \"users\" WHERE \"Email\" IS NOT NULL AND \"UserName\" LIKE '%john%' ORDER BY \"UserName\" DESC LIMIT 5",
@@ -239,7 +239,7 @@ internal class CrossDialectCompositionTests
             ss:     "SELECT [UserName], [Email] FROM [users] WHERE [Email] IS NOT NULL AND [UserName] LIKE '%john%' ORDER BY [UserName] DESC OFFSET 0 ROWS FETCH NEXT 5 ROWS ONLY");
 
         // No seed users have "john" in UserName — 0 results
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0));
     }
 
@@ -254,7 +254,7 @@ internal class CrossDialectCompositionTests
         var (Lite, Pg, My, Ss) = t;
 
         var statuses = new[] { "pending", "processing", "shipped" };
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id)
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id)
                 .Where((u, o) => statuses.Contains(o.Status))
                 .Select((u, o) => (u.UserName, o.Total))
                 .Prepare();
@@ -272,7 +272,7 @@ internal class CrossDialectCompositionTests
                 .Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t1\".\"Status\" IN ('pending', 'processing', 'shipped')",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t1\".\"Status\" IN ('pending', 'processing', 'shipped')",
@@ -280,7 +280,7 @@ internal class CrossDialectCompositionTests
             ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId] WHERE [t1].[Status] IN ('pending', 'processing', 'shipped')");
 
         // Case-sensitive: seed has "Shipped", "Pending" — lowercase "shipped"/"pending" match 0
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0));
     }
 
@@ -294,7 +294,7 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users()
+        var lt = Lite.Users()
                 .Where(u => u.Orders.Count(o => o.Priority == OrderPriority.Urgent) > 2)
                 .Select(u => (u.UserId, u.UserName))
                 .Prepare();
@@ -312,7 +312,7 @@ internal class CrossDialectCompositionTests
                 .Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (SELECT COUNT(*) FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\" AND (\"sq0\".\"Priority\" = 3)) > 2",
             pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (SELECT COUNT(*) FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\" AND (\"sq0\".\"Priority\" = 3)) > 2",
@@ -320,7 +320,7 @@ internal class CrossDialectCompositionTests
             ss:     "SELECT [UserId], [UserName] FROM [users] WHERE (SELECT COUNT(*) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND ([sq0].[Priority] = 3)) > 2");
 
         // Seed: Bob has 1 Urgent order, nobody has >2 — 0 results
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0));
     }
 
@@ -334,7 +334,7 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders()
+        var lt = Lite.Orders()
                 .Where(o => true)
                 .GroupBy(o => o.Status)
                 .Having(o => Sql.Count() > 5)
@@ -360,7 +360,7 @@ internal class CrossDialectCompositionTests
                 .Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"Status\", COUNT(*) AS \"Item2\", SUM(\"Total\") AS \"Item3\" FROM \"orders\" GROUP BY \"Status\" HAVING COUNT(*) > 5",
             pg:     "SELECT \"Status\", COUNT(*) AS \"Item2\", SUM(\"Total\") AS \"Item3\" FROM \"orders\" GROUP BY \"Status\" HAVING COUNT(*) > 5",
@@ -368,7 +368,7 @@ internal class CrossDialectCompositionTests
             ss:     "SELECT [Status], COUNT(*) AS [Item2], SUM(\"Total\") AS [Item3] FROM [orders] GROUP BY [Status] HAVING COUNT(*) > 5");
 
         // Seed: only 3 orders total, no status group has >5 — 0 results
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0));
     }
 
@@ -382,7 +382,7 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id)
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id)
                 .Where((u, o) => o.Total > 0)
                 .OrderBy((u, o) => o.Total)
                 .Distinct()
@@ -412,7 +412,7 @@ internal class CrossDialectCompositionTests
                 .Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT DISTINCT \"t0\".\"UserName\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t1\".\"Total\" > 0 ORDER BY \"t1\".\"Total\" ASC LIMIT 20",
             pg:     "SELECT DISTINCT \"t0\".\"UserName\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t1\".\"Total\" > 0 ORDER BY \"t1\".\"Total\" ASC LIMIT 20",
@@ -420,7 +420,7 @@ internal class CrossDialectCompositionTests
             ss:     "SELECT DISTINCT [t0].[UserName] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId] WHERE [t1].[Total] > 0 ORDER BY [t1].[Total] ASC OFFSET 0 ROWS FETCH NEXT 20 ROWS ONLY");
 
         // Seed: Alice has 2 orders, Bob has 1 — DISTINCT UserName gives Alice, Bob — 2 results
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
     }
 
@@ -434,7 +434,7 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users()
+        var lt = Lite.Users()
                 .Where(u => u.Orders.Any(o => o.Items.Any(i => i.UnitPrice > 100)))
                 .Select(u => (u.UserId, u.UserName))
                 .Prepare();
@@ -452,7 +452,7 @@ internal class CrossDialectCompositionTests
                 .Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE EXISTS (SELECT 1 FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\" AND (EXISTS (SELECT 1 FROM \"order_items\" AS \"sq1\" WHERE \"sq1\".\"OrderId\" = \"sq0\".\"OrderId\" AND (\"sq1\".\"UnitPrice\" > 100))))",
             pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE EXISTS (SELECT 1 FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\" AND (EXISTS (SELECT 1 FROM \"order_items\" AS \"sq1\" WHERE \"sq1\".\"OrderId\" = \"sq0\".\"OrderId\" AND (\"sq1\".\"UnitPrice\" > 100))))",
@@ -460,7 +460,7 @@ internal class CrossDialectCompositionTests
             ss:     "SELECT [UserId], [UserName] FROM [users] WHERE EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND (EXISTS (SELECT 1 FROM [order_items] AS [sq1] WHERE [sq1].[OrderId] = [sq0].[OrderId] AND ([sq1].[UnitPrice] > 100))))");
 
         // Seed: Widget UnitPrice=125 (>100) in order 1 (Alice) — Alice matches
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
     }
@@ -475,13 +475,13 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).Prepare();
-        var pg   = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).Prepare();
-        var my   = My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).Prepare();
-        var ss   = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).Prepare();
+        var lt = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).Prepare();
+        var pg = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).Prepare();
+        var my = My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).Prepare();
+        var ss = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Avg(o.Total))).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"Status\", AVG(\"Total\") AS \"Item2\" FROM \"orders\" GROUP BY \"Status\"",
             pg:     "SELECT \"Status\", AVG(\"Total\") AS \"Item2\" FROM \"orders\" GROUP BY \"Status\"",
@@ -489,7 +489,7 @@ internal class CrossDialectCompositionTests
             ss:     "SELECT [Status], AVG(\"Total\") AS [Item2] FROM [orders] GROUP BY [Status]");
 
         // Seed: Shipped=(250+150)/2=200, Pending=75.50 — 2 groups
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
     }
 
@@ -499,20 +499,20 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).Prepare();
-        var pg   = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).Prepare();
-        var my   = My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).Prepare();
-        var ss   = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).Prepare();
+        var lt = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).Prepare();
+        var pg = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).Prepare();
+        var my = My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).Prepare();
+        var ss = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Min(o.Total))).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"Status\", MIN(\"Total\") AS \"Item2\" FROM \"orders\" GROUP BY \"Status\"",
             pg:     "SELECT \"Status\", MIN(\"Total\") AS \"Item2\" FROM \"orders\" GROUP BY \"Status\"",
             mysql:  "SELECT `Status`, MIN(\"Total\") AS `Item2` FROM `orders` GROUP BY `Status`",
             ss:     "SELECT [Status], MIN(\"Total\") AS [Item2] FROM [orders] GROUP BY [Status]");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
     }
 
@@ -522,20 +522,20 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).Prepare();
-        var pg   = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).Prepare();
-        var my   = My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).Prepare();
-        var ss   = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).Prepare();
+        var lt = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).Prepare();
+        var pg = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).Prepare();
+        var my = My.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).Prepare();
+        var ss = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Select(o => (o.Status, Sql.Max(o.Total))).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"Status\", MAX(\"Total\") AS \"Item2\" FROM \"orders\" GROUP BY \"Status\"",
             pg:     "SELECT \"Status\", MAX(\"Total\") AS \"Item2\" FROM \"orders\" GROUP BY \"Status\"",
             mysql:  "SELECT `Status`, MAX(\"Total\") AS `Item2` FROM `orders` GROUP BY `Status`",
             ss:     "SELECT [Status], MAX(\"Total\") AS [Item2] FROM [orders] GROUP BY [Status]");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
     }
 
@@ -545,13 +545,13 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total), Sql.Avg(o.Total), Sql.Min(o.Total), Sql.Max(o.Total))).Prepare();
-        var pg   = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total), Sql.Avg(o.Total), Sql.Min(o.Total), Sql.Max(o.Total))).Prepare();
-        var my   = My.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total), Sql.Avg(o.Total), Sql.Min(o.Total), Sql.Max(o.Total))).Prepare();
-        var ss   = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total), Sql.Avg(o.Total), Sql.Min(o.Total), Sql.Max(o.Total))).Prepare();
+        var lt = Lite.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total), Sql.Avg(o.Total), Sql.Min(o.Total), Sql.Max(o.Total))).Prepare();
+        var pg = Pg.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total), Sql.Avg(o.Total), Sql.Min(o.Total), Sql.Max(o.Total))).Prepare();
+        var my = My.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total), Sql.Avg(o.Total), Sql.Min(o.Total), Sql.Max(o.Total))).Prepare();
+        var ss = Ss.Orders().Where(o => true).GroupBy(o => o.Status).Having(o => Sql.Count() > 1).Select(o => (o.Status, Sql.Count(), Sql.Sum(o.Total), Sql.Avg(o.Total), Sql.Min(o.Total), Sql.Max(o.Total))).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"Status\", COUNT(*) AS \"Item2\", SUM(\"Total\") AS \"Item3\", AVG(\"Total\") AS \"Item4\", MIN(\"Total\") AS \"Item5\", MAX(\"Total\") AS \"Item6\" FROM \"orders\" GROUP BY \"Status\" HAVING COUNT(*) > 1",
             pg:     "SELECT \"Status\", COUNT(*) AS \"Item2\", SUM(\"Total\") AS \"Item3\", AVG(\"Total\") AS \"Item4\", MIN(\"Total\") AS \"Item5\", MAX(\"Total\") AS \"Item6\" FROM \"orders\" GROUP BY \"Status\" HAVING COUNT(*) > 1",
@@ -559,7 +559,7 @@ internal class CrossDialectCompositionTests
             ss:     "SELECT [Status], COUNT(*) AS [Item2], SUM(\"Total\") AS [Item3], AVG(\"Total\") AS [Item4], MIN(\"Total\") AS [Item5], MAX(\"Total\") AS [Item6] FROM [orders] GROUP BY [Status] HAVING COUNT(*) > 1");
 
         // Seed: Shipped has 2 orders (>1), Pending has 1 (not >1) — 1 group
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].Item1, Is.EqualTo("Shipped"));
         Assert.That(results[0].Item2, Is.EqualTo(2));
@@ -578,13 +578,13 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => _runtimeStatuses.Contains(o.Status)).Select(o => (o.OrderId, o.Status)).Prepare();
-        var pg   = Pg.Orders().Where(o => _runtimeStatuses.Contains(o.Status)).Select(o => (o.OrderId, o.Status)).Prepare();
-        var my   = My.Orders().Where(o => _runtimeStatuses.Contains(o.Status)).Select(o => (o.OrderId, o.Status)).Prepare();
-        var ss   = Ss.Orders().Where(o => _runtimeStatuses.Contains(o.Status)).Select(o => (o.OrderId, o.Status)).Prepare();
+        var lt = Lite.Orders().Where(o => _runtimeStatuses.Contains(o.Status)).Select(o => (o.OrderId, o.Status)).Prepare();
+        var pg = Pg.Orders().Where(o => _runtimeStatuses.Contains(o.Status)).Select(o => (o.OrderId, o.Status)).Prepare();
+        var my = My.Orders().Where(o => _runtimeStatuses.Contains(o.Status)).Select(o => (o.OrderId, o.Status)).Prepare();
+        var ss = Ss.Orders().Where(o => _runtimeStatuses.Contains(o.Status)).Select(o => (o.OrderId, o.Status)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"OrderId\", \"Status\" FROM \"orders\" WHERE \"Status\" IN ('pending', 'processing', 'shipped')",
             pg:     "SELECT \"OrderId\", \"Status\" FROM \"orders\" WHERE \"Status\" IN ('pending', 'processing', 'shipped')",
@@ -592,7 +592,7 @@ internal class CrossDialectCompositionTests
             ss:     "SELECT [OrderId], [Status] FROM [orders] WHERE [Status] IN ('pending', 'processing', 'shipped')");
 
         // Case-sensitive: seed has "Shipped", "Pending" — lowercase values match 0
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0));
     }
 
@@ -630,13 +630,13 @@ internal class CrossDialectCompositionTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => _mutableStatuses.Contains(o.Status)).Select(o => (o.OrderId, o.Status)).Prepare();
+        var lt = Lite.Orders().Where(o => _mutableStatuses.Contains(o.Status)).Select(o => (o.OrderId, o.Status)).Prepare();
 
         // Mutable static field must stay parameterized — values are NOT inlined
-        var liteDiag = lite.ToDiagnostics();
-        Assert.That(liteDiag.Parameters, Has.Count.GreaterThan(0),
+        var ltDiag = lt.ToDiagnostics();
+        Assert.That(ltDiag.Parameters, Has.Count.GreaterThan(0),
             "Mutable static array should not be inlined — parameters expected");
-        Assert.That(liteDiag.Sql, Does.Not.Contain("IN ('pending'"),
+        Assert.That(ltDiag.Sql, Does.Not.Contain("IN ('pending'"),
             "Mutable static array values should not appear as inline literals");
 
         var pgDiag = Pg.Orders().Where(o => _mutableStatuses.Contains(o.Status)).Select(o => (o.OrderId, o.Status)).ToDiagnostics();
@@ -711,18 +711,38 @@ internal class CrossDialectCompositionTests
     public async Task ConditionalWhere_OnTupleProjection_ResolvesCorrectType()
     {
         await using var t = await QueryTestHarness.CreateAsync();
-        var (Lite, _, _, _) = t;
+        var (Lite, Pg, My, Ss) = t;
 
         var priority = OrderPriority.High;
 
         // This pattern triggers the bug: Select returns IQueryBuilder<Order, (int, decimal, OrderPriority)>
         // but when assigned to var and Where is called conditionally, the generator sees (object, object, object).
-        var query = Lite.Orders().Select(o => (o.OrderId, o.Total, o.Priority));
-        query = query.Where(o => o.Priority == priority);
+        var ltQ = Lite.Orders().Select(o => (o.OrderId, o.Total, o.Priority));
+        ltQ = ltQ.Where(o => o.Priority == priority);
+        var lt = ltQ.Prepare();
 
-        var results = await query.ExecuteFetchAllAsync();
+        var pgQ = Pg.Orders().Select(o => (o.OrderId, o.Total, o.Priority));
+        pgQ = pgQ.Where(o => o.Priority == priority);
+        var pg = pgQ.Prepare();
+
+        var myQ = My.Orders().Select(o => (o.OrderId, o.Total, o.Priority));
+        myQ = myQ.Where(o => o.Priority == priority);
+        var my = myQ.Prepare();
+
+        var ssQ = Ss.Orders().Select(o => (o.OrderId, o.Total, o.Priority));
+        ssQ = ssQ.Where(o => o.Priority == priority);
+        var ss = ssQ.Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"OrderId\", \"Total\", \"Priority\" FROM \"orders\" WHERE \"Priority\" = @p0",
+            pg:     "SELECT \"OrderId\", \"Total\", \"Priority\" FROM \"orders\" WHERE \"Priority\" = $1",
+            mysql:  "SELECT `OrderId`, `Total`, `Priority` FROM `orders` WHERE `Priority` = ?",
+            ss:     "SELECT [OrderId], [Total], [Priority] FROM [orders] WHERE [Priority] = @p0");
 
         // Seed: Order1(High,250), Order2(Normal,75.50), Order3(Urgent,150)
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].OrderId, Is.EqualTo(1));
     }
@@ -731,15 +751,35 @@ internal class CrossDialectCompositionTests
     public async Task ConditionalOrderBy_OnTupleProjection_ResolvesCorrectType()
     {
         await using var t = await QueryTestHarness.CreateAsync();
-        var (Lite, _, _, _) = t;
+        var (Lite, Pg, My, Ss) = t;
 
         // OrderBy after Select with tuple projection + variable reassignment
-        var query = Lite.Orders().Select(o => (o.OrderId, o.Total));
-        query = query.OrderBy(o => o.Total);
+        var ltQ = Lite.Orders().Select(o => (o.OrderId, o.Total));
+        ltQ = ltQ.OrderBy(o => o.Total);
+        var lt = ltQ.Prepare();
 
-        var results = await query.ExecuteFetchAllAsync();
+        var pgQ = Pg.Orders().Select(o => (o.OrderId, o.Total));
+        pgQ = pgQ.OrderBy(o => o.Total);
+        var pg = pgQ.Prepare();
+
+        var myQ = My.Orders().Select(o => (o.OrderId, o.Total));
+        myQ = myQ.OrderBy(o => o.Total);
+        var my = myQ.Prepare();
+
+        var ssQ = Ss.Orders().Select(o => (o.OrderId, o.Total));
+        ssQ = ssQ.OrderBy(o => o.Total);
+        var ss = ssQ.Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"OrderId\", \"Total\" FROM \"orders\" ORDER BY \"Total\" ASC",
+            pg:     "SELECT \"OrderId\", \"Total\" FROM \"orders\" ORDER BY \"Total\" ASC",
+            mysql:  "SELECT `OrderId`, `Total` FROM `orders` ORDER BY `Total` ASC",
+            ss:     "SELECT [OrderId], [Total] FROM [orders] ORDER BY [Total] ASC");
 
         // Seed: 3 orders — should be sorted by Total ascending
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
         Assert.That(results[0].Total, Is.LessThanOrEqualTo(results[1].Total));
         Assert.That(results[1].Total, Is.LessThanOrEqualTo(results[2].Total));
@@ -749,16 +789,36 @@ internal class CrossDialectCompositionTests
     public async Task ConditionalWhere_OnEntityProjection_ResolvesCorrectType()
     {
         await using var t = await QueryTestHarness.CreateAsync();
-        var (Lite, _, _, _) = t;
+        var (Lite, Pg, My, Ss) = t;
 
         // Entity projection (Select identity) with reassignment — should already work
         // but this ensures the resolution doesn't regress entity-typed chains.
-        var query = Lite.Users().Select(u => u);
-        query = query.Where(u => u.IsActive);
+        var ltQ = Lite.Users().Select(u => u);
+        ltQ = ltQ.Where(u => u.IsActive);
+        var lt = ltQ.Prepare();
 
-        var results = await query.ExecuteFetchAllAsync();
+        var pgQ = Pg.Users().Select(u => u);
+        pgQ = pgQ.Where(u => u.IsActive);
+        var pg = pgQ.Prepare();
+
+        var myQ = My.Users().Select(u => u);
+        myQ = myQ.Where(u => u.IsActive);
+        var my = myQ.Prepare();
+
+        var ssQ = Ss.Users().Select(u => u);
+        ssQ = ssQ.Where(u => u.IsActive);
+        var ss = ssQ.Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"IsActive\" = 1",
+            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"IsActive\" = TRUE",
+            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE `IsActive` = 1",
+            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE [IsActive] = 1");
 
         // Seed: 2 active users, 1 inactive
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
     }
 
@@ -766,15 +826,35 @@ internal class CrossDialectCompositionTests
     public async Task ConditionalWhere_OnSingleColumnProjection_ResolvesCorrectType()
     {
         await using var t = await QueryTestHarness.CreateAsync();
-        var (Lite, _, _, _) = t;
+        var (Lite, Pg, My, Ss) = t;
 
         // Single column projection with reassignment
-        var query = Lite.Orders().Select(o => o.Total);
-        query = query.Where(o => o.Total > 100m);
+        var ltQ = Lite.Orders().Select(o => o.Total);
+        ltQ = ltQ.Where(o => o.Total > 100m);
+        var lt = ltQ.Prepare();
 
-        var results = await query.ExecuteFetchAllAsync();
+        var pgQ = Pg.Orders().Select(o => o.Total);
+        pgQ = pgQ.Where(o => o.Total > 100m);
+        var pg = pgQ.Prepare();
+
+        var myQ = My.Orders().Select(o => o.Total);
+        myQ = myQ.Where(o => o.Total > 100m);
+        var my = myQ.Prepare();
+
+        var ssQ = Ss.Orders().Select(o => o.Total);
+        ssQ = ssQ.Where(o => o.Total > 100m);
+        var ss = ssQ.Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"Total\" FROM \"orders\" WHERE \"Total\" > 100",
+            pg:     "SELECT \"Total\" FROM \"orders\" WHERE \"Total\" > 100",
+            mysql:  "SELECT `Total` FROM `orders` WHERE `Total` > 100",
+            ss:     "SELECT [Total] FROM [orders] WHERE [Total] > 100");
 
         // Seed: Order1(250), Order2(75.50), Order3(150) — 2 > 100
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
     }
 
@@ -782,16 +862,39 @@ internal class CrossDialectCompositionTests
     public async Task ConditionalWhere_OnTupleProjection_FieldInfoCachingWorks()
     {
         await using var t = await QueryTestHarness.CreateAsync();
-        var (Lite, _, _, _) = t;
+        var (Lite, Pg, My, Ss) = t;
 
         var priority = OrderPriority.High;
 
         // Execute the same query pattern twice to verify FieldInfo caching
         // (the static F0 field should be populated on first call and reused)
-        var query1 = Lite.Orders().Select(o => (o.OrderId, o.Total, o.Priority));
-        query1 = query1.Where(o => o.Priority == priority);
-        var results1 = await query1.ExecuteFetchAllAsync();
+        var ltQ1 = Lite.Orders().Select(o => (o.OrderId, o.Total, o.Priority));
+        ltQ1 = ltQ1.Where(o => o.Priority == priority);
+        var lt = ltQ1.Prepare();
 
+        var pgQ1 = Pg.Orders().Select(o => (o.OrderId, o.Total, o.Priority));
+        pgQ1 = pgQ1.Where(o => o.Priority == priority);
+        var pg = pgQ1.Prepare();
+
+        var myQ1 = My.Orders().Select(o => (o.OrderId, o.Total, o.Priority));
+        myQ1 = myQ1.Where(o => o.Priority == priority);
+        var my = myQ1.Prepare();
+
+        var ssQ1 = Ss.Orders().Select(o => (o.OrderId, o.Total, o.Priority));
+        ssQ1 = ssQ1.Where(o => o.Priority == priority);
+        var ss = ssQ1.Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"OrderId\", \"Total\", \"Priority\" FROM \"orders\" WHERE \"Priority\" = @p0",
+            pg:     "SELECT \"OrderId\", \"Total\", \"Priority\" FROM \"orders\" WHERE \"Priority\" = $1",
+            mysql:  "SELECT `OrderId`, `Total`, `Priority` FROM `orders` WHERE `Priority` = ?",
+            ss:     "SELECT [OrderId], [Total], [Priority] FROM [orders] WHERE [Priority] = @p0");
+
+        var results1 = await lt.ExecuteFetchAllAsync();
+
+        // Second execution (Lite-only is fine — caching is runtime behavior)
         var query2 = Lite.Orders().Select(o => (o.OrderId, o.Total, o.Priority));
         query2 = query2.Where(o => o.Priority == priority);
         var results2 = await query2.ExecuteFetchAllAsync();

--- a/src/Quarry.Tests/SqlOutput/CrossDialectDeleteTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectDeleteTests.cs
@@ -17,19 +17,20 @@ internal class CrossDialectDeleteTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Delete().Where(u => u.UserId == 1).Prepare();
+        var lt = Lite.Users().Delete().Where(u => u.UserId == 1).Prepare();
+        var pg = Pg.Users().Delete().Where(u => u.UserId == 1).Prepare();
+        var my = My.Users().Delete().Where(u => u.UserId == 1).Prepare();
+        var ss = Ss.Users().Delete().Where(u => u.UserId == 1).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Delete().Where(u => u.UserId == 1).ToDiagnostics(),
-            My.Users().Delete().Where(u => u.UserId == 1).ToDiagnostics(),
-            Ss.Users().Delete().Where(u => u.UserId == 1).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "DELETE FROM \"users\" WHERE \"UserId\" = 1",
             pg:     "DELETE FROM \"users\" WHERE \"UserId\" = 1",
             mysql:  "DELETE FROM `users` WHERE `UserId` = 1",
             ss:     "DELETE FROM [users] WHERE [UserId] = 1");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(1));
     }
 
@@ -39,19 +40,20 @@ internal class CrossDialectDeleteTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Delete().Where(u => u.UserId > 100).Prepare();
+        var lt = Lite.Users().Delete().Where(u => u.UserId > 100).Prepare();
+        var pg = Pg.Users().Delete().Where(u => u.UserId > 100).Prepare();
+        var my = My.Users().Delete().Where(u => u.UserId > 100).Prepare();
+        var ss = Ss.Users().Delete().Where(u => u.UserId > 100).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Delete().Where(u => u.UserId > 100).ToDiagnostics(),
-            My.Users().Delete().Where(u => u.UserId > 100).ToDiagnostics(),
-            Ss.Users().Delete().Where(u => u.UserId > 100).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "DELETE FROM \"users\" WHERE \"UserId\" > 100",
             pg:     "DELETE FROM \"users\" WHERE \"UserId\" > 100",
             mysql:  "DELETE FROM `users` WHERE `UserId` > 100",
             ss:     "DELETE FROM [users] WHERE [UserId] > 100");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(0));
     }
 
@@ -65,19 +67,20 @@ internal class CrossDialectDeleteTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Delete().Where(u => u.IsActive).Prepare();
+        var lt = Lite.Users().Delete().Where(u => u.IsActive).Prepare();
+        var pg = Pg.Users().Delete().Where(u => u.IsActive).Prepare();
+        var my = My.Users().Delete().Where(u => u.IsActive).Prepare();
+        var ss = Ss.Users().Delete().Where(u => u.IsActive).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Delete().Where(u => u.IsActive).ToDiagnostics(),
-            My.Users().Delete().Where(u => u.IsActive).ToDiagnostics(),
-            Ss.Users().Delete().Where(u => u.IsActive).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "DELETE FROM \"users\" WHERE \"IsActive\" = 1",
             pg:     "DELETE FROM \"users\" WHERE \"IsActive\" = TRUE",
             mysql:  "DELETE FROM `users` WHERE `IsActive` = 1",
             ss:     "DELETE FROM [users] WHERE [IsActive] = 1");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(2)); // Alice and Bob are active
     }
 
@@ -87,19 +90,20 @@ internal class CrossDialectDeleteTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Delete().Where(u => !u.IsActive).Prepare();
+        var lt = Lite.Users().Delete().Where(u => !u.IsActive).Prepare();
+        var pg = Pg.Users().Delete().Where(u => !u.IsActive).Prepare();
+        var my = My.Users().Delete().Where(u => !u.IsActive).Prepare();
+        var ss = Ss.Users().Delete().Where(u => !u.IsActive).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Delete().Where(u => !u.IsActive).ToDiagnostics(),
-            My.Users().Delete().Where(u => !u.IsActive).ToDiagnostics(),
-            Ss.Users().Delete().Where(u => !u.IsActive).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "DELETE FROM \"users\" WHERE NOT (\"IsActive\")",
             pg:     "DELETE FROM \"users\" WHERE NOT (\"IsActive\")",
             mysql:  "DELETE FROM `users` WHERE NOT (`IsActive`)",
             ss:     "DELETE FROM [users] WHERE NOT ([IsActive])");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(1)); // Only Charlie is inactive
     }
 
@@ -113,19 +117,20 @@ internal class CrossDialectDeleteTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Delete().Where(u => u.UserId == 1).Where(u => u.IsActive).Prepare();
+        var lt = Lite.Users().Delete().Where(u => u.UserId == 1).Where(u => u.IsActive).Prepare();
+        var pg = Pg.Users().Delete().Where(u => u.UserId == 1).Where(u => u.IsActive).Prepare();
+        var my = My.Users().Delete().Where(u => u.UserId == 1).Where(u => u.IsActive).Prepare();
+        var ss = Ss.Users().Delete().Where(u => u.UserId == 1).Where(u => u.IsActive).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Delete().Where(u => u.UserId == 1).Where(u => u.IsActive).ToDiagnostics(),
-            My.Users().Delete().Where(u => u.UserId == 1).Where(u => u.IsActive).ToDiagnostics(),
-            Ss.Users().Delete().Where(u => u.UserId == 1).Where(u => u.IsActive).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "DELETE FROM \"users\" WHERE (\"UserId\" = 1) AND (\"IsActive\" = 1)",
             pg:     "DELETE FROM \"users\" WHERE (\"UserId\" = 1) AND (\"IsActive\" = TRUE)",
             mysql:  "DELETE FROM `users` WHERE (`UserId` = 1) AND (`IsActive` = 1)",
             ss:     "DELETE FROM [users] WHERE ([UserId] = 1) AND ([IsActive] = 1)");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(1)); // Alice: UserId=1, IsActive=true
     }
 
@@ -139,19 +144,20 @@ internal class CrossDialectDeleteTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Delete().Where(o => o.OrderId == 42).Prepare();
+        var lt = Lite.Orders().Delete().Where(o => o.OrderId == 42).Prepare();
+        var pg = Pg.Orders().Delete().Where(o => o.OrderId == 42).Prepare();
+        var my = My.Orders().Delete().Where(o => o.OrderId == 42).Prepare();
+        var ss = Ss.Orders().Delete().Where(o => o.OrderId == 42).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Orders().Delete().Where(o => o.OrderId == 42).ToDiagnostics(),
-            My.Orders().Delete().Where(o => o.OrderId == 42).ToDiagnostics(),
-            Ss.Orders().Delete().Where(o => o.OrderId == 42).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "DELETE FROM \"orders\" WHERE \"OrderId\" = 42",
             pg:     "DELETE FROM \"orders\" WHERE \"OrderId\" = 42",
             mysql:  "DELETE FROM `orders` WHERE `OrderId` = 42",
             ss:     "DELETE FROM [orders] WHERE [OrderId] = 42");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(0)); // No order with ID 42
     }
 

--- a/src/Quarry.Tests/SqlOutput/CrossDialectEnumTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectEnumTests.cs
@@ -9,6 +9,8 @@ namespace Quarry.Tests.SqlOutput;
 [TestFixture]
 internal class CrossDialectEnumTests
 {
+    #region Enum in WHERE
+
     [Test]
     public async Task Where_EnumCapturedVariable()
     {
@@ -17,13 +19,13 @@ internal class CrossDialectEnumTests
 
         var priority = OrderPriority.Urgent;
 
-        var lite = Lite.Orders().Where(o => o.Priority == priority).Select(o => (o.OrderId, o.Total)).Prepare();
-        var pg   = Pg.Orders().Where(o => o.Priority == priority).Select(o => (o.OrderId, o.Total)).Prepare();
-        var my   = My.Orders().Where(o => o.Priority == priority).Select(o => (o.OrderId, o.Total)).Prepare();
-        var ss   = Ss.Orders().Where(o => o.Priority == priority).Select(o => (o.OrderId, o.Total)).Prepare();
+        var lt = Lite.Orders().Where(o => o.Priority == priority).Select(o => (o.OrderId, o.Total)).Prepare();
+        var pg = Pg.Orders().Where(o => o.Priority == priority).Select(o => (o.OrderId, o.Total)).Prepare();
+        var my = My.Orders().Where(o => o.Priority == priority).Select(o => (o.OrderId, o.Total)).Prepare();
+        var ss = Ss.Orders().Where(o => o.Priority == priority).Select(o => (o.OrderId, o.Total)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"OrderId\", \"Total\" FROM \"orders\" WHERE \"Priority\" = @p0",
             pg:     "SELECT \"OrderId\", \"Total\" FROM \"orders\" WHERE \"Priority\" = $1",
@@ -31,7 +33,7 @@ internal class CrossDialectEnumTests
             ss:     "SELECT [OrderId], [Total] FROM [orders] WHERE [Priority] = @p0");
 
         // Priority: Order1=2(High), Order2=1(Normal), Order3=3(Urgent) — only Order3 matches Urgent(3)
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0], Is.EqualTo((3, 150.00m)));
     }
@@ -42,15 +44,25 @@ internal class CrossDialectEnumTests
         // Regression test: enum parameter must be cast to underlying int for SQLite binding.
         // Without the cast, the enum object is boxed and SQLite rejects or mismatches it.
         await using var t = await QueryTestHarness.CreateAsync();
-        var (Lite, _, _, _) = t;
+        var (Lite, Pg, My, Ss) = t;
 
         var priority = OrderPriority.High;
-        var results = await Lite.Orders()
-            .Where(o => o.Priority == priority)
-            .Select(o => (o.OrderId, o.Total))
-            .ExecuteFetchAllAsync();
+
+        var lt = Lite.Orders().Where(o => o.Priority == priority).Select(o => (o.OrderId, o.Total)).Prepare();
+        var pg = Pg.Orders().Where(o => o.Priority == priority).Select(o => (o.OrderId, o.Total)).Prepare();
+        var my = My.Orders().Where(o => o.Priority == priority).Select(o => (o.OrderId, o.Total)).Prepare();
+        var ss = Ss.Orders().Where(o => o.Priority == priority).Select(o => (o.OrderId, o.Total)).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"OrderId\", \"Total\" FROM \"orders\" WHERE \"Priority\" = @p0",
+            pg:     "SELECT \"OrderId\", \"Total\" FROM \"orders\" WHERE \"Priority\" = $1",
+            mysql:  "SELECT `OrderId`, `Total` FROM `orders` WHERE `Priority` = ?",
+            ss:     "SELECT [OrderId], [Total] FROM [orders] WHERE [Priority] = @p0");
 
         // Seed: Order1(High), Order2(Normal), Order3(Urgent) — only Order1 matches High
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].OrderId, Is.EqualTo(1));
     }
@@ -62,16 +74,26 @@ internal class CrossDialectEnumTests
         // The enum parameter goes through EnrichParametersFromColumns which must set both
         // IsEnum and EnumUnderlyingType so the terminal emits (int) cast, not bare object boxing.
         await using var t = await QueryTestHarness.CreateAsync();
-        var (Lite, _, _, _) = t;
+        var (Lite, Pg, My, Ss) = t;
 
         var priority = OrderPriority.High;
         var minTotal = 100m;
-        var results = await Lite.Orders()
-            .Where(o => o.Priority == priority && o.Total > minTotal)
-            .Select(o => (o.OrderId, o.Total))
-            .ExecuteFetchAllAsync();
+
+        var lt = Lite.Orders().Where(o => o.Priority == priority && o.Total > minTotal).Select(o => (o.OrderId, o.Total)).Prepare();
+        var pg = Pg.Orders().Where(o => o.Priority == priority && o.Total > minTotal).Select(o => (o.OrderId, o.Total)).Prepare();
+        var my = My.Orders().Where(o => o.Priority == priority && o.Total > minTotal).Select(o => (o.OrderId, o.Total)).Prepare();
+        var ss = Ss.Orders().Where(o => o.Priority == priority && o.Total > minTotal).Select(o => (o.OrderId, o.Total)).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"OrderId\", \"Total\" FROM \"orders\" WHERE \"Priority\" = @p0 AND \"Total\" > @p1",
+            pg:     "SELECT \"OrderId\", \"Total\" FROM \"orders\" WHERE \"Priority\" = $1 AND \"Total\" > $2",
+            mysql:  "SELECT `OrderId`, `Total` FROM `orders` WHERE `Priority` = ? AND `Total` > ?",
+            ss:     "SELECT [OrderId], [Total] FROM [orders] WHERE [Priority] = @p0 AND [Total] > @p1");
 
         // Seed: Order1(High,250), Order2(Normal,75.50), Order3(Urgent,150) — only Order1 matches
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].OrderId, Is.EqualTo(1));
     }
@@ -81,18 +103,33 @@ internal class CrossDialectEnumTests
     {
         // Verify the diagnostics report the enum parameter value as an integer, not the enum name.
         await using var t = await QueryTestHarness.CreateAsync();
-        var (Lite, _, _, _) = t;
+        var (Lite, Pg, My, Ss) = t;
 
         var priority = OrderPriority.Urgent;
-        var diag = Lite.Orders()
-            .Where(o => o.Priority == priority)
-            .Select(o => o.OrderId)
-            .ToDiagnostics();
 
+        var lt = Lite.Orders().Where(o => o.Priority == priority).Select(o => o.OrderId).Prepare();
+        var pg = Pg.Orders().Where(o => o.Priority == priority).Select(o => o.OrderId).Prepare();
+        var my = My.Orders().Where(o => o.Priority == priority).Select(o => o.OrderId).Prepare();
+        var ss = Ss.Orders().Where(o => o.Priority == priority).Select(o => o.OrderId).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"OrderId\" FROM \"orders\" WHERE \"Priority\" = @p0",
+            pg:     "SELECT \"OrderId\" FROM \"orders\" WHERE \"Priority\" = $1",
+            mysql:  "SELECT `OrderId` FROM `orders` WHERE `Priority` = ?",
+            ss:     "SELECT [OrderId] FROM [orders] WHERE [Priority] = @p0");
+
+        var diag = lt.ToDiagnostics();
         Assert.That(diag.Parameters, Has.Count.EqualTo(1));
         // The parameter value should be the underlying integer (3), not the enum name
         Assert.That(diag.Parameters[0].Value, Is.EqualTo(3));
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(1));
     }
+
+    #endregion
 
     #region Boolean in INSERT
 
@@ -103,15 +140,21 @@ internal class CrossDialectEnumTests
         var (Lite, Pg, My, Ss) = t;
 
         // Boolean values are parameterized in INSERT, so no literal TRUE/1 difference
+        var lt = Lite.Users().Insert(new User { UserName = "x", IsActive = true, CreatedAt = DateTime.UtcNow }).Prepare();
+        var pg = Pg.Users().Insert(new Pg.User { UserName = "x", IsActive = true, CreatedAt = DateTime.UtcNow }).Prepare();
+        var my = My.Users().Insert(new My.User { UserName = "x", IsActive = true, CreatedAt = DateTime.UtcNow }).Prepare();
+        var ss = Ss.Users().Insert(new Ss.User { UserName = "x", IsActive = true, CreatedAt = DateTime.UtcNow }).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Insert(new User { UserName = "x", IsActive = true }).ToDiagnostics().Sql,
-            Pg.Users().Insert(new Pg.User { UserName = "x", IsActive = true }).ToDiagnostics().Sql,
-            My.Users().Insert(new My.User { UserName = "x", IsActive = true }).ToDiagnostics().Sql,
-            Ss.Users().Insert(new Ss.User { UserName = "x", IsActive = true }).ToDiagnostics().Sql,
-            sqlite: "INSERT INTO \"users\" (\"UserName\", \"IsActive\") VALUES (@p0, @p1) RETURNING \"UserId\"",
-            pg:     "INSERT INTO \"users\" (\"UserName\", \"IsActive\") VALUES ($1, $2) RETURNING \"UserId\"",
-            mysql:  "INSERT INTO `users` (`UserName`, `IsActive`) VALUES (?, ?); SELECT LAST_INSERT_ID()",
-            ss:     "INSERT INTO [users] ([UserName], [IsActive]) VALUES (@p0, @p1) OUTPUT INSERTED.[UserId]");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "INSERT INTO \"users\" (\"UserName\", \"IsActive\", \"CreatedAt\") VALUES (@p0, @p1, @p2) RETURNING \"UserId\"",
+            pg:     "INSERT INTO \"users\" (\"UserName\", \"IsActive\", \"CreatedAt\") VALUES ($1, $2, $3) RETURNING \"UserId\"",
+            mysql:  "INSERT INTO `users` (`UserName`, `IsActive`, `CreatedAt`) VALUES (?, ?, ?); SELECT LAST_INSERT_ID()",
+            ss:     "INSERT INTO [users] ([UserName], [IsActive], [CreatedAt]) VALUES (@p0, @p1, @p2) OUTPUT INSERTED.[UserId]");
+
+        var newId = await lt.ExecuteScalarAsync<int>();
+        Assert.That(newId, Is.GreaterThan(0));
     }
 
     #endregion
@@ -124,15 +167,21 @@ internal class CrossDialectEnumTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Orders().Insert(new Order { UserId = 1, Total = 0m, Status = "x", Priority = OrderPriority.Urgent, OrderDate = default }).Prepare();
+        var pg = Pg.Orders().Insert(new Pg.Order { UserId = 1, Total = 0m, Status = "x", Priority = OrderPriority.Urgent, OrderDate = default }).Prepare();
+        var my = My.Orders().Insert(new My.Order { UserId = 1, Total = 0m, Status = "x", Priority = OrderPriority.Urgent, OrderDate = default }).Prepare();
+        var ss = Ss.Orders().Insert(new Ss.Order { UserId = 1, Total = 0m, Status = "x", Priority = OrderPriority.Urgent, OrderDate = default }).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Orders().Insert(new Order { UserId = 1, Total = 0m, Status = "x", Priority = OrderPriority.Urgent, OrderDate = default }).ToDiagnostics().Sql,
-            Pg.Orders().Insert(new Pg.Order { UserId = 1, Total = 0m, Status = "x", Priority = OrderPriority.Urgent, OrderDate = default }).ToDiagnostics().Sql,
-            My.Orders().Insert(new My.Order { UserId = 1, Total = 0m, Status = "x", Priority = OrderPriority.Urgent, OrderDate = default }).ToDiagnostics().Sql,
-            Ss.Orders().Insert(new Ss.Order { UserId = 1, Total = 0m, Status = "x", Priority = OrderPriority.Urgent, OrderDate = default }).ToDiagnostics().Sql,
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "INSERT INTO \"orders\" (\"UserId\", \"Total\", \"Status\", \"Priority\", \"OrderDate\") VALUES (@p0, @p1, @p2, @p3, @p4) RETURNING \"OrderId\"",
             pg:     "INSERT INTO \"orders\" (\"UserId\", \"Total\", \"Status\", \"Priority\", \"OrderDate\") VALUES ($1, $2, $3, $4, $5) RETURNING \"OrderId\"",
             mysql:  "INSERT INTO `orders` (`UserId`, `Total`, `Status`, `Priority`, `OrderDate`) VALUES (?, ?, ?, ?, ?); SELECT LAST_INSERT_ID()",
             ss:     "INSERT INTO [orders] ([UserId], [Total], [Status], [Priority], [OrderDate]) VALUES (@p0, @p1, @p2, @p3, @p4) OUTPUT INSERTED.[OrderId]");
+
+        var newId = await lt.ExecuteScalarAsync<int>();
+        Assert.That(newId, Is.GreaterThan(0));
     }
 
     #endregion
@@ -145,20 +194,20 @@ internal class CrossDialectEnumTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Update().Set(o => o.Priority = OrderPriority.High).Where(o => o.OrderId == 1).Prepare();
-        var pg   = Pg.Orders().Update().Set(o => o.Priority = OrderPriority.High).Where(o => o.OrderId == 1).Prepare();
-        var my   = My.Orders().Update().Set(o => o.Priority = OrderPriority.High).Where(o => o.OrderId == 1).Prepare();
-        var ss   = Ss.Orders().Update().Set(o => o.Priority = OrderPriority.High).Where(o => o.OrderId == 1).Prepare();
+        var lt = Lite.Orders().Update().Set(o => o.Priority = OrderPriority.High).Where(o => o.OrderId == 1).Prepare();
+        var pg = Pg.Orders().Update().Set(o => o.Priority = OrderPriority.High).Where(o => o.OrderId == 1).Prepare();
+        var my = My.Orders().Update().Set(o => o.Priority = OrderPriority.High).Where(o => o.OrderId == 1).Prepare();
+        var ss = Ss.Orders().Update().Set(o => o.Priority = OrderPriority.High).Where(o => o.OrderId == 1).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "UPDATE \"orders\" SET \"Priority\" = 2 WHERE \"OrderId\" = 1",
             pg:     "UPDATE \"orders\" SET \"Priority\" = 2 WHERE \"OrderId\" = 1",
             mysql:  "UPDATE `orders` SET `Priority` = 2 WHERE `OrderId` = 1",
             ss:     "UPDATE [orders] SET [Priority] = 2 WHERE [OrderId] = 1");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(1));
     }
 

--- a/src/Quarry.Tests/SqlOutput/CrossDialectInsertTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectInsertTests.cs
@@ -17,20 +17,20 @@ internal class CrossDialectInsertTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Insert(new User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
-        var pg   = Pg.Users().Insert(new Pg.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
-        var my   = My.Users().Insert(new My.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
-        var ss   = Ss.Users().Insert(new Ss.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
+        var lt= Lite.Users().Insert(new User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
+        var pg = Pg.Users().Insert(new Pg.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
+        var my = My.Users().Insert(new My.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
+        var ss = Ss.Users().Insert(new Ss.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "INSERT INTO \"users\" (\"UserName\", \"IsActive\", \"CreatedAt\") VALUES (@p0, @p1, @p2) RETURNING \"UserId\"",
             pg:     "INSERT INTO \"users\" (\"UserName\", \"IsActive\", \"CreatedAt\") VALUES ($1, $2, $3) RETURNING \"UserId\"",
             mysql:  "INSERT INTO `users` (`UserName`, `IsActive`, `CreatedAt`) VALUES (?, ?, ?); SELECT LAST_INSERT_ID()",
             ss:     "INSERT INTO [users] ([UserName], [IsActive], [CreatedAt]) VALUES (@p0, @p1, @p2) OUTPUT INSERTED.[UserId]");
 
-        var newId = await lite.ExecuteScalarAsync<int>();
+        var newId = await lt.ExecuteScalarAsync<int>();
         Assert.That(newId, Is.GreaterThan(0));
     }
 
@@ -44,20 +44,20 @@ internal class CrossDialectInsertTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Insert(new Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
-        var pg   = Pg.Orders().Insert(new Pg.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
-        var my   = My.Orders().Insert(new My.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
-        var ss   = Ss.Orders().Insert(new Ss.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
+        var lt= Lite.Orders().Insert(new Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
+        var pg = Pg.Orders().Insert(new Pg.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
+        var my = My.Orders().Insert(new My.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
+        var ss = Ss.Orders().Insert(new Ss.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "INSERT INTO \"orders\" (\"UserId\", \"Total\", \"Status\", \"OrderDate\") VALUES (@p0, @p1, @p2, @p3) RETURNING \"OrderId\"",
             pg:     "INSERT INTO \"orders\" (\"UserId\", \"Total\", \"Status\", \"OrderDate\") VALUES ($1, $2, $3, $4) RETURNING \"OrderId\"",
             mysql:  "INSERT INTO `orders` (`UserId`, `Total`, `Status`, `OrderDate`) VALUES (?, ?, ?, ?); SELECT LAST_INSERT_ID()",
             ss:     "INSERT INTO [orders] ([UserId], [Total], [Status], [OrderDate]) VALUES (@p0, @p1, @p2, @p3) OUTPUT INSERTED.[OrderId]");
 
-        var newId = await lite.ExecuteScalarAsync<int>();
+        var newId = await lt.ExecuteScalarAsync<int>();
         Assert.That(newId, Is.GreaterThan(0));
     }
 
@@ -71,20 +71,20 @@ internal class CrossDialectInsertTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.OrderItems().Insert(new OrderItem { OrderId = 1, ProductName = "x", Quantity = 0, UnitPrice = 0m, LineTotal = 0m }).Prepare();
-        var pg   = Pg.OrderItems().Insert(new Pg.OrderItem { OrderId = 1, ProductName = "x", Quantity = 0, UnitPrice = 0m, LineTotal = 0m }).Prepare();
-        var my   = My.OrderItems().Insert(new My.OrderItem { OrderId = 1, ProductName = "x", Quantity = 0, UnitPrice = 0m, LineTotal = 0m }).Prepare();
-        var ss   = Ss.OrderItems().Insert(new Ss.OrderItem { OrderId = 1, ProductName = "x", Quantity = 0, UnitPrice = 0m, LineTotal = 0m }).Prepare();
+        var lt= Lite.OrderItems().Insert(new OrderItem { OrderId = 1, ProductName = "x", Quantity = 0, UnitPrice = 0m, LineTotal = 0m }).Prepare();
+        var pg = Pg.OrderItems().Insert(new Pg.OrderItem { OrderId = 1, ProductName = "x", Quantity = 0, UnitPrice = 0m, LineTotal = 0m }).Prepare();
+        var my = My.OrderItems().Insert(new My.OrderItem { OrderId = 1, ProductName = "x", Quantity = 0, UnitPrice = 0m, LineTotal = 0m }).Prepare();
+        var ss = Ss.OrderItems().Insert(new Ss.OrderItem { OrderId = 1, ProductName = "x", Quantity = 0, UnitPrice = 0m, LineTotal = 0m }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "INSERT INTO \"order_items\" (\"OrderId\", \"ProductName\", \"Quantity\", \"UnitPrice\", \"LineTotal\") VALUES (@p0, @p1, @p2, @p3, @p4) RETURNING \"OrderItemId\"",
             pg:     "INSERT INTO \"order_items\" (\"OrderId\", \"ProductName\", \"Quantity\", \"UnitPrice\", \"LineTotal\") VALUES ($1, $2, $3, $4, $5) RETURNING \"OrderItemId\"",
             mysql:  "INSERT INTO `order_items` (`OrderId`, `ProductName`, `Quantity`, `UnitPrice`, `LineTotal`) VALUES (?, ?, ?, ?, ?); SELECT LAST_INSERT_ID()",
             ss:     "INSERT INTO [order_items] ([OrderId], [ProductName], [Quantity], [UnitPrice], [LineTotal]) VALUES (@p0, @p1, @p2, @p3, @p4) OUTPUT INSERTED.[OrderItemId]");
 
-        var newId = await lite.ExecuteScalarAsync<int>();
+        var newId = await lt.ExecuteScalarAsync<int>();
         Assert.That(newId, Is.GreaterThan(0));
     }
 
@@ -98,20 +98,20 @@ internal class CrossDialectInsertTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Insert(new User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
-        var pg   = Pg.Users().Insert(new Pg.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
-        var my   = My.Users().Insert(new My.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
-        var ss   = Ss.Users().Insert(new Ss.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
+        var lt= Lite.Users().Insert(new User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
+        var pg = Pg.Users().Insert(new Pg.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
+        var my = My.Users().Insert(new My.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
+        var ss = Ss.Users().Insert(new Ss.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "INSERT INTO \"users\" (\"UserName\", \"IsActive\", \"CreatedAt\") VALUES (@p0, @p1, @p2) RETURNING \"UserId\"",
             pg:     "INSERT INTO \"users\" (\"UserName\", \"IsActive\", \"CreatedAt\") VALUES ($1, $2, $3) RETURNING \"UserId\"",
             mysql:  "INSERT INTO `users` (`UserName`, `IsActive`, `CreatedAt`) VALUES (?, ?, ?); SELECT LAST_INSERT_ID()",
             ss:     "INSERT INTO [users] ([UserName], [IsActive], [CreatedAt]) VALUES (@p0, @p1, @p2) OUTPUT INSERTED.[UserId]");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(1));
     }
 
@@ -121,20 +121,20 @@ internal class CrossDialectInsertTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Insert(new Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
-        var pg   = Pg.Orders().Insert(new Pg.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
-        var my   = My.Orders().Insert(new My.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
-        var ss   = Ss.Orders().Insert(new Ss.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
+        var lt= Lite.Orders().Insert(new Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
+        var pg = Pg.Orders().Insert(new Pg.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
+        var my = My.Orders().Insert(new My.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
+        var ss = Ss.Orders().Insert(new Ss.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "INSERT INTO \"orders\" (\"UserId\", \"Total\", \"Status\", \"OrderDate\") VALUES (@p0, @p1, @p2, @p3) RETURNING \"OrderId\"",
             pg:     "INSERT INTO \"orders\" (\"UserId\", \"Total\", \"Status\", \"OrderDate\") VALUES ($1, $2, $3, $4) RETURNING \"OrderId\"",
             mysql:  "INSERT INTO `orders` (`UserId`, `Total`, `Status`, `OrderDate`) VALUES (?, ?, ?, ?); SELECT LAST_INSERT_ID()",
             ss:     "INSERT INTO [orders] ([UserId], [Total], [Status], [OrderDate]) VALUES (@p0, @p1, @p2, @p3) OUTPUT INSERTED.[OrderId]");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(1));
     }
 
@@ -148,20 +148,20 @@ internal class CrossDialectInsertTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Insert(new User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
-        var pg   = Pg.Users().Insert(new Pg.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
-        var my   = My.Users().Insert(new My.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
-        var ss   = Ss.Users().Insert(new Ss.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
+        var lt= Lite.Users().Insert(new User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
+        var pg = Pg.Users().Insert(new Pg.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
+        var my = My.Users().Insert(new My.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
+        var ss = Ss.Users().Insert(new Ss.User { UserName = "x", IsActive = true, CreatedAt = default }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "INSERT INTO \"users\" (\"UserName\", \"IsActive\", \"CreatedAt\") VALUES (@p0, @p1, @p2) RETURNING \"UserId\"",
             pg:     "INSERT INTO \"users\" (\"UserName\", \"IsActive\", \"CreatedAt\") VALUES ($1, $2, $3) RETURNING \"UserId\"",
             mysql:  "INSERT INTO `users` (`UserName`, `IsActive`, `CreatedAt`) VALUES (?, ?, ?); SELECT LAST_INSERT_ID()",
             ss:     "INSERT INTO [users] ([UserName], [IsActive], [CreatedAt]) VALUES (@p0, @p1, @p2) OUTPUT INSERTED.[UserId]");
 
-        var newId = await lite.ExecuteScalarAsync<int>();
+        var newId = await lt.ExecuteScalarAsync<int>();
         Assert.That(newId, Is.GreaterThan(0));
     }
 
@@ -171,20 +171,20 @@ internal class CrossDialectInsertTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Insert(new Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
-        var pg   = Pg.Orders().Insert(new Pg.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
-        var my   = My.Orders().Insert(new My.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
-        var ss   = Ss.Orders().Insert(new Ss.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
+        var lt= Lite.Orders().Insert(new Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
+        var pg = Pg.Orders().Insert(new Pg.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
+        var my = My.Orders().Insert(new My.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
+        var ss = Ss.Orders().Insert(new Ss.Order { UserId = 1, Total = 0m, Status = "x", OrderDate = default }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "INSERT INTO \"orders\" (\"UserId\", \"Total\", \"Status\", \"OrderDate\") VALUES (@p0, @p1, @p2, @p3) RETURNING \"OrderId\"",
             pg:     "INSERT INTO \"orders\" (\"UserId\", \"Total\", \"Status\", \"OrderDate\") VALUES ($1, $2, $3, $4) RETURNING \"OrderId\"",
             mysql:  "INSERT INTO `orders` (`UserId`, `Total`, `Status`, `OrderDate`) VALUES (?, ?, ?, ?); SELECT LAST_INSERT_ID()",
             ss:     "INSERT INTO [orders] ([UserId], [Total], [Status], [OrderDate]) VALUES (@p0, @p1, @p2, @p3) OUTPUT INSERTED.[OrderId]");
 
-        var newId = await lite.ExecuteScalarAsync<int>();
+        var newId = await lt.ExecuteScalarAsync<int>();
         Assert.That(newId, Is.GreaterThan(0));
     }
 

--- a/src/Quarry.Tests/SqlOutput/CrossDialectJoinTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectJoinTests.cs
@@ -17,20 +17,20 @@ internal class CrossDialectJoinTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var pg   = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var my   = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var ss   = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var pg = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var my = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var ss = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
             mysql:  "SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` INNER JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId`",
             ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId]");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
         Assert.That(results[0], Is.EqualTo(("Alice", 250.00m)));
         Assert.That(results[1], Is.EqualTo(("Alice", 75.50m)));
@@ -47,20 +47,20 @@ internal class CrossDialectJoinTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var pg   = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var my   = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var ss   = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var pg = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var my = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var ss = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t0\".\"IsActive\" = 1",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t0\".\"IsActive\" = TRUE",
             mysql:  "SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` INNER JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId` WHERE `t0`.`IsActive` = 1",
             ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId] WHERE [t0].[IsActive] = 1");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
         Assert.That(results[0], Is.EqualTo(("Alice", 250.00m)));
         Assert.That(results[1], Is.EqualTo(("Alice", 75.50m)));
@@ -73,20 +73,20 @@ internal class CrossDialectJoinTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 100).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var pg   = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 100).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var my   = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 100).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var ss   = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 100).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 100).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var pg = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 100).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var my = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 100).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var ss = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => o.Total > 100).Select((u, o) => (u.UserName, o.Total)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t1\".\"Total\" > 100",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t1\".\"Total\" > 100",
             mysql:  "SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` INNER JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId` WHERE `t1`.`Total` > 100",
             ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId] WHERE [t1].[Total] > 100");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo(("Alice", 250.00m)));
         Assert.That(results[1], Is.EqualTo(("Bob", 150.00m)));
@@ -102,20 +102,20 @@ internal class CrossDialectJoinTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var pg   = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var my   = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var ss   = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var pg = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var my = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var ss = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
             mysql:  "SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` INNER JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId`",
             ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId]");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
     }
 
@@ -129,20 +129,20 @@ internal class CrossDialectJoinTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (Name: u.UserName, Amount: o.Total)).Prepare();
-        var pg   = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (Name: u.UserName, Amount: o.Total)).Prepare();
-        var my   = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (Name: u.UserName, Amount: o.Total)).Prepare();
-        var ss   = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (Name: u.UserName, Amount: o.Total)).Prepare();
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (Name: u.UserName, Amount: o.Total)).Prepare();
+        var pg = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (Name: u.UserName, Amount: o.Total)).Prepare();
+        var my = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (Name: u.UserName, Amount: o.Total)).Prepare();
+        var ss = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (Name: u.UserName, Amount: o.Total)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
             mysql:  "SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` INNER JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId`",
             ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId]");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
         // Verify named element access works across join boundaries
         Assert.That(results[0].Name, Is.EqualTo("Alice"));
@@ -159,20 +159,20 @@ internal class CrossDialectJoinTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Join<OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (User: u.UserName, Amount: o.Total, Product: oi.ProductName)).Prepare();
-        var pg   = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Join<Pg.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (User: u.UserName, Amount: o.Total, Product: oi.ProductName)).Prepare();
-        var my   = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Join<My.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (User: u.UserName, Amount: o.Total, Product: oi.ProductName)).Prepare();
-        var ss   = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Join<Ss.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (User: u.UserName, Amount: o.Total, Product: oi.ProductName)).Prepare();
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Join<OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (User: u.UserName, Amount: o.Total, Product: oi.ProductName)).Prepare();
+        var pg = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Join<Pg.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (User: u.UserName, Amount: o.Total, Product: oi.ProductName)).Prepare();
+        var my = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Join<My.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (User: u.UserName, Amount: o.Total, Product: oi.ProductName)).Prepare();
+        var ss = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Join<Ss.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (User: u.UserName, Amount: o.Total, Product: oi.ProductName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\", \"t2\".\"ProductName\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" INNER JOIN \"order_items\" AS \"t2\" ON \"t1\".\"OrderId\" = \"t2\".\"OrderId\"",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\", \"t2\".\"ProductName\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" INNER JOIN \"order_items\" AS \"t2\" ON \"t1\".\"OrderId\" = \"t2\".\"OrderId\"",
             mysql:  "SELECT `t0`.`UserName`, `t1`.`Total`, `t2`.`ProductName` FROM `users` AS `t0` INNER JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId` INNER JOIN `order_items` AS `t2` ON `t1`.`OrderId` = `t2`.`OrderId`",
             ss:     "SELECT [t0].[UserName], [t1].[Total], [t2].[ProductName] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId] INNER JOIN [order_items] AS [t2] ON [t1].[OrderId] = [t2].[OrderId]");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
         Assert.That(results[0].User, Is.EqualTo("Alice"));
         Assert.That(results[0].Amount, Is.EqualTo(250.00m));
@@ -189,13 +189,13 @@ internal class CrossDialectJoinTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().LeftJoin<Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => u.UserName).Prepare();
-        var pg   = Pg.Users().LeftJoin<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => u.UserName).Prepare();
-        var my   = My.Users().LeftJoin<My.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => u.UserName).Prepare();
-        var ss   = Ss.Users().LeftJoin<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => u.UserName).Prepare();
+        var lt = Lite.Users().LeftJoin<Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => u.UserName).Prepare();
+        var pg = Pg.Users().LeftJoin<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => u.UserName).Prepare();
+        var my = My.Users().LeftJoin<My.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => u.UserName).Prepare();
+        var ss = Ss.Users().LeftJoin<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => u.UserName).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\" FROM \"users\" AS \"t0\" LEFT JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
             pg:     "SELECT \"t0\".\"UserName\" FROM \"users\" AS \"t0\" LEFT JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
@@ -203,7 +203,7 @@ internal class CrossDialectJoinTests
             ss:     "SELECT [t0].[UserName] FROM [users] AS [t0] LEFT JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId]");
 
         // Alice has 2 orders, Bob has 1 order, Charlie has 0 orders (NULL row) — 4 rows
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(4));
         Assert.That(results.Count(r => r == "Alice"), Is.EqualTo(2));
         Assert.That(results.Count(r => r == "Charlie"), Is.EqualTo(1));
@@ -215,13 +215,13 @@ internal class CrossDialectJoinTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().LeftJoin<Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var pg   = Pg.Users().LeftJoin<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var my   = My.Users().LeftJoin<My.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var ss   = Ss.Users().LeftJoin<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var lt = Lite.Users().LeftJoin<Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var pg = Pg.Users().LeftJoin<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var my = My.Users().LeftJoin<My.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var ss = Ss.Users().LeftJoin<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Where((u, o) => u.IsActive).Select((u, o) => (u.UserName, o.Total)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" LEFT JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t0\".\"IsActive\" = 1",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" LEFT JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t0\".\"IsActive\" = TRUE",
@@ -229,7 +229,7 @@ internal class CrossDialectJoinTests
             ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] LEFT JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId] WHERE [t0].[IsActive] = 1");
 
         // Alice (active, 2 orders) + Bob (active, 1 order) = 3 rows; Charlie (inactive) excluded
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
         Assert.That(results.Any(r => r.Item1 == "Charlie"), Is.False);
     }
@@ -245,13 +245,13 @@ internal class CrossDialectJoinTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().RightJoin<Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var pg   = Pg.Users().RightJoin<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var my   = My.Users().RightJoin<My.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
-        var ss   = Ss.Users().RightJoin<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var lt = Lite.Users().RightJoin<Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var pg = Pg.Users().RightJoin<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var my = My.Users().RightJoin<My.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var ss = Ss.Users().RightJoin<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" RIGHT JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" RIGHT JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
@@ -269,13 +269,13 @@ internal class CrossDialectJoinTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Join<OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (u.UserName, o.Total, oi.ProductName)).Prepare();
-        var pg   = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Join<Pg.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (u.UserName, o.Total, oi.ProductName)).Prepare();
-        var my   = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Join<My.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (u.UserName, o.Total, oi.ProductName)).Prepare();
-        var ss   = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Join<Ss.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (u.UserName, o.Total, oi.ProductName)).Prepare();
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Join<OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (u.UserName, o.Total, oi.ProductName)).Prepare();
+        var pg = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Join<Pg.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (u.UserName, o.Total, oi.ProductName)).Prepare();
+        var my = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Join<My.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (u.UserName, o.Total, oi.ProductName)).Prepare();
+        var ss = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Join<Ss.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Select((u, o, oi) => (u.UserName, o.Total, oi.ProductName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\", \"t2\".\"ProductName\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" INNER JOIN \"order_items\" AS \"t2\" ON \"t1\".\"OrderId\" = \"t2\".\"OrderId\"",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\", \"t2\".\"ProductName\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" INNER JOIN \"order_items\" AS \"t2\" ON \"t1\".\"OrderId\" = \"t2\".\"OrderId\"",
@@ -283,7 +283,7 @@ internal class CrossDialectJoinTests
             ss:     "SELECT [t0].[UserName], [t1].[Total], [t2].[ProductName] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId] INNER JOIN [order_items] AS [t2] ON [t1].[OrderId] = [t2].[OrderId]");
 
         // Seed: 3 order items, each in a different order
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
     }
 
@@ -297,13 +297,13 @@ internal class CrossDialectJoinTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Join<OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Join<Account>((u, o, oi, a) => u.UserId == a.UserId.Id).Select((u, o, oi, a) => (u.UserName, o.Total, oi.ProductName, a.AccountName)).Prepare();
-        var pg   = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Join<Pg.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Join<Pg.Account>((u, o, oi, a) => u.UserId == a.UserId.Id).Select((u, o, oi, a) => (u.UserName, o.Total, oi.ProductName, a.AccountName)).Prepare();
-        var my   = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Join<My.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Join<My.Account>((u, o, oi, a) => u.UserId == a.UserId.Id).Select((u, o, oi, a) => (u.UserName, o.Total, oi.ProductName, a.AccountName)).Prepare();
-        var ss   = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Join<Ss.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Join<Ss.Account>((u, o, oi, a) => u.UserId == a.UserId.Id).Select((u, o, oi, a) => (u.UserName, o.Total, oi.ProductName, a.AccountName)).Prepare();
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Join<OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Join<Account>((u, o, oi, a) => u.UserId == a.UserId.Id).Select((u, o, oi, a) => (u.UserName, o.Total, oi.ProductName, a.AccountName)).Prepare();
+        var pg = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Join<Pg.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Join<Pg.Account>((u, o, oi, a) => u.UserId == a.UserId.Id).Select((u, o, oi, a) => (u.UserName, o.Total, oi.ProductName, a.AccountName)).Prepare();
+        var my = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Join<My.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Join<My.Account>((u, o, oi, a) => u.UserId == a.UserId.Id).Select((u, o, oi, a) => (u.UserName, o.Total, oi.ProductName, a.AccountName)).Prepare();
+        var ss = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Join<Ss.OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id).Join<Ss.Account>((u, o, oi, a) => u.UserId == a.UserId.Id).Select((u, o, oi, a) => (u.UserName, o.Total, oi.ProductName, a.AccountName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\", \"t2\".\"ProductName\", \"t3\".\"AccountName\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" INNER JOIN \"order_items\" AS \"t2\" ON \"t1\".\"OrderId\" = \"t2\".\"OrderId\" INNER JOIN \"accounts\" AS \"t3\" ON \"t0\".\"UserId\" = \"t3\".\"UserId\"",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\", \"t2\".\"ProductName\", \"t3\".\"AccountName\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" INNER JOIN \"order_items\" AS \"t2\" ON \"t1\".\"OrderId\" = \"t2\".\"OrderId\" INNER JOIN \"accounts\" AS \"t3\" ON \"t0\".\"UserId\" = \"t3\".\"UserId\"",
@@ -314,7 +314,7 @@ internal class CrossDialectJoinTests
         // Alice: order1(Widget) × Savings,Checking = 2 rows, order2(Gadget) × Savings,Checking = 2 rows — 4
         // Bob: order3(Widget) × Savings = 1 row — 1
         // Total = 5
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(5));
     }
 
@@ -331,7 +331,7 @@ internal class CrossDialectJoinTests
         var (Lite, Pg, My, Ss) = t;
 
         var minTotal = 100m;
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id)
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id)
             .Where((u, o) => o.Total > minTotal && u.IsActive)
             .Select((u, o) => (u.UserName, o.Total)).Prepare();
         var pg = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id)
@@ -345,14 +345,14 @@ internal class CrossDialectJoinTests
             .Select((u, o) => (u.UserName, o.Total)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t1\".\"Total\" > @p0 AND \"t0\".\"IsActive\" = 1",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t1\".\"Total\" > $1 AND \"t0\".\"IsActive\" = TRUE",
             mysql:  "SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` INNER JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId` WHERE `t1`.`Total` > ? AND `t0`.`IsActive` = 1",
             ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId] WHERE [t1].[Total] > @p0 AND [t0].[IsActive] = 1");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo(("Alice", 250.00m)));
         Assert.That(results[1], Is.EqualTo(("Bob", 150.00m)));
@@ -367,7 +367,7 @@ internal class CrossDialectJoinTests
 
         var userName = "Alice";
         var minTotal = 50m;
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id)
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id)
             .Where((u, o) => u.UserName == userName && u.IsActive && o.Total > minTotal)
             .Select((u, o) => (u.UserName, o.Total)).Prepare();
         var pg = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id)
@@ -381,14 +381,14 @@ internal class CrossDialectJoinTests
             .Select((u, o) => (u.UserName, o.Total)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t0\".\"UserName\" = @p0 AND \"t0\".\"IsActive\" = 1 AND \"t1\".\"Total\" > @p1",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" WHERE \"t0\".\"UserName\" = $1 AND \"t0\".\"IsActive\" = TRUE AND \"t1\".\"Total\" > $2",
             mysql:  "SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` INNER JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId` WHERE `t0`.`UserName` = ? AND `t0`.`IsActive` = 1 AND `t1`.`Total` > ?",
             ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId] WHERE [t0].[UserName] = @p0 AND [t0].[IsActive] = 1 AND [t1].[Total] > @p1");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo(("Alice", 250.00m)));
         Assert.That(results[1], Is.EqualTo(("Alice", 75.50m)));

--- a/src/Quarry.Tests/SqlOutput/CrossDialectMiscTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectMiscTests.cs
@@ -17,15 +17,21 @@ internal class CrossDialectMiscTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => u.UserName.ToLower() == "john").Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.ToLower() == "john").Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserName.ToLower() == "john").Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.ToLower() == "john").Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.UserName.ToLower() == "john").ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.ToLower() == "john").ToDiagnostics(),
-            My.Users().Where(u => u.UserName.ToLower() == "john").ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.ToLower() == "john").ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE LOWER(\"UserName\") = @p0",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE LOWER(\"UserName\") = $1",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE LOWER(`UserName`) = ?",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE LOWER([UserName]) = @p0");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE LOWER(\"UserName\") = @p0",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE LOWER(\"UserName\") = $1",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE LOWER(`UserName`) = ?",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE LOWER([UserName]) = @p0");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(0)); // "john" matches no seeded users
     }
 
     #endregion
@@ -38,15 +44,21 @@ internal class CrossDialectMiscTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => u.UserName.ToUpper() == "JOHN").Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.ToUpper() == "JOHN").Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserName.ToUpper() == "JOHN").Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.ToUpper() == "JOHN").Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.UserName.ToUpper() == "JOHN").ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.ToUpper() == "JOHN").ToDiagnostics(),
-            My.Users().Where(u => u.UserName.ToUpper() == "JOHN").ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.ToUpper() == "JOHN").ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE UPPER(\"UserName\") = @p0",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE UPPER(\"UserName\") = $1",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE UPPER(`UserName`) = ?",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE UPPER([UserName]) = @p0");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE UPPER(\"UserName\") = @p0",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE UPPER(\"UserName\") = $1",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE UPPER(`UserName`) = ?",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE UPPER([UserName]) = @p0");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(0)); // "JOHN" matches no seeded users
     }
 
     #endregion
@@ -59,15 +71,21 @@ internal class CrossDialectMiscTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => u.UserName.Trim() == "john").Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.Trim() == "john").Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserName.Trim() == "john").Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.Trim() == "john").Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.UserName.Trim() == "john").ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.Trim() == "john").ToDiagnostics(),
-            My.Users().Where(u => u.UserName.Trim() == "john").ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.Trim() == "john").ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE TRIM(\"UserName\") = @p0",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE TRIM(\"UserName\") = $1",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE TRIM(`UserName`) = ?",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE TRIM([UserName]) = @p0");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE TRIM(\"UserName\") = @p0",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE TRIM(\"UserName\") = $1",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE TRIM(`UserName`) = ?",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE TRIM([UserName]) = @p0");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(0)); // "john" matches no seeded users
     }
 
     #endregion
@@ -80,15 +98,18 @@ internal class CrossDialectMiscTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => Sql.Raw<bool>("custom_func({0})", u.UserId)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => Sql.Raw<bool>("custom_func({0})", u.UserId)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => Sql.Raw<bool>("custom_func({0})", u.UserId)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => Sql.Raw<bool>("custom_func({0})", u.UserId)).Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => Sql.Raw<bool>("custom_func({0})", u.UserId)).ToDiagnostics(),
-            Pg.Users().Where(u => Sql.Raw<bool>("custom_func({0})", u.UserId)).ToDiagnostics(),
-            My.Users().Where(u => Sql.Raw<bool>("custom_func({0})", u.UserId)).ToDiagnostics(),
-            Ss.Users().Where(u => Sql.Raw<bool>("custom_func({0})", u.UserId)).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE custom_func(\"UserId\")",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE custom_func(\"UserId\")",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE custom_func(`UserId`)",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE custom_func([UserId])");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE custom_func(\"UserId\")",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE custom_func(\"UserId\")",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE custom_func(`UserId`)",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE custom_func([UserId])");
     }
 
     [Test]
@@ -97,15 +118,18 @@ internal class CrossDialectMiscTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => Sql.Raw<bool>("check_cols({0}, {1})", u.UserId, u.IsActive)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => Sql.Raw<bool>("check_cols({0}, {1})", u.UserId, u.IsActive)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => Sql.Raw<bool>("check_cols({0}, {1})", u.UserId, u.IsActive)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => Sql.Raw<bool>("check_cols({0}, {1})", u.UserId, u.IsActive)).Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => Sql.Raw<bool>("check_cols({0}, {1})", u.UserId, u.IsActive)).ToDiagnostics(),
-            Pg.Users().Where(u => Sql.Raw<bool>("check_cols({0}, {1})", u.UserId, u.IsActive)).ToDiagnostics(),
-            My.Users().Where(u => Sql.Raw<bool>("check_cols({0}, {1})", u.UserId, u.IsActive)).ToDiagnostics(),
-            Ss.Users().Where(u => Sql.Raw<bool>("check_cols({0}, {1})", u.UserId, u.IsActive)).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE check_cols(\"UserId\", \"IsActive\")",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE check_cols(\"UserId\", \"IsActive\")",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE check_cols(`UserId`, `IsActive`)",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE check_cols([UserId], [IsActive])");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE check_cols(\"UserId\", \"IsActive\")",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE check_cols(\"UserId\", \"IsActive\")",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE check_cols(`UserId`, `IsActive`)",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE check_cols([UserId], [IsActive])");
     }
 
     [Test]
@@ -115,15 +139,18 @@ internal class CrossDialectMiscTests
         var (Lite, Pg, My, Ss) = t;
 
         var searchTerm = "john";
+        var lt = Lite.Users().Where(u => Sql.Raw<bool>("CONTAINS({0}, {1})", u.UserName, searchTerm)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => Sql.Raw<bool>("CONTAINS({0}, {1})", u.UserName, searchTerm)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => Sql.Raw<bool>("CONTAINS({0}, {1})", u.UserName, searchTerm)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => Sql.Raw<bool>("CONTAINS({0}, {1})", u.UserName, searchTerm)).Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => Sql.Raw<bool>("CONTAINS({0}, {1})", u.UserName, searchTerm)).ToDiagnostics(),
-            Pg.Users().Where(u => Sql.Raw<bool>("CONTAINS({0}, {1})", u.UserName, searchTerm)).ToDiagnostics(),
-            My.Users().Where(u => Sql.Raw<bool>("CONTAINS({0}, {1})", u.UserName, searchTerm)).ToDiagnostics(),
-            Ss.Users().Where(u => Sql.Raw<bool>("CONTAINS({0}, {1})", u.UserName, searchTerm)).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE CONTAINS(\"UserName\", @p0)",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE CONTAINS(\"UserName\", $1)",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE CONTAINS(`UserName`, ?)",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE CONTAINS([UserName], @p0)");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE CONTAINS(\"UserName\", @p0)",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE CONTAINS(\"UserName\", $1)",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE CONTAINS(`UserName`, ?)",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE CONTAINS([UserName], @p0)");
     }
 
     [Test]
@@ -132,15 +159,18 @@ internal class CrossDialectMiscTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => Sql.Raw<bool>("status_check({0}, {1})", u.UserName, 42)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => Sql.Raw<bool>("status_check({0}, {1})", u.UserName, 42)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => Sql.Raw<bool>("status_check({0}, {1})", u.UserName, 42)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => Sql.Raw<bool>("status_check({0}, {1})", u.UserName, 42)).Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => Sql.Raw<bool>("status_check({0}, {1})", u.UserName, 42)).ToDiagnostics(),
-            Pg.Users().Where(u => Sql.Raw<bool>("status_check({0}, {1})", u.UserName, 42)).ToDiagnostics(),
-            My.Users().Where(u => Sql.Raw<bool>("status_check({0}, {1})", u.UserName, 42)).ToDiagnostics(),
-            Ss.Users().Where(u => Sql.Raw<bool>("status_check({0}, {1})", u.UserName, 42)).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE status_check(\"UserName\", 42)",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE status_check(\"UserName\", 42)",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE status_check(`UserName`, 42)",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE status_check([UserName], 42)");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE status_check(\"UserName\", 42)",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE status_check(\"UserName\", 42)",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE status_check(`UserName`, 42)",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE status_check([UserName], 42)");
     }
 
     #endregion
@@ -157,20 +187,21 @@ internal class CrossDialectMiscTests
 
         // Instance field on the test class — must use UnsafeAccessorKind.Field + func.Target!
         // (not StaticField + null!, which would throw MissingFieldException at runtime)
-        var lite = Lite.Users().Where(u => u.UserId == _instanceUserId).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var lt = Lite.Users().Where(u => u.UserId == _instanceUserId).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var pg = Pg.Users().Where(u => u.UserId == _instanceUserId).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var my = My.Users().Where(u => u.UserId == _instanceUserId).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var ss = Ss.Users().Where(u => u.UserId == _instanceUserId).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.UserId == _instanceUserId).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            My.Users().Where(u => u.UserId == _instanceUserId).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserId == _instanceUserId).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserId\" = @p0",
             pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserId\" = $1",
             mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users` WHERE `UserId` = ?",
             ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users] WHERE [UserId] = @p0");
 
         // Runtime execution — would throw MissingFieldException if StaticField was used
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].UserId, Is.EqualTo(1));
     }

--- a/src/Quarry.Tests/SqlOutput/CrossDialectOrderByTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectOrderByTests.cs
@@ -17,19 +17,20 @@ internal class CrossDialectOrderByTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).Prepare();
+        var lt = Lite.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).Prepare();
+        var pg = Pg.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).Prepare();
+        var my = My.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).Prepare();
+        var ss = Ss.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).ToDiagnostics(),
-            My.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).ToDiagnostics(),
-            Ss.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" ORDER BY \"UserName\" ASC",
             pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" ORDER BY \"UserName\" ASC",
             mysql:  "SELECT `UserId`, `UserName` FROM `users` ORDER BY `UserName` ASC",
             ss:     "SELECT [UserId], [UserName] FROM [users] ORDER BY [UserName] ASC");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((2, "Bob")));
@@ -42,19 +43,20 @@ internal class CrossDialectOrderByTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.CreatedAt, Direction.Descending).Prepare();
+        var lt = Lite.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.CreatedAt, Direction.Descending).Prepare();
+        var pg = Pg.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.CreatedAt, Direction.Descending).Prepare();
+        var my = My.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.CreatedAt, Direction.Descending).Prepare();
+        var ss = Ss.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.CreatedAt, Direction.Descending).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.CreatedAt, Direction.Descending).ToDiagnostics(),
-            My.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.CreatedAt, Direction.Descending).ToDiagnostics(),
-            Ss.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.CreatedAt, Direction.Descending).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" ORDER BY \"CreatedAt\" DESC",
             pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" ORDER BY \"CreatedAt\" DESC",
             mysql:  "SELECT `UserId`, `UserName` FROM `users` ORDER BY `CreatedAt` DESC",
             ss:     "SELECT [UserId], [UserName] FROM [users] ORDER BY [CreatedAt] DESC");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
         // Charlie created 2024-03-10, Bob 2024-02-20, Alice 2024-01-15
         Assert.That(results[0], Is.EqualTo((3, "Charlie")));
@@ -72,19 +74,20 @@ internal class CrossDialectOrderByTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).ThenBy(u => u.CreatedAt).Prepare();
+        var lt = Lite.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).ThenBy(u => u.CreatedAt).Prepare();
+        var pg = Pg.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).ThenBy(u => u.CreatedAt).Prepare();
+        var my = My.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).ThenBy(u => u.CreatedAt).Prepare();
+        var ss = Ss.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).ThenBy(u => u.CreatedAt).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).ThenBy(u => u.CreatedAt).ToDiagnostics(),
-            My.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).ThenBy(u => u.CreatedAt).ToDiagnostics(),
-            Ss.Users().Select(u => (u.UserId, u.UserName)).OrderBy(u => u.UserName).ThenBy(u => u.CreatedAt).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" ORDER BY \"UserName\" ASC, \"CreatedAt\" ASC",
             pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" ORDER BY \"UserName\" ASC, \"CreatedAt\" ASC",
             mysql:  "SELECT `UserId`, `UserName` FROM `users` ORDER BY `UserName` ASC, `CreatedAt` ASC",
             ss:     "SELECT [UserId], [UserName] FROM [users] ORDER BY [UserName] ASC, [CreatedAt] ASC");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((2, "Bob")));
@@ -101,20 +104,21 @@ internal class CrossDialectOrderByTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).OrderBy((u, o) => o.Total).Prepare();
+        var lt = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).OrderBy((u, o) => o.Total).Prepare();
+        var pg = Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).OrderBy((u, o) => o.Total).Prepare();
+        var my = My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).OrderBy((u, o) => o.Total).Prepare();
+        var ss = Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).OrderBy((u, o) => o.Total).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Join<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).OrderBy((u, o) => o.Total).ToDiagnostics(),
-            My.Users().Join<My.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).OrderBy((u, o) => o.Total).ToDiagnostics(),
-            Ss.Users().Join<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).OrderBy((u, o) => o.Total).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" ORDER BY \"t1\".\"Total\" ASC",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" INNER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\" ORDER BY \"t1\".\"Total\" ASC",
             mysql:  "SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` INNER JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId` ORDER BY `t1`.`Total` ASC",
             ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] INNER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId] ORDER BY [t1].[Total] ASC");
 
         // Join uses "Order" view which maps to "orders" table
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
         // Ordered by Total ASC: 75.50, 150.00, 250.00
         Assert.That(results[0], Is.EqualTo(("Alice", 75.50m)));

--- a/src/Quarry.Tests/SqlOutput/CrossDialectSchemaTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectSchemaTests.cs
@@ -48,13 +48,13 @@ internal class CrossDialectSchemaTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Accounts().Select(a => (a.AccountId, a.CreditLimit)).Prepare();
-        var pg   = Pg.Accounts().Select(a => (a.AccountId, a.CreditLimit)).Prepare();
-        var my   = My.Accounts().Select(a => (a.AccountId, a.CreditLimit)).Prepare();
-        var ss   = Ss.Accounts().Select(a => (a.AccountId, a.CreditLimit)).Prepare();
+        var lt= Lite.Accounts().Select(a => (a.AccountId, a.CreditLimit)).Prepare();
+        var pg = Pg.Accounts().Select(a => (a.AccountId, a.CreditLimit)).Prepare();
+        var my = My.Accounts().Select(a => (a.AccountId, a.CreditLimit)).Prepare();
+        var ss = Ss.Accounts().Select(a => (a.AccountId, a.CreditLimit)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"AccountId\", \"credit_limit\" FROM \"accounts\"",
             pg:     "SELECT \"AccountId\", \"credit_limit\" FROM \"accounts\"",
@@ -72,20 +72,20 @@ internal class CrossDialectSchemaTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Select(u => u.UserName).Prepare();
-        var pg   = Pg.Users().Select(u => u.UserName).Prepare();
-        var my   = My.Users().Select(u => u.UserName).Prepare();
-        var ss   = Ss.Users().Select(u => u.UserName).Prepare();
+        var lt= Lite.Users().Select(u => u.UserName).Prepare();
+        var pg = Pg.Users().Select(u => u.UserName).Prepare();
+        var my = My.Users().Select(u => u.UserName).Prepare();
+        var ss = Ss.Users().Select(u => u.UserName).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserName\" FROM \"users\"",
             pg:     "SELECT \"UserName\" FROM \"users\"",
             mysql:  "SELECT `UserName` FROM `users`",
             ss:     "SELECT [UserName] FROM [users]");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
         Assert.That(results[0], Is.EqualTo("Alice"));
     }
@@ -100,13 +100,13 @@ internal class CrossDialectSchemaTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Orders().Where(o => o.UserId.Id == 5).Prepare();
-        var pg   = Pg.Orders().Where(o => o.UserId.Id == 5).Prepare();
-        var my   = My.Orders().Where(o => o.UserId.Id == 5).Prepare();
-        var ss   = Ss.Orders().Where(o => o.UserId.Id == 5).Prepare();
+        var lt= Lite.Orders().Where(o => o.UserId.Id == 5).Prepare();
+        var pg = Pg.Orders().Where(o => o.UserId.Id == 5).Prepare();
+        var my = My.Orders().Where(o => o.UserId.Id == 5).Prepare();
+        var ss = Ss.Orders().Where(o => o.UserId.Id == 5).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"OrderId\", \"UserId\", \"Total\", \"Status\", \"Priority\", \"OrderDate\", \"Notes\" FROM \"orders\" WHERE \"UserId\" = 5",
             pg:     "SELECT \"OrderId\", \"UserId\", \"Total\", \"Status\", \"Priority\", \"OrderDate\", \"Notes\" FROM \"orders\" WHERE \"UserId\" = 5",
@@ -156,20 +156,20 @@ internal class CrossDialectSchemaTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Delete().All().Prepare();
-        var pg   = Pg.Users().Delete().All().Prepare();
-        var my   = My.Users().Delete().All().Prepare();
-        var ss   = Ss.Users().Delete().All().Prepare();
+        var lt= Lite.Users().Delete().All().Prepare();
+        var pg = Pg.Users().Delete().All().Prepare();
+        var my = My.Users().Delete().All().Prepare();
+        var ss = Ss.Users().Delete().All().Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "DELETE FROM \"users\"",
             pg:     "DELETE FROM \"users\"",
             mysql:  "DELETE FROM `users`",
             ss:     "DELETE FROM [users]");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(3)); // All 3 seeded users
     }
 

--- a/src/Quarry.Tests/SqlOutput/CrossDialectSelectTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectSelectTests.cs
@@ -9,25 +9,28 @@ namespace Quarry.Tests.SqlOutput;
 [TestFixture]
 internal class CrossDialectSelectTests
 {
+    #region Tuple Projections
+
     [Test]
     public async Task Select_Tuple_TwoColumns()
     {
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Select(u => (u.UserId, u.UserName)).Prepare();
+        var lt = Lite.Users().Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Select(u => (u.UserId, u.UserName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Select(u => (u.UserId, u.UserName)).ToDiagnostics(),
-            My.Users().Select(u => (u.UserId, u.UserName)).ToDiagnostics(),
-            Ss.Users().Select(u => (u.UserId, u.UserName)).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\"",
             pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\"",
             mysql:  "SELECT `UserId`, `UserName` FROM `users`",
             ss:     "SELECT [UserId], [UserName] FROM [users]");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((2, "Bob")));
@@ -40,24 +43,91 @@ internal class CrossDialectSelectTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Select(u => (u.UserId, u.UserName, u.IsActive)).Prepare();
+        var lt = Lite.Users().Select(u => (u.UserId, u.UserName, u.IsActive)).Prepare();
+        var pg = Pg.Users().Select(u => (u.UserId, u.UserName, u.IsActive)).Prepare();
+        var my = My.Users().Select(u => (u.UserId, u.UserName, u.IsActive)).Prepare();
+        var ss = Ss.Users().Select(u => (u.UserId, u.UserName, u.IsActive)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Select(u => (u.UserId, u.UserName, u.IsActive)).ToDiagnostics(),
-            My.Users().Select(u => (u.UserId, u.UserName, u.IsActive)).ToDiagnostics(),
-            Ss.Users().Select(u => (u.UserId, u.UserName, u.IsActive)).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\"",
             pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\"",
             mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users`",
             ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users]");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
         Assert.That(results[0], Is.EqualTo((1, "Alice", true)));
         Assert.That(results[1], Is.EqualTo((2, "Bob", true)));
         Assert.That(results[2], Is.EqualTo((3, "Charlie", false)));
     }
+
+    #endregion
+
+    #region Named Tuple Projections
+
+    [Test]
+    public async Task Select_NamedTuple_TwoColumns()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var lt = Lite.Users().Select(u => (Id: u.UserId, Name: u.UserName)).Prepare();
+        var pg = Pg.Users().Select(u => (Id: u.UserId, Name: u.UserName)).Prepare();
+        var my = My.Users().Select(u => (Id: u.UserId, Name: u.UserName)).Prepare();
+        var ss = Ss.Users().Select(u => (Id: u.UserId, Name: u.UserName)).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\"",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\"",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users`",
+            ss:     "SELECT [UserId], [UserName] FROM [users]");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(3));
+        // Verify named element access works
+        Assert.That(results[0].Id, Is.EqualTo(1));
+        Assert.That(results[0].Name, Is.EqualTo("Alice"));
+        Assert.That(results[1].Id, Is.EqualTo(2));
+        Assert.That(results[1].Name, Is.EqualTo("Bob"));
+        Assert.That(results[2].Id, Is.EqualTo(3));
+        Assert.That(results[2].Name, Is.EqualTo("Charlie"));
+    }
+
+    [Test]
+    public async Task Select_NamedTuple_ThreeColumns()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var lt = Lite.Users().Select(u => (Id: u.UserId, Name: u.UserName, Active: u.IsActive)).Prepare();
+        var pg = Pg.Users().Select(u => (Id: u.UserId, Name: u.UserName, Active: u.IsActive)).Prepare();
+        var my = My.Users().Select(u => (Id: u.UserId, Name: u.UserName, Active: u.IsActive)).Prepare();
+        var ss = Ss.Users().Select(u => (Id: u.UserId, Name: u.UserName, Active: u.IsActive)).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\"",
+            pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\"",
+            mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users`",
+            ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users]");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(3));
+        Assert.That(results[0].Id, Is.EqualTo(1));
+        Assert.That(results[0].Name, Is.EqualTo("Alice"));
+        Assert.That(results[0].Active, Is.True);
+        Assert.That(results[2].Id, Is.EqualTo(3));
+        Assert.That(results[2].Active, Is.False);
+    }
+
+    #endregion
+
+    #region DTO Projections
 
     [Test]
     public async Task Select_Dto_UserSummary()
@@ -65,20 +135,20 @@ internal class CrossDialectSelectTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var pg = Pg.Users().Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var my = My.Users().Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var ss = Ss.Users().Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Pg.Users().Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            My.Users().Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Ss.Users().Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\"",
             pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\"",
             mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users`",
             ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users]");
 
-        var results = await Lite.Users()
-            .Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive })
-            .ExecuteFetchAllAsync();
-
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
 
         Assert.That(results[0].UserId, Is.EqualTo(1));
@@ -100,20 +170,20 @@ internal class CrossDialectSelectTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Select(u => new UserWithEmailDto { UserId = u.UserId, UserName = u.UserName, Email = u.Email }).Prepare();
+        var pg = Pg.Users().Select(u => new UserWithEmailDto { UserId = u.UserId, UserName = u.UserName, Email = u.Email }).Prepare();
+        var my = My.Users().Select(u => new UserWithEmailDto { UserId = u.UserId, UserName = u.UserName, Email = u.Email }).Prepare();
+        var ss = Ss.Users().Select(u => new UserWithEmailDto { UserId = u.UserId, UserName = u.UserName, Email = u.Email }).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Select(u => new UserWithEmailDto { UserId = u.UserId, UserName = u.UserName, Email = u.Email }).ToDiagnostics(),
-            Pg.Users().Select(u => new UserWithEmailDto { UserId = u.UserId, UserName = u.UserName, Email = u.Email }).ToDiagnostics(),
-            My.Users().Select(u => new UserWithEmailDto { UserId = u.UserId, UserName = u.UserName, Email = u.Email }).ToDiagnostics(),
-            Ss.Users().Select(u => new UserWithEmailDto { UserId = u.UserId, UserName = u.UserName, Email = u.Email }).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"Email\" FROM \"users\"",
             pg:     "SELECT \"UserId\", \"UserName\", \"Email\" FROM \"users\"",
             mysql:  "SELECT `UserId`, `UserName`, `Email` FROM `users`",
             ss:     "SELECT [UserId], [UserName], [Email] FROM [users]");
 
-        var results = await Lite.Users()
-            .Select(u => new UserWithEmailDto { UserId = u.UserId, UserName = u.UserName, Email = u.Email })
-            .ExecuteFetchAllAsync();
-
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
 
         Assert.That(results[0].UserId, Is.EqualTo(1));
@@ -126,47 +196,9 @@ internal class CrossDialectSelectTests
         Assert.That(results[2].Email, Is.EqualTo("charlie@test.com"));
     }
 
-    [Test]
-    public async Task Select_OrdersTable_Tuple()
-    {
-        await using var t = await QueryTestHarness.CreateAsync();
-        var (Lite, Pg, My, Ss) = t;
+    #endregion
 
-        var lite = Lite.Orders().Select(o => (o.OrderId, o.Total)).Prepare();
-
-        QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Orders().Select(o => (o.OrderId, o.Total)).ToDiagnostics(),
-            My.Orders().Select(o => (o.OrderId, o.Total)).ToDiagnostics(),
-            Ss.Orders().Select(o => (o.OrderId, o.Total)).ToDiagnostics(),
-            sqlite: "SELECT \"OrderId\", \"Total\" FROM \"orders\"",
-            pg:     "SELECT \"OrderId\", \"Total\" FROM \"orders\"",
-            mysql:  "SELECT `OrderId`, `Total` FROM `orders`",
-            ss:     "SELECT [OrderId], [Total] FROM [orders]");
-
-        var results = await lite.ExecuteFetchAllAsync();
-        Assert.That(results, Has.Count.EqualTo(3));
-        Assert.That(results[0], Is.EqualTo((1, 250.00m)));
-        Assert.That(results[1], Is.EqualTo((2, 75.50m)));
-        Assert.That(results[2], Is.EqualTo((3, 150.00m)));
-    }
-
-    [Test]
-    public async Task Select_Distinct()
-    {
-        await using var t = await QueryTestHarness.CreateAsync();
-        var (Lite, Pg, My, Ss) = t;
-
-        QueryTestHarness.AssertDialects(
-            Lite.Users().Distinct().ToDiagnostics(),
-            Pg.Users().Distinct().ToDiagnostics(),
-            My.Users().Distinct().ToDiagnostics(),
-            Ss.Users().Distinct().ToDiagnostics(),
-            sqlite: "SELECT DISTINCT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\"",
-            pg:     "SELECT DISTINCT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\"",
-            mysql:  "SELECT DISTINCT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users`",
-            ss:     "SELECT DISTINCT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users]");
-    }
+    #region Entity Projections
 
     [Test]
     public async Task Select_Entity_User_AllColumns()
@@ -174,15 +206,31 @@ internal class CrossDialectSelectTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Select(u => u).Prepare();
+        var pg = Pg.Users().Select(u => u).Prepare();
+        var my = My.Users().Select(u => u).Prepare();
+        var ss = Ss.Users().Select(u => u).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Select(u => u).ToDiagnostics(),
-            Pg.Users().Select(u => u).ToDiagnostics(),
-            My.Users().Select(u => u).ToDiagnostics(),
-            Ss.Users().Select(u => u).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\"",
             pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\"",
             mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users`",
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users]");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(3));
+        Assert.That(results[0].UserId, Is.EqualTo(1));
+        Assert.That(results[0].UserName, Is.EqualTo("Alice"));
+        Assert.That(results[0].Email, Is.EqualTo("alice@test.com"));
+        Assert.That(results[0].IsActive, Is.True);
+        Assert.That(results[1].UserId, Is.EqualTo(2));
+        Assert.That(results[1].UserName, Is.EqualTo("Bob"));
+        Assert.That(results[1].Email, Is.Null);
+        Assert.That(results[2].UserId, Is.EqualTo(3));
+        Assert.That(results[2].UserName, Is.EqualTo("Charlie"));
+        Assert.That(results[2].IsActive, Is.False);
     }
 
     [Test]
@@ -191,16 +239,94 @@ internal class CrossDialectSelectTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Orders().Select(o => o).Prepare();
+        var pg = Pg.Orders().Select(o => o).Prepare();
+        var my = My.Orders().Select(o => o).Prepare();
+        var ss = Ss.Orders().Select(o => o).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Orders().Select(o => o).ToDiagnostics(),
-            Pg.Orders().Select(o => o).ToDiagnostics(),
-            My.Orders().Select(o => o).ToDiagnostics(),
-            Ss.Orders().Select(o => o).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"OrderId\", \"UserId\", \"Total\", \"Status\", \"Priority\", \"OrderDate\", \"Notes\" FROM \"orders\"",
             pg:     "SELECT \"OrderId\", \"UserId\", \"Total\", \"Status\", \"Priority\", \"OrderDate\", \"Notes\" FROM \"orders\"",
             mysql:  "SELECT `OrderId`, `UserId`, `Total`, `Status`, `Priority`, `OrderDate`, `Notes` FROM `orders`",
             ss:     "SELECT [OrderId], [UserId], [Total], [Status], [Priority], [OrderDate], [Notes] FROM [orders]");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(3));
+        Assert.That(results[0].OrderId, Is.EqualTo(1));
+        Assert.That(results[0].Total, Is.EqualTo(250.00m));
+        Assert.That(results[0].Status, Is.EqualTo("Shipped"));
+        Assert.That(results[1].OrderId, Is.EqualTo(2));
+        Assert.That(results[1].Total, Is.EqualTo(75.50m));
+        Assert.That(results[2].OrderId, Is.EqualTo(3));
+        Assert.That(results[2].Total, Is.EqualTo(150.00m));
     }
+
+    [Test]
+    public async Task Select_Distinct()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var lt = Lite.Users().Distinct().Select(u => u).Prepare();
+        var pg = Pg.Users().Distinct().Select(u => u).Prepare();
+        var my = My.Users().Distinct().Select(u => u).Prepare();
+        var ss = Ss.Users().Distinct().Select(u => u).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT DISTINCT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\"",
+            pg:     "SELECT DISTINCT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\"",
+            mysql:  "SELECT DISTINCT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users`",
+            ss:     "SELECT DISTINCT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users]");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(3));
+        Assert.That(results[0].UserId, Is.EqualTo(1));
+        Assert.That(results[0].UserName, Is.EqualTo("Alice"));
+        Assert.That(results[0].IsActive, Is.True);
+        Assert.That(results[1].UserId, Is.EqualTo(2));
+        Assert.That(results[1].UserName, Is.EqualTo("Bob"));
+        Assert.That(results[2].UserId, Is.EqualTo(3));
+        Assert.That(results[2].UserName, Is.EqualTo("Charlie"));
+        Assert.That(results[2].IsActive, Is.False);
+    }
+
+    #endregion
+
+    #region Table Select
+
+    [Test]
+    public async Task Select_OrdersTable_Tuple()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var lt = Lite.Orders().Select(o => (o.OrderId, o.Total)).Prepare();
+        var pg = Pg.Orders().Select(o => (o.OrderId, o.Total)).Prepare();
+        var my = My.Orders().Select(o => (o.OrderId, o.Total)).Prepare();
+        var ss = Ss.Orders().Select(o => (o.OrderId, o.Total)).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"OrderId\", \"Total\" FROM \"orders\"",
+            pg:     "SELECT \"OrderId\", \"Total\" FROM \"orders\"",
+            mysql:  "SELECT `OrderId`, `Total` FROM `orders`",
+            ss:     "SELECT [OrderId], [Total] FROM [orders]");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(3));
+        Assert.That(results[0], Is.EqualTo((1, 250.00m)));
+        Assert.That(results[1], Is.EqualTo((2, 75.50m)));
+        Assert.That(results[2], Is.EqualTo((3, 150.00m)));
+    }
+
+    #endregion
+
+    #region Pagination
 
     [Test]
     public async Task Pagination_LimitOffset()
@@ -208,22 +334,20 @@ internal class CrossDialectSelectTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Select(u => (u.UserId, u.UserName)).Limit(2).Offset(1).Prepare();
+        var pg = Pg.Users().Select(u => (u.UserId, u.UserName)).Limit(2).Offset(1).Prepare();
+        var my = My.Users().Select(u => (u.UserId, u.UserName)).Limit(2).Offset(1).Prepare();
+        var ss = Ss.Users().Select(u => (u.UserId, u.UserName)).Limit(2).Offset(1).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => true).Limit(10).Offset(20).ToDiagnostics(),
-            Pg.Users().Where(u => true).Limit(10).Offset(20).ToDiagnostics(),
-            My.Users().Where(u => true).Limit(10).Offset(20).ToDiagnostics(),
-            Ss.Users().Where(u => true).Limit(10).Offset(20).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" LIMIT 10 OFFSET 20",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" LIMIT 10 OFFSET 20",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` LIMIT 10 OFFSET 20",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] ORDER BY (SELECT NULL) OFFSET 20 ROWS FETCH NEXT 10 ROWS ONLY");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" LIMIT 2 OFFSET 1",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" LIMIT 2 OFFSET 1",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` LIMIT 2 OFFSET 1",
+            ss:     "SELECT [UserId], [UserName] FROM [users] ORDER BY (SELECT NULL) OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY");
 
-        // Execution: skip 1, take 2 using Select tuple for verifiable results
-        var results = await Lite.Users()
-            .Select(u => (u.UserId, u.UserName))
-            .Limit(2).Offset(1)
-            .ExecuteFetchAllAsync();
-
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((2, "Bob")));
         Assert.That(results[1], Is.EqualTo((3, "Charlie")));
@@ -235,15 +359,24 @@ internal class CrossDialectSelectTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Select(u => (u.UserId, u.UserName)).Limit(5).Prepare();
+        var pg = Pg.Users().Select(u => (u.UserId, u.UserName)).Limit(5).Prepare();
+        var my = My.Users().Select(u => (u.UserId, u.UserName)).Limit(5).Prepare();
+        var ss = Ss.Users().Select(u => (u.UserId, u.UserName)).Limit(5).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => true).Limit(5).ToDiagnostics(),
-            Pg.Users().Where(u => true).Limit(5).ToDiagnostics(),
-            My.Users().Where(u => true).Limit(5).ToDiagnostics(),
-            Ss.Users().Where(u => true).Limit(5).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" LIMIT 5",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" LIMIT 5",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` LIMIT 5",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 5 ROWS ONLY");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" LIMIT 5",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" LIMIT 5",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` LIMIT 5",
+            ss:     "SELECT [UserId], [UserName] FROM [users] ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 5 ROWS ONLY");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(3));
+        Assert.That(results[0], Is.EqualTo((1, "Alice")));
+        Assert.That(results[1], Is.EqualTo((2, "Bob")));
+        Assert.That(results[2], Is.EqualTo((3, "Charlie")));
     }
 
     [Test]
@@ -255,22 +388,21 @@ internal class CrossDialectSelectTests
         // Use a variable (not const) so the generator treats offset as parameterized
         int offset = 1;
 
+        var lt = Lite.Users().Select(u => (u.UserId, u.UserName)).Limit(2).Offset(offset).Prepare();
+        var pg = Pg.Users().Select(u => (u.UserId, u.UserName)).Limit(2).Offset(offset).Prepare();
+        var my = My.Users().Select(u => (u.UserId, u.UserName)).Limit(2).Offset(offset).Prepare();
+        var ss = Ss.Users().Select(u => (u.UserId, u.UserName)).Limit(2).Offset(offset).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Select(u => (u.UserId, u.UserName)).Limit(2).Offset(offset).ToDiagnostics(),
-            Pg.Users().Select(u => (u.UserId, u.UserName)).Limit(2).Offset(offset).ToDiagnostics(),
-            My.Users().Select(u => (u.UserId, u.UserName)).Limit(2).Offset(offset).ToDiagnostics(),
-            Ss.Users().Select(u => (u.UserId, u.UserName)).Limit(2).Offset(offset).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" LIMIT 2 OFFSET @p0",
             pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" LIMIT 2 OFFSET $1",
             mysql:  "SELECT `UserId`, `UserName` FROM `users` LIMIT 2 OFFSET ?",
             ss:     "SELECT [UserId], [UserName] FROM [users] ORDER BY (SELECT NULL) OFFSET @p0 ROWS FETCH NEXT 2 ROWS ONLY");
 
         // Execution: skip 1 user, take 2 → should get Bob and Charlie
-        var results = await Lite.Users()
-            .Select(u => (u.UserId, u.UserName))
-            .Limit(2).Offset(offset)
-            .ExecuteFetchAllAsync();
-
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((2, "Bob")));
         Assert.That(results[1], Is.EqualTo((3, "Charlie")));
@@ -285,81 +417,24 @@ internal class CrossDialectSelectTests
         // Inverse mixed case: parameterized limit, literal offset
         int limit = 2;
 
+        var lt = Lite.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(1).Prepare();
+        var pg = Pg.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(1).Prepare();
+        var my = My.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(1).Prepare();
+        var ss = Ss.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(1).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(1).ToDiagnostics(),
-            Pg.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(1).ToDiagnostics(),
-            My.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(1).ToDiagnostics(),
-            Ss.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(1).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" LIMIT @p0 OFFSET 1",
             pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" LIMIT $1 OFFSET 1",
             mysql:  "SELECT `UserId`, `UserName` FROM `users` LIMIT ? OFFSET 1",
             ss:     "SELECT [UserId], [UserName] FROM [users] ORDER BY (SELECT NULL) OFFSET 1 ROWS FETCH NEXT @p0 ROWS ONLY");
 
         // Execution: skip 1, take 2 → should get Bob and Charlie
-        var results = await Lite.Users()
-            .Select(u => (u.UserId, u.UserName))
-            .Limit(limit).Offset(1)
-            .ExecuteFetchAllAsync();
-
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((2, "Bob")));
         Assert.That(results[1], Is.EqualTo((3, "Charlie")));
-    }
-
-    [Test]
-    public async Task Select_NamedTuple_TwoColumns()
-    {
-        await using var t = await QueryTestHarness.CreateAsync();
-        var (Lite, Pg, My, Ss) = t;
-
-        var lite = Lite.Users().Select(u => (Id: u.UserId, Name: u.UserName)).Prepare();
-
-        QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Select(u => (Id: u.UserId, Name: u.UserName)).ToDiagnostics(),
-            My.Users().Select(u => (Id: u.UserId, Name: u.UserName)).ToDiagnostics(),
-            Ss.Users().Select(u => (Id: u.UserId, Name: u.UserName)).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\"",
-            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\"",
-            mysql:  "SELECT `UserId`, `UserName` FROM `users`",
-            ss:     "SELECT [UserId], [UserName] FROM [users]");
-
-        var results = await lite.ExecuteFetchAllAsync();
-        Assert.That(results, Has.Count.EqualTo(3));
-        // Verify named element access works
-        Assert.That(results[0].Id, Is.EqualTo(1));
-        Assert.That(results[0].Name, Is.EqualTo("Alice"));
-        Assert.That(results[1].Id, Is.EqualTo(2));
-        Assert.That(results[1].Name, Is.EqualTo("Bob"));
-        Assert.That(results[2].Id, Is.EqualTo(3));
-        Assert.That(results[2].Name, Is.EqualTo("Charlie"));
-    }
-
-    [Test]
-    public async Task Select_NamedTuple_ThreeColumns()
-    {
-        await using var t = await QueryTestHarness.CreateAsync();
-        var (Lite, Pg, My, Ss) = t;
-
-        var lite = Lite.Users().Select(u => (Id: u.UserId, Name: u.UserName, Active: u.IsActive)).Prepare();
-
-        QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Select(u => (Id: u.UserId, Name: u.UserName, Active: u.IsActive)).ToDiagnostics(),
-            My.Users().Select(u => (Id: u.UserId, Name: u.UserName, Active: u.IsActive)).ToDiagnostics(),
-            Ss.Users().Select(u => (Id: u.UserId, Name: u.UserName, Active: u.IsActive)).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\"",
-            pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\"",
-            mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users`",
-            ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users]");
-
-        var results = await lite.ExecuteFetchAllAsync();
-        Assert.That(results, Has.Count.EqualTo(3));
-        Assert.That(results[0].Id, Is.EqualTo(1));
-        Assert.That(results[0].Name, Is.EqualTo("Alice"));
-        Assert.That(results[0].Active, Is.True);
-        Assert.That(results[2].Id, Is.EqualTo(3));
-        Assert.That(results[2].Active, Is.False);
     }
 
     [Test]
@@ -372,24 +447,25 @@ internal class CrossDialectSelectTests
         int limit = 2;
         int offset = 1;
 
+        var lt = Lite.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(offset).Prepare();
+        var pg = Pg.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(offset).Prepare();
+        var my = My.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(offset).Prepare();
+        var ss = Ss.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(offset).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(offset).ToDiagnostics(),
-            Pg.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(offset).ToDiagnostics(),
-            My.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(offset).ToDiagnostics(),
-            Ss.Users().Select(u => (u.UserId, u.UserName)).Limit(limit).Offset(offset).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" LIMIT @p0 OFFSET @p1",
             pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" LIMIT $1 OFFSET $2",
             mysql:  "SELECT `UserId`, `UserName` FROM `users` LIMIT ? OFFSET ?",
             ss:     "SELECT [UserId], [UserName] FROM [users] ORDER BY (SELECT NULL) OFFSET @p1 ROWS FETCH NEXT @p0 ROWS ONLY");
 
         // Execution: skip 1, take 2 → should get Bob and Charlie
-        var results = await Lite.Users()
-            .Select(u => (u.UserId, u.UserName))
-            .Limit(limit).Offset(offset)
-            .ExecuteFetchAllAsync();
-
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((2, "Bob")));
         Assert.That(results[1], Is.EqualTo((3, "Charlie")));
     }
+
+    #endregion
 }

--- a/src/Quarry.Tests/SqlOutput/CrossDialectStringOpTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectStringOpTests.cs
@@ -17,15 +17,21 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => u.UserName.Contains("User05")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.Contains("User05")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserName.Contains("User05")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.Contains("User05")).Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.UserName.Contains("User05")).ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.Contains("User05")).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.Contains("User05")).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.Contains("User05")).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserName\" LIKE '%User05%'",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserName\" LIKE '%User05%'",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE `UserName` LIKE '%User05%'",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE [UserName] LIKE '%User05%'");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserName\" LIKE '%User05%'",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserName\" LIKE '%User05%'",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `UserName` LIKE '%User05%'",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [UserName] LIKE '%User05%'");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(0));
     }
 
     [Test]
@@ -34,19 +40,20 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var lt = Lite.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var my = My.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%lic%'",
             pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%lic%'",
             mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users` WHERE `UserName` LIKE '%lic%'",
             ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users] WHERE [UserName] LIKE '%lic%'");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].UserName, Is.EqualTo("Alice"));
     }
@@ -57,15 +64,21 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => u.UserName.Contains("admin")).Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.Contains("admin")).Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserName.Contains("admin")).Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.Contains("admin")).Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.UserName.Contains("admin")).Where(u => u.IsActive).ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.Contains("admin")).Where(u => u.IsActive).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.Contains("admin")).Where(u => u.IsActive).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.Contains("admin")).Where(u => u.IsActive).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (\"UserName\" LIKE '%admin%') AND (\"IsActive\" = 1)",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (\"UserName\" LIKE '%admin%') AND (\"IsActive\" = TRUE)",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (`UserName` LIKE '%admin%') AND (`IsActive` = 1)",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE ([UserName] LIKE '%admin%') AND ([IsActive] = 1)");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (\"UserName\" LIKE '%admin%') AND (\"IsActive\" = 1)",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (\"UserName\" LIKE '%admin%') AND (\"IsActive\" = TRUE)",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE (`UserName` LIKE '%admin%') AND (`IsActive` = 1)",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE ([UserName] LIKE '%admin%') AND ([IsActive] = 1)");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(0));
     }
 
     #endregion
@@ -78,15 +91,21 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => u.UserName.StartsWith("User0")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.StartsWith("User0")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserName.StartsWith("User0")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.StartsWith("User0")).Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.UserName.StartsWith("User0")).ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.StartsWith("User0")).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.StartsWith("User0")).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.StartsWith("User0")).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserName\" LIKE 'User0%'",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserName\" LIKE 'User0%'",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE `UserName` LIKE 'User0%'",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE [UserName] LIKE 'User0%'");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserName\" LIKE 'User0%'",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserName\" LIKE 'User0%'",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `UserName` LIKE 'User0%'",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [UserName] LIKE 'User0%'");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(0));
     }
 
     [Test]
@@ -95,19 +114,20 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.UserName.StartsWith("A")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var lt = Lite.Users().Where(u => u.UserName.StartsWith("A")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.StartsWith("A")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var my = My.Users().Where(u => u.UserName.StartsWith("A")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.StartsWith("A")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.StartsWith("A")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.StartsWith("A")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.StartsWith("A")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE 'A%'",
             pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE 'A%'",
             mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users` WHERE `UserName` LIKE 'A%'",
             ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users] WHERE [UserName] LIKE 'A%'");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].UserName, Is.EqualTo("Alice"));
     }
@@ -122,15 +142,21 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => u.UserName.EndsWith("son")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.EndsWith("son")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserName.EndsWith("son")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.EndsWith("son")).Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.UserName.EndsWith("son")).ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.EndsWith("son")).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.EndsWith("son")).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.EndsWith("son")).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserName\" LIKE '%son'",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserName\" LIKE '%son'",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE `UserName` LIKE '%son'",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE [UserName] LIKE '%son'");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserName\" LIKE '%son'",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserName\" LIKE '%son'",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `UserName` LIKE '%son'",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [UserName] LIKE '%son'");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(0));
     }
 
     [Test]
@@ -139,15 +165,21 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => u.UserName.EndsWith("z")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.EndsWith("z")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var my = My.Users().Where(u => u.UserName.EndsWith("z")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.EndsWith("z")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.UserName.EndsWith("z")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.EndsWith("z")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.EndsWith("z")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.EndsWith("z")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%z'",
             pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%z'",
             mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users` WHERE `UserName` LIKE '%z'",
             ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users] WHERE [UserName] LIKE '%z'");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(0));
     }
 
     #endregion
@@ -160,15 +192,21 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => u.Email!.Contains("@example")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Email!.Contains("@example")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.Email!.Contains("@example")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.Email!.Contains("@example")).Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.Email!.Contains("@example")).ToDiagnostics(),
-            Pg.Users().Where(u => u.Email!.Contains("@example")).ToDiagnostics(),
-            My.Users().Where(u => u.Email!.Contains("@example")).ToDiagnostics(),
-            Ss.Users().Where(u => u.Email!.Contains("@example")).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"Email\" LIKE '%@example%'",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"Email\" LIKE '%@example%'",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE `Email` LIKE '%@example%'",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE [Email] LIKE '%@example%'");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"Email\" LIKE '%@example%'",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"Email\" LIKE '%@example%'",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `Email` LIKE '%@example%'",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [Email] LIKE '%@example%'");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(0));
     }
 
     #endregion
@@ -181,15 +219,21 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (\"UserName\" LIKE '%er%') AND (\"UserName\" LIKE 'Us%')",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (\"UserName\" LIKE '%er%') AND (\"UserName\" LIKE 'Us%')",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (`UserName` LIKE '%er%') AND (`UserName` LIKE 'Us%')",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE ([UserName] LIKE '%er%') AND ([UserName] LIKE 'Us%')");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (\"UserName\" LIKE '%er%') AND (\"UserName\" LIKE 'Us%')",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (\"UserName\" LIKE '%er%') AND (\"UserName\" LIKE 'Us%')",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE (`UserName` LIKE '%er%') AND (`UserName` LIKE 'Us%')",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE ([UserName] LIKE '%er%') AND ([UserName] LIKE 'Us%')");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(0));
     }
 
     #endregion
@@ -212,21 +256,22 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var lt = Lite.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var my = My.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.Contains("lic")).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%lic%'",
             pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%lic%'",
             mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users` WHERE `UserName` LIKE '%lic%'",
             ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users] WHERE [UserName] LIKE '%lic%'");
 
-        Assert.That(lite.ToDiagnostics().Parameters, Has.Count.EqualTo(0));
+        Assert.That(lt.ToDiagnostics().Parameters, Has.Count.EqualTo(0));
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].UserName, Is.EqualTo("Alice"));
     }
@@ -237,15 +282,21 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => u.UserName.StartsWith("A")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.StartsWith("A")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserName.StartsWith("A")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.StartsWith("A")).Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.UserName.StartsWith("A")).ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.StartsWith("A")).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.StartsWith("A")).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.StartsWith("A")).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserName\" LIKE 'A%'",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserName\" LIKE 'A%'",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE `UserName` LIKE 'A%'",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE [UserName] LIKE 'A%'");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserName\" LIKE 'A%'",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserName\" LIKE 'A%'",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `UserName` LIKE 'A%'",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [UserName] LIKE 'A%'");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(1));
     }
 
     [Test]
@@ -254,15 +305,21 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => u.UserName.EndsWith("ce")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.EndsWith("ce")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserName.EndsWith("ce")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.EndsWith("ce")).Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.UserName.EndsWith("ce")).ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.EndsWith("ce")).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.EndsWith("ce")).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.EndsWith("ce")).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserName\" LIKE '%ce'",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserName\" LIKE '%ce'",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE `UserName` LIKE '%ce'",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE [UserName] LIKE '%ce'");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserName\" LIKE '%ce'",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserName\" LIKE '%ce'",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `UserName` LIKE '%ce'",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [UserName] LIKE '%ce'");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(1));
     }
 
     [Test]
@@ -271,21 +328,22 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.UserName.Contains(ConstSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var lt = Lite.Users().Where(u => u.UserName.Contains(ConstSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.Contains(ConstSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var my = My.Users().Where(u => u.UserName.Contains(ConstSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.Contains(ConstSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.Contains(ConstSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.Contains(ConstSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.Contains(ConstSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%lic%'",
             pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%lic%'",
             mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users` WHERE `UserName` LIKE '%lic%'",
             ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users] WHERE [UserName] LIKE '%lic%'");
 
-        Assert.That(lite.ToDiagnostics().Parameters, Has.Count.EqualTo(0));
+        Assert.That(lt.ToDiagnostics().Parameters, Has.Count.EqualTo(0));
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].UserName, Is.EqualTo("Alice"));
     }
@@ -296,21 +354,22 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.UserName.Contains(ReadonlySearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var lt = Lite.Users().Where(u => u.UserName.Contains(ReadonlySearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.Contains(ReadonlySearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var my = My.Users().Where(u => u.UserName.Contains(ReadonlySearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.Contains(ReadonlySearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.Contains(ReadonlySearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.Contains(ReadonlySearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.Contains(ReadonlySearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%lic%'",
             pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%lic%'",
             mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users` WHERE `UserName` LIKE '%lic%'",
             ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users] WHERE [UserName] LIKE '%lic%'");
 
-        Assert.That(lite.ToDiagnostics().Parameters, Has.Count.EqualTo(0));
+        Assert.That(lt.ToDiagnostics().Parameters, Has.Count.EqualTo(0));
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].UserName, Is.EqualTo("Alice"));
     }
@@ -323,21 +382,22 @@ internal class CrossDialectStringOpTests
 
         const string search = "lic";
 
-        var lite = Lite.Users().Where(u => u.UserName.Contains(search)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var lt = Lite.Users().Where(u => u.UserName.Contains(search)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.Contains(search)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var my = My.Users().Where(u => u.UserName.Contains(search)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.Contains(search)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.Contains(search)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.Contains(search)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.Contains(search)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%lic%'",
             pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%lic%'",
             mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users` WHERE `UserName` LIKE '%lic%'",
             ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users] WHERE [UserName] LIKE '%lic%'");
 
-        Assert.That(lite.ToDiagnostics().Parameters, Has.Count.EqualTo(0));
+        Assert.That(lt.ToDiagnostics().Parameters, Has.Count.EqualTo(0));
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].UserName, Is.EqualTo("Alice"));
     }
@@ -349,21 +409,22 @@ internal class CrossDialectStringOpTests
         var (Lite, Pg, My, Ss) = t;
 
         // Mutable static field — cannot be inlined, must stay parameterized
-        var lite = Lite.Users().Where(u => u.UserName.Contains(MutableSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var lt = Lite.Users().Where(u => u.UserName.Contains(MutableSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.Contains(MutableSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var my = My.Users().Where(u => u.UserName.Contains(MutableSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.Contains(MutableSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.Contains(MutableSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.Contains(MutableSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.Contains(MutableSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%' || @p0 || '%'",
             pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%' || $1 || '%'",
             mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users` WHERE `UserName` LIKE CONCAT('%', ?, '%')",
             ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users] WHERE [UserName] LIKE '%' + @p0 + '%'");
 
-        Assert.That(lite.ToDiagnostics().Parameters, Has.Count.EqualTo(1));
+        Assert.That(lt.ToDiagnostics().Parameters, Has.Count.EqualTo(1));
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].UserName, Is.EqualTo("Alice"));
     }
@@ -410,15 +471,21 @@ internal class CrossDialectStringOpTests
         var (Lite, Pg, My, Ss) = t;
 
         // Literal containing LIKE metacharacter _ should be escaped and inlined
+        var lt = Lite.Users().Where(u => u.UserName.Contains("user_name")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.Contains("user_name")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserName.Contains("user_name")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.Contains("user_name")).Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.UserName.Contains("user_name")).ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.Contains("user_name")).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.Contains("user_name")).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.Contains("user_name")).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserName\" LIKE '%user\\_name%' ESCAPE '\\'",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserName\" LIKE '%user\\_name%' ESCAPE '\\'",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE `UserName` LIKE '%user\\_name%' ESCAPE '\\'",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE [UserName] LIKE '%user\\_name%' ESCAPE '\\'");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserName\" LIKE '%user\\_name%' ESCAPE '\\'",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserName\" LIKE '%user\\_name%' ESCAPE '\\'",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `UserName` LIKE '%user\\_name%' ESCAPE '\\'",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [UserName] LIKE '%user\\_name%' ESCAPE '\\'");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(0));
     }
 
     [Test]
@@ -427,15 +494,21 @@ internal class CrossDialectStringOpTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).Select(u => (u.UserId, u.UserName)).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.Contains("er")).Where(u => u.UserName.StartsWith("Us")).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (\"UserName\" LIKE '%er%') AND (\"UserName\" LIKE 'Us%')",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (\"UserName\" LIKE '%er%') AND (\"UserName\" LIKE 'Us%')",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (`UserName` LIKE '%er%') AND (`UserName` LIKE 'Us%')",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE ([UserName] LIKE '%er%') AND ([UserName] LIKE 'Us%')");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (\"UserName\" LIKE '%er%') AND (\"UserName\" LIKE 'Us%')",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (\"UserName\" LIKE '%er%') AND (\"UserName\" LIKE 'Us%')",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE (`UserName` LIKE '%er%') AND (`UserName` LIKE 'Us%')",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE ([UserName] LIKE '%er%') AND ([UserName] LIKE 'Us%')");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(0));
     }
 
     [Test]
@@ -445,21 +518,22 @@ internal class CrossDialectStringOpTests
         var (Lite, Pg, My, Ss) = t;
 
         // Qualified member access to const string (e.g., StringConstants.SearchTerm) should be folded
-        var lite = Lite.Users().Where(u => u.UserName.Contains(StringConstants.SearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var lt = Lite.Users().Where(u => u.UserName.Contains(StringConstants.SearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.Contains(StringConstants.SearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var my = My.Users().Where(u => u.UserName.Contains(StringConstants.SearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.Contains(StringConstants.SearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.Contains(StringConstants.SearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.Contains(StringConstants.SearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.Contains(StringConstants.SearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%lic%'",
             pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%lic%'",
             mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users` WHERE `UserName` LIKE '%lic%'",
             ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users] WHERE [UserName] LIKE '%lic%'");
 
-        Assert.That(lite.ToDiagnostics().Parameters, Has.Count.EqualTo(0));
+        Assert.That(lt.ToDiagnostics().Parameters, Has.Count.EqualTo(0));
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].UserName, Is.EqualTo("Alice"));
     }
@@ -471,15 +545,21 @@ internal class CrossDialectStringOpTests
         var (Lite, Pg, My, Ss) = t;
 
         // Qualified const containing LIKE metacharacter (%) must be escaped
+        var lt = Lite.Users().Where(u => u.UserName.Contains(StringConstants.MetaSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var pg = Pg.Users().Where(u => u.UserName.Contains(StringConstants.MetaSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var my = My.Users().Where(u => u.UserName.Contains(StringConstants.MetaSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var ss = Ss.Users().Where(u => u.UserName.Contains(StringConstants.MetaSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Users().Where(u => u.UserName.Contains(StringConstants.MetaSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Pg.Users().Where(u => u.UserName.Contains(StringConstants.MetaSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            My.Users().Where(u => u.UserName.Contains(StringConstants.MetaSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserName.Contains(StringConstants.MetaSearchTerm)).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%50\\%%' ESCAPE '\\'",
             pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"UserName\" LIKE '%50\\%%' ESCAPE '\\'",
             mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users` WHERE `UserName` LIKE '%50\\%%' ESCAPE '\\'",
             ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users] WHERE [UserName] LIKE '%50\\%%' ESCAPE '\\'");
+
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(0));
     }
 
     #endregion

--- a/src/Quarry.Tests/SqlOutput/CrossDialectSubqueryTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectSubqueryTests.cs
@@ -17,13 +17,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Any()).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Any()).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Any()).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Any()).Prepare();
+        var my = My.Users().Where(u => u.Orders.Any()).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Any()).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -33,7 +33,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId])");
 
         // Alice has 2 orders, Bob has 1 order, Charlie has none
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((2, "Bob")));
@@ -45,13 +45,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => !u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => !u.Orders.Any()).Prepare();
-        var my   = My.Users().Where(u => !u.Orders.Any()).Prepare();
-        var ss   = Ss.Users().Where(u => !u.Orders.Any()).Prepare();
+        var lt = Lite.Users().Where(u => !u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => !u.Orders.Any()).Prepare();
+        var my = My.Users().Where(u => !u.Orders.Any()).Prepare();
+        var ss = Ss.Users().Where(u => !u.Orders.Any()).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -61,7 +61,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE NOT (EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]))");
 
         // Only Charlie has no orders
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0], Is.EqualTo((3, "Charlie")));
     }
@@ -76,13 +76,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Any(o => o.Total > 100)).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Any(o => o.Total > 100)).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Any(o => o.Total > 100)).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Any(o => o.Total > 100)).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Any(o => o.Total > 100)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Any(o => o.Total > 100)).Prepare();
+        var my = My.Users().Where(u => u.Orders.Any(o => o.Total > 100)).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Any(o => o.Total > 100)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -92,7 +92,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND ([sq0].[Total] > 100))");
 
         // Alice has order 250, Bob has order 150 — both > 100
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((2, "Bob")));
@@ -104,13 +104,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Any(o => o.Status == "paid")).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Any(o => o.Status == "paid")).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Any(o => o.Status == "paid")).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Any(o => o.Status == "paid")).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Any(o => o.Status == "paid")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Any(o => o.Status == "paid")).Prepare();
+        var my = My.Users().Where(u => u.Orders.Any(o => o.Status == "paid")).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Any(o => o.Status == "paid")).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -120,7 +120,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND ([sq0].[Status] = 'paid'))");
 
         // No orders have status 'paid' (they're 'Shipped' and 'Pending')
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0));
     }
 
@@ -134,13 +134,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.All(o => o.Status == "paid")).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.All(o => o.Status == "paid")).Prepare();
-        var my   = My.Users().Where(u => u.Orders.All(o => o.Status == "paid")).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.All(o => o.Status == "paid")).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.All(o => o.Status == "paid")).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.All(o => o.Status == "paid")).Prepare();
+        var my = My.Users().Where(u => u.Orders.All(o => o.Status == "paid")).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.All(o => o.Status == "paid")).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -151,7 +151,7 @@ internal class CrossDialectSubqueryTests
 
         // All(status=="paid") is vacuously true for users with no orders (Charlie)
         // Alice/Bob have non-paid orders, so they fail the All check
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0], Is.EqualTo((3, "Charlie")));
     }
@@ -166,13 +166,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Count() > 5).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Count() > 5).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Count() > 5).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Count() > 5).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Count() > 5).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Count() > 5).Prepare();
+        var my = My.Users().Where(u => u.Orders.Count() > 5).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Count() > 5).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -182,7 +182,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT COUNT(*) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) > 5");
 
         // Max orders per user is 2 (Alice), nobody has > 5
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0));
     }
 
@@ -192,13 +192,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Count() == 0).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Count() == 0).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Count() == 0).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Count() == 0).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Count() == 0).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Count() == 0).Prepare();
+        var my = My.Users().Where(u => u.Orders.Count() == 0).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Count() == 0).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -208,7 +208,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT COUNT(*) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) = 0");
 
         // Only Charlie has zero orders
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0], Is.EqualTo((3, "Charlie")));
     }
@@ -219,13 +219,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Count(o => o.Total > 100) > 2).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Count(o => o.Total > 100) > 2).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Count(o => o.Total > 100) > 2).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Count(o => o.Total > 100) > 2).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Count(o => o.Total > 100) > 2).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Count(o => o.Total > 100) > 2).Prepare();
+        var my = My.Users().Where(u => u.Orders.Count(o => o.Total > 100) > 2).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Count(o => o.Total > 100) > 2).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -235,7 +235,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT COUNT(*) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND ([sq0].[Total] > 100)) > 2");
 
         // Alice has 1 order > 100 (250), Bob has 1 (150) — neither > 2
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0));
     }
 
@@ -245,13 +245,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Count(o => o.Status == "paid") >= 1).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Count(o => o.Status == "paid") >= 1).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Count(o => o.Status == "paid") >= 1).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Count(o => o.Status == "paid") >= 1).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Count(o => o.Status == "paid") >= 1).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Count(o => o.Status == "paid") >= 1).Prepare();
+        var my = My.Users().Where(u => u.Orders.Count(o => o.Status == "paid") >= 1).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Count(o => o.Status == "paid") >= 1).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -261,7 +261,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT COUNT(*) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND ([sq0].[Status] = 'paid')) >= 1");
 
         // No orders have status 'paid'
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(0));
     }
 
@@ -273,13 +273,13 @@ internal class CrossDialectSubqueryTests
 
         var minTotal = 50m;
 
-        var lite = Lite.Users().Where(u => u.Orders.Count(o => o.Total > minTotal) > 0).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Count(o => o.Total > minTotal) > 0).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Count(o => o.Total > minTotal) > 0).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Count(o => o.Total > minTotal) > 0).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Count(o => o.Total > minTotal) > 0).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Count(o => o.Total > minTotal) > 0).Prepare();
+        var my = My.Users().Where(u => u.Orders.Count(o => o.Total > minTotal) > 0).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Count(o => o.Total > minTotal) > 0).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -289,7 +289,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT COUNT(*) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND ([sq0].[Total] > @p0)) > 0");
 
         // All 3 orders have Total > 50 — Alice and Bob both qualify
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((2, "Bob")));
@@ -305,13 +305,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Any(o => o.Items.Any(i => i.UnitPrice > 50))).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Any(o => o.Items.Any(i => i.UnitPrice > 50))).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Any(o => o.Items.Any(i => i.UnitPrice > 50))).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Any(o => o.Items.Any(i => i.UnitPrice > 50))).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Any(o => o.Items.Any(i => i.UnitPrice > 50))).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Any(o => o.Items.Any(i => i.UnitPrice > 50))).Prepare();
+        var my = My.Users().Where(u => u.Orders.Any(o => o.Items.Any(i => i.UnitPrice > 50))).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Any(o => o.Items.Any(i => i.UnitPrice > 50))).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -322,7 +322,7 @@ internal class CrossDialectSubqueryTests
 
         // Order1 has Widget UnitPrice=125 (>50), Order2 has Gadget UnitPrice=75.50 (>50) → Alice
         // Order3 has Widget UnitPrice=50 (not >50) → Bob does NOT qualify
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
     }
@@ -333,13 +333,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Any(o => o.Items.All(i => i.Quantity > 0))).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Any(o => o.Items.All(i => i.Quantity > 0))).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Any(o => o.Items.All(i => i.Quantity > 0))).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Any(o => o.Items.All(i => i.Quantity > 0))).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Any(o => o.Items.All(i => i.Quantity > 0))).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Any(o => o.Items.All(i => i.Quantity > 0))).Prepare();
+        var my = My.Users().Where(u => u.Orders.Any(o => o.Items.All(i => i.Quantity > 0))).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Any(o => o.Items.All(i => i.Quantity > 0))).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -349,7 +349,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND (NOT EXISTS (SELECT 1 FROM [order_items] AS [sq1] WHERE [sq1].[OrderId] = [sq0].[OrderId] AND NOT ([sq1].[Quantity] > 0))))");
 
         // All order items have Quantity > 0 — Alice and Bob both have orders where All items have Quantity > 0
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((2, "Bob")));
@@ -367,13 +367,13 @@ internal class CrossDialectSubqueryTests
 
         var minAmount = 100m;
 
-        var lite = Lite.Users().Where(u => u.Orders.Any(o => o.Total > minAmount)).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Any(o => o.Total > minAmount)).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Any(o => o.Total > minAmount)).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Any(o => o.Total > minAmount)).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Any(o => o.Total > minAmount)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Any(o => o.Total > minAmount)).Prepare();
+        var my = My.Users().Where(u => u.Orders.Any(o => o.Total > minAmount)).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Any(o => o.Total > minAmount)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -383,7 +383,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND ([sq0].[Total] > @p0))");
 
         // Alice (250 > 100), Bob (150 > 100)
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
     }
 
@@ -395,13 +395,13 @@ internal class CrossDialectSubqueryTests
 
         var status = "paid";
 
-        var lite = Lite.Users().Where(u => u.Orders.All(o => o.Status == status)).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.All(o => o.Status == status)).Prepare();
-        var my   = My.Users().Where(u => u.Orders.All(o => o.Status == status)).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.All(o => o.Status == status)).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.All(o => o.Status == status)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.All(o => o.Status == status)).Prepare();
+        var my = My.Users().Where(u => u.Orders.All(o => o.Status == status)).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.All(o => o.Status == status)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -411,7 +411,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE NOT EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND NOT ([sq0].[Status] = @p0))");
 
         // No orders are 'paid' — vacuously true only for Charlie (no orders)
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0], Is.EqualTo((3, "Charlie")));
     }
@@ -426,13 +426,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.IsActive && u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.IsActive && u.Orders.Any()).Prepare();
-        var my   = My.Users().Where(u => u.IsActive && u.Orders.Any()).Prepare();
-        var ss   = Ss.Users().Where(u => u.IsActive && u.Orders.Any()).Prepare();
+        var lt = Lite.Users().Where(u => u.IsActive && u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.IsActive && u.Orders.Any()).Prepare();
+        var my = My.Users().Where(u => u.IsActive && u.Orders.Any()).Prepare();
+        var ss = Ss.Users().Where(u => u.IsActive && u.Orders.Any()).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -442,7 +442,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE [IsActive] = 1 AND EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId])");
 
         // Active users with orders: Alice and Bob
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((2, "Bob")));
@@ -454,20 +454,20 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE EXISTS (SELECT 1 FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\")",
             pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE EXISTS (SELECT 1 FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\")",
             mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE EXISTS (SELECT 1 FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId`)",
             ss:     "SELECT [UserId], [UserName] FROM [users] WHERE EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId])");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((2, "Bob")));
@@ -483,13 +483,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Any() || u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Any() || u.IsActive).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Any() || u.IsActive).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Any() || u.IsActive).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Any() || u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Any() || u.IsActive).Prepare();
+        var my = My.Users().Where(u => u.Orders.Any() || u.IsActive).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Any() || u.IsActive).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -500,7 +500,7 @@ internal class CrossDialectSubqueryTests
 
         // Has orders OR is active — all 3 users (Alice/Bob have orders, Alice/Bob are active, Charlie is neither but... wait Charlie is inactive and has no orders, so she fails)
         // Alice: orders=yes → true. Bob: orders=yes → true. Charlie: orders=no, active=no → false.
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
     }
 
@@ -510,13 +510,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Any() && u.Orders.Any(o => o.Total > 100)).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Any() && u.Orders.Any(o => o.Total > 100)).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Any() && u.Orders.Any(o => o.Total > 100)).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Any() && u.Orders.Any(o => o.Total > 100)).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Any() && u.Orders.Any(o => o.Total > 100)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Any() && u.Orders.Any(o => o.Total > 100)).Prepare();
+        var my = My.Users().Where(u => u.Orders.Any() && u.Orders.Any(o => o.Total > 100)).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Any() && u.Orders.Any(o => o.Total > 100)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -526,7 +526,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) AND EXISTS (SELECT 1 FROM [orders] AS [sq1] WHERE [sq1].[UserId] = [users].[UserId] AND ([sq1].[Total] > 100))");
 
         // Has any order AND has an order > 100: Alice (250), Bob (150)
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
     }
 
@@ -536,13 +536,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Any(o => o.Items.Any())).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Any(o => o.Items.Any())).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Any(o => o.Items.Any())).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Any(o => o.Items.Any())).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Any(o => o.Items.Any())).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Any(o => o.Items.Any())).Prepare();
+        var my = My.Users().Where(u => u.Orders.Any(o => o.Items.Any())).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Any(o => o.Items.Any())).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -552,7 +552,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND (EXISTS (SELECT 1 FROM [order_items] AS [sq1] WHERE [sq1].[OrderId] = [sq0].[OrderId])))");
 
         // All orders have at least one item — Alice and Bob
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((2, "Bob")));
@@ -564,13 +564,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Any(o => o.Status.Contains("hipp"))).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Any(o => o.Status.Contains("paid"))).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Any(o => o.Status.Contains("paid"))).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Any(o => o.Status.Contains("paid"))).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Any(o => o.Status.Contains("hipp"))).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Any(o => o.Status.Contains("paid"))).Prepare();
+        var my = My.Users().Where(u => u.Orders.Any(o => o.Status.Contains("paid"))).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Any(o => o.Status.Contains("paid"))).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -579,10 +579,10 @@ internal class CrossDialectSubqueryTests
             mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE EXISTS (SELECT 1 FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId` AND (`sq0`.`Status` LIKE '%paid%'))",
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND ([sq0].[Status] LIKE '%paid%'))");
 
-        Assert.That(lite.ToDiagnostics().Parameters, Has.Count.EqualTo(0));
+        Assert.That(lt.ToDiagnostics().Parameters, Has.Count.EqualTo(0));
 
         // 'Shipped' contains 'hipp' — Alice (order 1) and Bob (order 3) have Shipped orders
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
     }
 
@@ -592,13 +592,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Any(o => o.Status.StartsWith("P"))).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Any(o => o.Status.StartsWith("p"))).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Any(o => o.Status.StartsWith("p"))).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Any(o => o.Status.StartsWith("p"))).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Any(o => o.Status.StartsWith("P"))).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Any(o => o.Status.StartsWith("p"))).Prepare();
+        var my = My.Users().Where(u => u.Orders.Any(o => o.Status.StartsWith("p"))).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Any(o => o.Status.StartsWith("p"))).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -608,7 +608,7 @@ internal class CrossDialectSubqueryTests
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND ([sq0].[Status] LIKE 'p%'))");
 
         // 'Pending' starts with 'P' — only Alice has a Pending order (order 2)
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
     }
@@ -619,13 +619,13 @@ internal class CrossDialectSubqueryTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Orders.Any(o => o.Status.EndsWith("ped"))).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Any(o => o.Status.EndsWith("ped"))).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Any(o => o.Status.EndsWith("ped"))).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Any(o => o.Status.EndsWith("ped"))).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Any(o => o.Status.EndsWith("ped"))).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Any(o => o.Status.EndsWith("ped"))).Prepare();
+        var my = My.Users().Where(u => u.Orders.Any(o => o.Status.EndsWith("ped"))).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Any(o => o.Status.EndsWith("ped"))).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -634,10 +634,10 @@ internal class CrossDialectSubqueryTests
             mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE EXISTS (SELECT 1 FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId` AND (`sq0`.`Status` LIKE '%ped'))",
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND ([sq0].[Status] LIKE '%ped'))");
 
-        Assert.That(lite.ToDiagnostics().Parameters, Has.Count.EqualTo(0));
+        Assert.That(lt.ToDiagnostics().Parameters, Has.Count.EqualTo(0));
 
         // 'Shipped' ends with 'ped' — Alice (order 1) and Bob (order 3) have Shipped orders
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
     }
 
@@ -650,13 +650,13 @@ internal class CrossDialectSubqueryTests
         // Mutable captured variable — must stay parameterized, not inlined
         var search = GetSubquerySearchValue();
 
-        var lite = Lite.Users().Where(u => u.Orders.Any(o => o.Status.Contains(search))).Select(u => (u.UserId, u.UserName)).Prepare();
-        var pg   = Pg.Users().Where(u => u.Orders.Any(o => o.Status.Contains(search))).Prepare();
-        var my   = My.Users().Where(u => u.Orders.Any(o => o.Status.Contains(search))).Prepare();
-        var ss   = Ss.Users().Where(u => u.Orders.Any(o => o.Status.Contains(search))).Prepare();
+        var lt = Lite.Users().Where(u => u.Orders.Any(o => o.Status.Contains(search))).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Any(o => o.Status.Contains(search))).Prepare();
+        var my = My.Users().Where(u => u.Orders.Any(o => o.Status.Contains(search))).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Any(o => o.Status.Contains(search))).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
+            lt.ToDiagnostics(),
             pg.ToDiagnostics(),
             my.ToDiagnostics(),
             ss.ToDiagnostics(),
@@ -665,10 +665,10 @@ internal class CrossDialectSubqueryTests
             mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE EXISTS (SELECT 1 FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId` AND (`sq0`.`Status` LIKE CONCAT('%', ?, '%')))",
             ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE EXISTS (SELECT 1 FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND ([sq0].[Status] LIKE '%' + @p0 + '%'))");
 
-        Assert.That(lite.ToDiagnostics().Parameters, Has.Count.EqualTo(1));
+        Assert.That(lt.ToDiagnostics().Parameters, Has.Count.EqualTo(1));
 
         // 'Shipped' contains 'hipp' — Alice (order 1) and Bob (order 3) have Shipped orders
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
     }
 

--- a/src/Quarry.Tests/SqlOutput/CrossDialectTypeMappingTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectTypeMappingTests.cs
@@ -29,20 +29,20 @@ internal class CrossDialectTypeMappingTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Accounts().Insert(new Account { UserId = 1, AccountName = "Savings", Balance = new Money(100m), CreditLimit = new Money(500m), IsActive = true }).Prepare();
-        var pg   = Pg.Accounts().Insert(new Pg.Account { UserId = 1, AccountName = "Savings", Balance = new Money(100m), CreditLimit = new Money(500m), IsActive = true }).Prepare();
-        var my   = My.Accounts().Insert(new My.Account { UserId = 1, AccountName = "Savings", Balance = new Money(100m), CreditLimit = new Money(500m), IsActive = true }).Prepare();
-        var ss   = Ss.Accounts().Insert(new Ss.Account { UserId = 1, AccountName = "Savings", Balance = new Money(100m), CreditLimit = new Money(500m), IsActive = true }).Prepare();
+        var lt= Lite.Accounts().Insert(new Account { UserId = 1, AccountName = "Savings", Balance = new Money(100m), CreditLimit = new Money(500m), IsActive = true }).Prepare();
+        var pg = Pg.Accounts().Insert(new Pg.Account { UserId = 1, AccountName = "Savings", Balance = new Money(100m), CreditLimit = new Money(500m), IsActive = true }).Prepare();
+        var my = My.Accounts().Insert(new My.Account { UserId = 1, AccountName = "Savings", Balance = new Money(100m), CreditLimit = new Money(500m), IsActive = true }).Prepare();
+        var ss = Ss.Accounts().Insert(new Ss.Account { UserId = 1, AccountName = "Savings", Balance = new Money(100m), CreditLimit = new Money(500m), IsActive = true }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "INSERT INTO \"accounts\" (\"UserId\", \"AccountName\", \"Balance\", \"credit_limit\", \"IsActive\") VALUES (@p0, @p1, @p2, @p3, @p4) RETURNING \"AccountId\"",
             pg:     "INSERT INTO \"accounts\" (\"UserId\", \"AccountName\", \"Balance\", \"credit_limit\", \"IsActive\") VALUES ($1, $2, $3, $4, $5) RETURNING \"AccountId\"",
             mysql:  "INSERT INTO `accounts` (`UserId`, `AccountName`, `Balance`, `credit_limit`, `IsActive`) VALUES (?, ?, ?, ?, ?); SELECT LAST_INSERT_ID()",
             ss:     "INSERT INTO [accounts] ([UserId], [AccountName], [Balance], [credit_limit], [IsActive]) VALUES (@p0, @p1, @p2, @p3, @p4) OUTPUT INSERTED.[AccountId]");
 
-        var newId = await lite.ExecuteScalarAsync<int>();
+        var newId = await lt.ExecuteScalarAsync<int>();
         Assert.That(newId, Is.GreaterThan(0));
     }
 
@@ -52,20 +52,20 @@ internal class CrossDialectTypeMappingTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Accounts().Insert(new Account { UserId = 1, AccountName = "Checking", Balance = new Money(0m) }).Prepare();
-        var pg   = Pg.Accounts().Insert(new Pg.Account { UserId = 1, AccountName = "Checking", Balance = new Money(0m) }).Prepare();
-        var my   = My.Accounts().Insert(new My.Account { UserId = 1, AccountName = "Checking", Balance = new Money(0m) }).Prepare();
-        var ss   = Ss.Accounts().Insert(new Ss.Account { UserId = 1, AccountName = "Checking", Balance = new Money(0m) }).Prepare();
+        var lt= Lite.Accounts().Insert(new Account { UserId = 1, AccountName = "Checking", Balance = new Money(0m) }).Prepare();
+        var pg = Pg.Accounts().Insert(new Pg.Account { UserId = 1, AccountName = "Checking", Balance = new Money(0m) }).Prepare();
+        var my = My.Accounts().Insert(new My.Account { UserId = 1, AccountName = "Checking", Balance = new Money(0m) }).Prepare();
+        var ss = Ss.Accounts().Insert(new Ss.Account { UserId = 1, AccountName = "Checking", Balance = new Money(0m) }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "INSERT INTO \"accounts\" (\"UserId\", \"AccountName\", \"Balance\") VALUES (@p0, @p1, @p2) RETURNING \"AccountId\"",
             pg:     "INSERT INTO \"accounts\" (\"UserId\", \"AccountName\", \"Balance\") VALUES ($1, $2, $3) RETURNING \"AccountId\"",
             mysql:  "INSERT INTO `accounts` (`UserId`, `AccountName`, `Balance`) VALUES (?, ?, ?); SELECT LAST_INSERT_ID()",
             ss:     "INSERT INTO [accounts] ([UserId], [AccountName], [Balance]) VALUES (@p0, @p1, @p2) OUTPUT INSERTED.[AccountId]");
 
-        var newId = await lite.ExecuteScalarAsync<int>();
+        var newId = await lt.ExecuteScalarAsync<int>();
         Assert.That(newId, Is.GreaterThan(0));
     }
 
@@ -79,20 +79,20 @@ internal class CrossDialectTypeMappingTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Accounts().Select(a => (a.AccountId, a.Balance)).Prepare();
-        var pg   = Pg.Accounts().Select(a => (a.AccountId, a.Balance)).Prepare();
-        var my   = My.Accounts().Select(a => (a.AccountId, a.Balance)).Prepare();
-        var ss   = Ss.Accounts().Select(a => (a.AccountId, a.Balance)).Prepare();
+        var lt= Lite.Accounts().Select(a => (a.AccountId, a.Balance)).Prepare();
+        var pg = Pg.Accounts().Select(a => (a.AccountId, a.Balance)).Prepare();
+        var my = My.Accounts().Select(a => (a.AccountId, a.Balance)).Prepare();
+        var ss = Ss.Accounts().Select(a => (a.AccountId, a.Balance)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"AccountId\", \"Balance\" FROM \"accounts\"",
             pg:     "SELECT \"AccountId\", \"Balance\" FROM \"accounts\"",
             mysql:  "SELECT `AccountId`, `Balance` FROM `accounts`",
             ss:     "SELECT [AccountId], [Balance] FROM [accounts]");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(3));
         var savings = results.First(r => r.AccountId == 1);
         Assert.That(savings.Balance, Is.EqualTo(new Money(1000.50m)));
@@ -104,20 +104,20 @@ internal class CrossDialectTypeMappingTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Accounts().Where(a => a.AccountId == 1).Select(a => (a.AccountId, a.AccountName, a.Balance, a.CreditLimit, a.IsActive)).Prepare();
-        var pg   = Pg.Accounts().Where(a => a.AccountId == 1).Select(a => (a.AccountId, a.AccountName, a.Balance, a.CreditLimit, a.IsActive)).Prepare();
-        var my   = My.Accounts().Where(a => a.AccountId == 1).Select(a => (a.AccountId, a.AccountName, a.Balance, a.CreditLimit, a.IsActive)).Prepare();
-        var ss   = Ss.Accounts().Where(a => a.AccountId == 1).Select(a => (a.AccountId, a.AccountName, a.Balance, a.CreditLimit, a.IsActive)).Prepare();
+        var lt= Lite.Accounts().Where(a => a.AccountId == 1).Select(a => (a.AccountId, a.AccountName, a.Balance, a.CreditLimit, a.IsActive)).Prepare();
+        var pg = Pg.Accounts().Where(a => a.AccountId == 1).Select(a => (a.AccountId, a.AccountName, a.Balance, a.CreditLimit, a.IsActive)).Prepare();
+        var my = My.Accounts().Where(a => a.AccountId == 1).Select(a => (a.AccountId, a.AccountName, a.Balance, a.CreditLimit, a.IsActive)).Prepare();
+        var ss = Ss.Accounts().Where(a => a.AccountId == 1).Select(a => (a.AccountId, a.AccountName, a.Balance, a.CreditLimit, a.IsActive)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"AccountId\", \"AccountName\", \"Balance\", \"credit_limit\", \"IsActive\" FROM \"accounts\" WHERE \"AccountId\" = 1",
             pg:     "SELECT \"AccountId\", \"AccountName\", \"Balance\", \"credit_limit\", \"IsActive\" FROM \"accounts\" WHERE \"AccountId\" = 1",
             mysql:  "SELECT `AccountId`, `AccountName`, `Balance`, `credit_limit`, `IsActive` FROM `accounts` WHERE `AccountId` = 1",
             ss:     "SELECT [AccountId], [AccountName], [Balance], [credit_limit], [IsActive] FROM [accounts] WHERE [AccountId] = 1");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].AccountName, Is.EqualTo("Savings"));
         Assert.That(results[0].Balance, Is.EqualTo(new Money(1000.50m)));
@@ -134,20 +134,20 @@ internal class CrossDialectTypeMappingTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Accounts().Where(a => a.IsActive == true).Select(a => (a.AccountId, a.AccountName)).Prepare();
-        var pg   = Pg.Accounts().Where(a => a.IsActive == true).Select(a => (a.AccountId, a.AccountName)).Prepare();
-        var my   = My.Accounts().Where(a => a.IsActive == true).Select(a => (a.AccountId, a.AccountName)).Prepare();
-        var ss   = Ss.Accounts().Where(a => a.IsActive == true).Select(a => (a.AccountId, a.AccountName)).Prepare();
+        var lt= Lite.Accounts().Where(a => a.IsActive == true).Select(a => (a.AccountId, a.AccountName)).Prepare();
+        var pg = Pg.Accounts().Where(a => a.IsActive == true).Select(a => (a.AccountId, a.AccountName)).Prepare();
+        var my = My.Accounts().Where(a => a.IsActive == true).Select(a => (a.AccountId, a.AccountName)).Prepare();
+        var ss = Ss.Accounts().Where(a => a.IsActive == true).Select(a => (a.AccountId, a.AccountName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(), pg.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
             my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"AccountId\", \"AccountName\" FROM \"accounts\" WHERE \"IsActive\" = 1",
             pg:     "SELECT \"AccountId\", \"AccountName\" FROM \"accounts\" WHERE \"IsActive\" = TRUE",
             mysql:  "SELECT `AccountId`, `AccountName` FROM `accounts` WHERE `IsActive` = 1",
             ss:     "SELECT [AccountId], [AccountName] FROM [accounts] WHERE [IsActive] = 1");
 
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results.All(r => r.AccountName is "Savings" or "Checking"), Is.True);
     }
@@ -165,6 +165,7 @@ internal class CrossDialectTypeMappingTests
         var money = new Money(42.42m);
         var creditLimit = new Money(100m);
 
+        // INSERT setup (Lite-only)
         await Lite.Accounts().Insert(new Account
         {
             UserId = 2,
@@ -174,11 +175,21 @@ internal class CrossDialectTypeMappingTests
             IsActive = true
         }).ExecuteNonQueryAsync();
 
-        var results = await Lite.Accounts()
-            .Where(a => a.AccountName == "RoundTrip")
-            .Select(a => (a.AccountName, a.Balance, a.CreditLimit))
-            .ExecuteFetchAllAsync();
+        // SELECT: cross-dialect SQL assertion
+        var lt = Lite.Accounts().Where(a => a.AccountName == "RoundTrip").Select(a => (a.AccountName, a.Balance, a.CreditLimit)).Prepare();
+        var pg = Pg.Accounts().Where(a => a.AccountName == "RoundTrip").Select(a => (a.AccountName, a.Balance, a.CreditLimit)).Prepare();
+        var my = My.Accounts().Where(a => a.AccountName == "RoundTrip").Select(a => (a.AccountName, a.Balance, a.CreditLimit)).Prepare();
+        var ss = Ss.Accounts().Where(a => a.AccountName == "RoundTrip").Select(a => (a.AccountName, a.Balance, a.CreditLimit)).Prepare();
 
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"AccountName\", \"Balance\", \"credit_limit\" FROM \"accounts\" WHERE \"AccountName\" = @p0",
+            pg:     "SELECT \"AccountName\", \"Balance\", \"credit_limit\" FROM \"accounts\" WHERE \"AccountName\" = $1",
+            mysql:  "SELECT `AccountName`, `Balance`, `credit_limit` FROM `accounts` WHERE `AccountName` = ?",
+            ss:     "SELECT [AccountName], [Balance], [credit_limit] FROM [accounts] WHERE [AccountName] = @p0");
+
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0].Balance, Is.EqualTo(money));
         Assert.That(results[0].CreditLimit, Is.EqualTo(creditLimit));

--- a/src/Quarry.Tests/SqlOutput/CrossDialectUpdateTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectUpdateTests.cs
@@ -17,19 +17,20 @@ internal class CrossDialectUpdateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).Prepare();
+        var lt = Lite.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).Prepare();
+        var pg = Pg.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).Prepare();
+        var my = My.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).Prepare();
+        var ss = Ss.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).ToDiagnostics(),
-            My.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).ToDiagnostics(),
-            Ss.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "UPDATE \"users\" SET \"UserName\" = 'NewName' WHERE \"UserId\" = 1",
             pg:     "UPDATE \"users\" SET \"UserName\" = 'NewName' WHERE \"UserId\" = 1",
             mysql:  "UPDATE `users` SET `UserName` = 'NewName' WHERE `UserId` = 1",
             ss:     "UPDATE [users] SET [UserName] = 'NewName' WHERE [UserId] = 1");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(1));
     }
 
@@ -39,20 +40,21 @@ internal class CrossDialectUpdateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).Prepare();
+        var lt = Lite.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).Prepare();
+        var pg = Pg.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).Prepare();
+        var my = My.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).Prepare();
+        var ss = Ss.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).ToDiagnostics(),
-            My.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).ToDiagnostics(),
-            Ss.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "UPDATE \"users\" SET \"IsActive\" = 0 WHERE \"IsActive\" = 1",
             pg:     "UPDATE \"users\" SET \"IsActive\" = FALSE WHERE \"IsActive\" = TRUE",
             mysql:  "UPDATE `users` SET `IsActive` = 0 WHERE `IsActive` = 1",
             ss:     "UPDATE [users] SET [IsActive] = 0 WHERE [IsActive] = 1");
 
         // Seed has 2 active users (Alice, Bob)
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(2));
     }
 
@@ -66,19 +68,20 @@ internal class CrossDialectUpdateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Update().Set(new User { UserName = "New", IsActive = false }).Where(u => u.UserId == 1).Prepare();
+        var lt = Lite.Users().Update().Set(new User { UserName = "New", IsActive = false }).Where(u => u.UserId == 1).Prepare();
+        var pg = Pg.Users().Update().Set(new Pg.User { UserName = "New", IsActive = false }).Where(u => u.UserId == 1).Prepare();
+        var my = My.Users().Update().Set(new My.User { UserName = "New", IsActive = false }).Where(u => u.UserId == 1).Prepare();
+        var ss = Ss.Users().Update().Set(new Ss.User { UserName = "New", IsActive = false }).Where(u => u.UserId == 1).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Update().Set(new Pg.User { UserName = "New", IsActive = false }).Where(u => u.UserId == 1).ToDiagnostics(),
-            My.Users().Update().Set(new My.User { UserName = "New", IsActive = false }).Where(u => u.UserId == 1).ToDiagnostics(),
-            Ss.Users().Update().Set(new Ss.User { UserName = "New", IsActive = false }).Where(u => u.UserId == 1).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "UPDATE \"users\" SET \"UserName\" = @p0, \"IsActive\" = @p1 WHERE \"UserId\" = 1",
             pg:     "UPDATE \"users\" SET \"UserName\" = $1, \"IsActive\" = $2 WHERE \"UserId\" = 1",
             mysql:  "UPDATE `users` SET `UserName` = ?, `IsActive` = ? WHERE `UserId` = 1",
             ss:     "UPDATE [users] SET [UserName] = @p0, [IsActive] = @p1 WHERE [UserId] = 1");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(1));
     }
 
@@ -92,19 +95,20 @@ internal class CrossDialectUpdateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
+        var lt = Lite.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
+        var pg = Pg.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
+        var my = My.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
+        var ss = Ss.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).ToDiagnostics(),
-            My.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).ToDiagnostics(),
-            Ss.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "UPDATE \"users\" SET \"UserName\" = 'x', \"IsActive\" = 0 WHERE \"UserId\" = 1",
             pg:     "UPDATE \"users\" SET \"UserName\" = 'x', \"IsActive\" = FALSE WHERE \"UserId\" = 1",
             mysql:  "UPDATE `users` SET `UserName` = 'x', `IsActive` = 0 WHERE `UserId` = 1",
             ss:     "UPDATE [users] SET [UserName] = 'x', [IsActive] = 0 WHERE [UserId] = 1");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(1));
     }
 
@@ -119,20 +123,21 @@ internal class CrossDialectUpdateTests
         var (Lite, Pg, My, Ss) = t;
 
         var id = 5;
-        var lite = Lite.Users().Update().Set(u => u.UserName = "x").Where(u => u.UserId == id).Prepare();
+        var lt = Lite.Users().Update().Set(u => u.UserName = "x").Where(u => u.UserId == id).Prepare();
+        var pg = Pg.Users().Update().Set(u => u.UserName = "x").Where(u => u.UserId == id).Prepare();
+        var my = My.Users().Update().Set(u => u.UserName = "x").Where(u => u.UserId == id).Prepare();
+        var ss = Ss.Users().Update().Set(u => u.UserName = "x").Where(u => u.UserId == id).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Update().Set(u => u.UserName = "x").Where(u => u.UserId == id).ToDiagnostics(),
-            My.Users().Update().Set(u => u.UserName = "x").Where(u => u.UserId == id).ToDiagnostics(),
-            Ss.Users().Update().Set(u => u.UserName = "x").Where(u => u.UserId == id).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "UPDATE \"users\" SET \"UserName\" = 'x' WHERE \"UserId\" = @p0",
             pg:     "UPDATE \"users\" SET \"UserName\" = 'x' WHERE \"UserId\" = $1",
             mysql:  "UPDATE `users` SET `UserName` = 'x' WHERE `UserId` = ?",
             ss:     "UPDATE [users] SET [UserName] = 'x' WHERE [UserId] = @p0");
 
         // UserId 5 doesn't exist in seed data — 0 rows affected
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(0));
     }
 
@@ -146,19 +151,20 @@ internal class CrossDialectUpdateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).Prepare();
+        var lt = Lite.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).Prepare();
+        var pg = Pg.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).Prepare();
+        var my = My.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).Prepare();
+        var ss = Ss.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).ToDiagnostics(),
-            My.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).ToDiagnostics(),
-            Ss.Users().Update().Set(u => u.UserName = "NewName").Where(u => u.UserId == 1).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "UPDATE \"users\" SET \"UserName\" = 'NewName' WHERE \"UserId\" = 1",
             pg:     "UPDATE \"users\" SET \"UserName\" = 'NewName' WHERE \"UserId\" = 1",
             mysql:  "UPDATE `users` SET `UserName` = 'NewName' WHERE `UserId` = 1",
             ss:     "UPDATE [users] SET [UserName] = 'NewName' WHERE [UserId] = 1");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(1));
     }
 
@@ -168,20 +174,21 @@ internal class CrossDialectUpdateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).Prepare();
+        var lt = Lite.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).Prepare();
+        var pg = Pg.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).Prepare();
+        var my = My.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).Prepare();
+        var ss = Ss.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).ToDiagnostics(),
-            My.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).ToDiagnostics(),
-            Ss.Users().Update().Set(u => u.IsActive = false).Where(u => u.IsActive).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "UPDATE \"users\" SET \"IsActive\" = 0 WHERE \"IsActive\" = 1",
             pg:     "UPDATE \"users\" SET \"IsActive\" = FALSE WHERE \"IsActive\" = TRUE",
             mysql:  "UPDATE `users` SET `IsActive` = 0 WHERE `IsActive` = 1",
             ss:     "UPDATE [users] SET [IsActive] = 0 WHERE [IsActive] = 1");
 
         // 2 active users in seed
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(2));
     }
 
@@ -195,19 +202,20 @@ internal class CrossDialectUpdateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
+        var lt = Lite.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
+        var pg = Pg.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
+        var my = My.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
+        var ss = Ss.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).ToDiagnostics(),
-            My.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).ToDiagnostics(),
-            Ss.Users().Update().Set(u => { u.UserName = "x"; u.IsActive = false; }).Where(u => u.UserId == 1).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "UPDATE \"users\" SET \"UserName\" = 'x', \"IsActive\" = 0 WHERE \"UserId\" = 1",
             pg:     "UPDATE \"users\" SET \"UserName\" = 'x', \"IsActive\" = FALSE WHERE \"UserId\" = 1",
             mysql:  "UPDATE `users` SET `UserName` = 'x', `IsActive` = 0 WHERE `UserId` = 1",
             ss:     "UPDATE [users] SET [UserName] = 'x', [IsActive] = 0 WHERE [UserId] = 1");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(1));
     }
 
@@ -221,19 +229,20 @@ internal class CrossDialectUpdateTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Update().Set(u => u.UserName = "x").Set(u => u.IsActive = false).Where(u => u.UserId == 1).Prepare();
+        var lt = Lite.Users().Update().Set(u => u.UserName = "x").Set(u => u.IsActive = false).Where(u => u.UserId == 1).Prepare();
+        var pg = Pg.Users().Update().Set(u => u.UserName = "x").Set(u => u.IsActive = false).Where(u => u.UserId == 1).Prepare();
+        var my = My.Users().Update().Set(u => u.UserName = "x").Set(u => u.IsActive = false).Where(u => u.UserId == 1).Prepare();
+        var ss = Ss.Users().Update().Set(u => u.UserName = "x").Set(u => u.IsActive = false).Where(u => u.UserId == 1).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Update().Set(u => u.UserName = "x").Set(u => u.IsActive = false).Where(u => u.UserId == 1).ToDiagnostics(),
-            My.Users().Update().Set(u => u.UserName = "x").Set(u => u.IsActive = false).Where(u => u.UserId == 1).ToDiagnostics(),
-            Ss.Users().Update().Set(u => u.UserName = "x").Set(u => u.IsActive = false).Where(u => u.UserId == 1).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "UPDATE \"users\" SET \"UserName\" = 'x', \"IsActive\" = 0 WHERE \"UserId\" = 1",
             pg:     "UPDATE \"users\" SET \"UserName\" = 'x', \"IsActive\" = FALSE WHERE \"UserId\" = 1",
             mysql:  "UPDATE `users` SET `UserName` = 'x', `IsActive` = 0 WHERE `UserId` = 1",
             ss:     "UPDATE [users] SET [UserName] = 'x', [IsActive] = 0 WHERE [UserId] = 1");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(1));
     }
 
@@ -248,19 +257,20 @@ internal class CrossDialectUpdateTests
         var (Lite, Pg, My, Ss) = t;
 
         var name = "captured";
-        var lite = Lite.Users().Update().Set(u => u.UserName = name).Where(u => u.UserId == 1).Prepare();
+        var lt = Lite.Users().Update().Set(u => u.UserName = name).Where(u => u.UserId == 1).Prepare();
+        var pg = Pg.Users().Update().Set(u => u.UserName = name).Where(u => u.UserId == 1).Prepare();
+        var my = My.Users().Update().Set(u => u.UserName = name).Where(u => u.UserId == 1).Prepare();
+        var ss = Ss.Users().Update().Set(u => u.UserName = name).Where(u => u.UserId == 1).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Update().Set(u => u.UserName = name).Where(u => u.UserId == 1).ToDiagnostics(),
-            My.Users().Update().Set(u => u.UserName = name).Where(u => u.UserId == 1).ToDiagnostics(),
-            Ss.Users().Update().Set(u => u.UserName = name).Where(u => u.UserId == 1).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "UPDATE \"users\" SET \"UserName\" = @p0 WHERE \"UserId\" = 1",
             pg:     "UPDATE \"users\" SET \"UserName\" = $1 WHERE \"UserId\" = 1",
             mysql:  "UPDATE `users` SET `UserName` = ? WHERE `UserId` = 1",
             ss:     "UPDATE [users] SET [UserName] = @p0 WHERE [UserId] = 1");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(1));
     }
 
@@ -271,19 +281,20 @@ internal class CrossDialectUpdateTests
         var (Lite, Pg, My, Ss) = t;
 
         var name = "captured";
-        var lite = Lite.Users().Update().Set(u => { u.UserName = name; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
+        var lt = Lite.Users().Update().Set(u => { u.UserName = name; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
+        var pg = Pg.Users().Update().Set(u => { u.UserName = name; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
+        var my = My.Users().Update().Set(u => { u.UserName = name; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
+        var ss = Ss.Users().Update().Set(u => { u.UserName = name; u.IsActive = false; }).Where(u => u.UserId == 1).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Update().Set(u => { u.UserName = name; u.IsActive = false; }).Where(u => u.UserId == 1).ToDiagnostics(),
-            My.Users().Update().Set(u => { u.UserName = name; u.IsActive = false; }).Where(u => u.UserId == 1).ToDiagnostics(),
-            Ss.Users().Update().Set(u => { u.UserName = name; u.IsActive = false; }).Where(u => u.UserId == 1).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "UPDATE \"users\" SET \"UserName\" = @p0, \"IsActive\" = 0 WHERE \"UserId\" = 1",
             pg:     "UPDATE \"users\" SET \"UserName\" = $1, \"IsActive\" = FALSE WHERE \"UserId\" = 1",
             mysql:  "UPDATE `users` SET `UserName` = ?, `IsActive` = 0 WHERE `UserId` = 1",
             ss:     "UPDATE [users] SET [UserName] = @p0, [IsActive] = 0 WHERE [UserId] = 1");
 
-        var affected = await lite.ExecuteNonQueryAsync();
+        var affected = await lt.ExecuteNonQueryAsync();
         Assert.That(affected, Is.EqualTo(1));
     }
 
@@ -298,11 +309,14 @@ internal class CrossDialectUpdateTests
         var (Lite, Pg, My, Ss) = t;
 
         // SQL-only verification — accounts table not in harness schema
+        var lt = Lite.Accounts().Update().Set(a => a.Balance = new Money(200m)).Where(a => a.AccountId == 1).Prepare();
+        var pg = Pg.Accounts().Update().Set(a => a.Balance = new Money(200m)).Where(a => a.AccountId == 1).Prepare();
+        var my = My.Accounts().Update().Set(a => a.Balance = new Money(200m)).Where(a => a.AccountId == 1).Prepare();
+        var ss = Ss.Accounts().Update().Set(a => a.Balance = new Money(200m)).Where(a => a.AccountId == 1).Prepare();
+
         QueryTestHarness.AssertDialects(
-            Lite.Accounts().Update().Set(a => a.Balance = new Money(200m)).Where(a => a.AccountId == 1).ToDiagnostics(),
-            Pg.Accounts().Update().Set(a => a.Balance = new Money(200m)).Where(a => a.AccountId == 1).ToDiagnostics(),
-            My.Accounts().Update().Set(a => a.Balance = new Money(200m)).Where(a => a.AccountId == 1).ToDiagnostics(),
-            Ss.Accounts().Update().Set(a => a.Balance = new Money(200m)).Where(a => a.AccountId == 1).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "UPDATE \"accounts\" SET \"Balance\" = @p0 WHERE \"AccountId\" = 1",
             pg:     "UPDATE \"accounts\" SET \"Balance\" = $1 WHERE \"AccountId\" = 1",
             mysql:  "UPDATE `accounts` SET `Balance` = ? WHERE `AccountId` = 1",

--- a/src/Quarry.Tests/SqlOutput/CrossDialectWhereTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectWhereTests.cs
@@ -17,20 +17,21 @@ internal class CrossDialectWhereTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.IsActive).Prepare();
+        var lt = Lite.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.IsActive).ToDiagnostics(),
-            My.Users().Where(u => u.IsActive).ToDiagnostics(),
-            Ss.Users().Where(u => u.IsActive).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"IsActive\" = 1",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"IsActive\" = TRUE",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE `IsActive` = 1",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE [IsActive] = 1");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"IsActive\" = 1",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"IsActive\" = TRUE",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `IsActive` = 1",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [IsActive] = 1");
 
         // Execution: 2 active users
-        var results = await Lite.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((2, "Bob")));
@@ -42,20 +43,21 @@ internal class CrossDialectWhereTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => !u.IsActive).Prepare();
+        var lt = Lite.Users().Where(u => !u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => !u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => !u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => !u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => !u.IsActive).ToDiagnostics(),
-            My.Users().Where(u => !u.IsActive).ToDiagnostics(),
-            Ss.Users().Where(u => !u.IsActive).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE NOT (\"IsActive\")",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE NOT (\"IsActive\")",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE NOT (`IsActive`)",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE NOT ([IsActive])");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE NOT (\"IsActive\")",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE NOT (\"IsActive\")",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE NOT (`IsActive`)",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE NOT ([IsActive])");
 
         // Execution: 1 inactive user
-        var results = await Lite.Users().Where(u => !u.IsActive).Select(u => (u.UserId, u.UserName)).ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0], Is.EqualTo((3, "Charlie")));
     }
@@ -70,20 +72,21 @@ internal class CrossDialectWhereTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.UserId > 0).Prepare();
+        var lt = Lite.Users().Where(u => u.UserId > 1).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserId > 1).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserId > 1).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserId > 1).Select(u => (u.UserId, u.UserName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.UserId > 0).ToDiagnostics(),
-            My.Users().Where(u => u.UserId > 0).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserId > 0).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserId\" > 0",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserId\" > 0",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE `UserId` > 0",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE [UserId] > 0");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserId\" > 1",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserId\" > 1",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `UserId` > 1",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [UserId] > 1");
 
-        // Execution: all 3 users have UserId > 0; integration uses > 1 yielding 2
-        var results = await Lite.Users().Where(u => u.UserId > 1).Select(u => (u.UserId, u.UserName)).ExecuteFetchAllAsync();
+        // Execution: 2 users with UserId > 1
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((2, "Bob")));
         Assert.That(results[1], Is.EqualTo((3, "Charlie")));
@@ -95,20 +98,21 @@ internal class CrossDialectWhereTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.UserId <= 100).Prepare();
+        var lt = Lite.Users().Where(u => u.UserId <= 2).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.UserId <= 2).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.UserId <= 2).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.UserId <= 2).Select(u => (u.UserId, u.UserName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.UserId <= 100).ToDiagnostics(),
-            My.Users().Where(u => u.UserId <= 100).ToDiagnostics(),
-            Ss.Users().Where(u => u.UserId <= 100).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserId\" <= 100",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"UserId\" <= 100",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE `UserId` <= 100",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE [UserId] <= 100");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserId\" <= 2",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"UserId\" <= 2",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `UserId` <= 2",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [UserId] <= 2");
 
-        // Execution: integration uses <= 2 yielding 2 results
-        var results = await Lite.Users().Where(u => u.UserId <= 2).Select(u => (u.UserId, u.UserName)).ExecuteFetchAllAsync();
+        // Execution: 2 users with UserId <= 2
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((2, "Bob")));
@@ -124,20 +128,21 @@ internal class CrossDialectWhereTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Email == null).Prepare();
+        var lt = Lite.Users().Where(u => u.Email == null).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Email == null).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.Email == null).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.Email == null).Select(u => (u.UserId, u.UserName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.Email == null).ToDiagnostics(),
-            My.Users().Where(u => u.Email == null).ToDiagnostics(),
-            Ss.Users().Where(u => u.Email == null).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"Email\" IS NULL",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"Email\" IS NULL",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE `Email` IS NULL",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE [Email] IS NULL");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"Email\" IS NULL",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"Email\" IS NULL",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `Email` IS NULL",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [Email] IS NULL");
 
         // Execution: Bob has null email
-        var results = await Lite.Users().Where(u => u.Email == null).Select(u => (u.UserId, u.UserName)).ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0], Is.EqualTo((2, "Bob")));
     }
@@ -148,20 +153,21 @@ internal class CrossDialectWhereTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Email != null).Prepare();
+        var lt = Lite.Users().Where(u => u.Email != null).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Email != null).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.Email != null).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.Email != null).Select(u => (u.UserId, u.UserName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.Email != null).ToDiagnostics(),
-            My.Users().Where(u => u.Email != null).ToDiagnostics(),
-            Ss.Users().Where(u => u.Email != null).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"Email\" IS NOT NULL",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE \"Email\" IS NOT NULL",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE `Email` IS NOT NULL",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE [Email] IS NOT NULL");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"Email\" IS NOT NULL",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"Email\" IS NOT NULL",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `Email` IS NOT NULL",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [Email] IS NOT NULL");
 
         // Execution: Alice and Charlie have non-null emails
-        var results = await Lite.Users().Where(u => u.Email != null).Select(u => (u.UserId, u.UserName)).ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((3, "Charlie")));
@@ -177,20 +183,21 @@ internal class CrossDialectWhereTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.IsActive).Where(u => u.UserId > 0).Prepare();
+        var lt = Lite.Users().Where(u => u.IsActive).Where(u => u.UserId > 0).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.IsActive).Where(u => u.UserId > 0).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.IsActive).Where(u => u.UserId > 0).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.IsActive).Where(u => u.UserId > 0).Select(u => (u.UserId, u.UserName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.IsActive).Where(u => u.UserId > 0).ToDiagnostics(),
-            My.Users().Where(u => u.IsActive).Where(u => u.UserId > 0).ToDiagnostics(),
-            Ss.Users().Where(u => u.IsActive).Where(u => u.UserId > 0).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (\"IsActive\" = 1) AND (\"UserId\" > 0)",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (\"IsActive\" = TRUE) AND (\"UserId\" > 0)",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (`IsActive` = 1) AND (`UserId` > 0)",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE ([IsActive] = 1) AND ([UserId] > 0)");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (\"IsActive\" = 1) AND (\"UserId\" > 0)",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (\"IsActive\" = TRUE) AND (\"UserId\" > 0)",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE (`IsActive` = 1) AND (`UserId` > 0)",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE ([IsActive] = 1) AND ([UserId] > 0)");
 
         // Execution: 2 active users with UserId > 0
-        var results = await Lite.Users().Where(u => u.IsActive).Where(u => u.UserId > 0).Select(u => (u.UserId, u.UserName)).ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((2, "Bob")));
@@ -202,20 +209,21 @@ internal class CrossDialectWhereTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.Email != null).Where(u => u.IsActive).Prepare();
+        var lt = Lite.Users().Where(u => u.Email != null).Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Email != null).Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.Email != null).Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.Email != null).Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.Email != null).Where(u => u.IsActive).ToDiagnostics(),
-            My.Users().Where(u => u.Email != null).Where(u => u.IsActive).ToDiagnostics(),
-            Ss.Users().Where(u => u.Email != null).Where(u => u.IsActive).ToDiagnostics(),
-            sqlite: "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (\"Email\" IS NOT NULL) AND (\"IsActive\" = 1)",
-            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (\"Email\" IS NOT NULL) AND (\"IsActive\" = TRUE)",
-            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (`Email` IS NOT NULL) AND (`IsActive` = 1)",
-            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE ([Email] IS NOT NULL) AND ([IsActive] = 1)");
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (\"Email\" IS NOT NULL) AND (\"IsActive\" = 1)",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (\"Email\" IS NOT NULL) AND (\"IsActive\" = TRUE)",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE (`Email` IS NOT NULL) AND (`IsActive` = 1)",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE ([Email] IS NOT NULL) AND ([IsActive] = 1)");
 
         // Execution: only Alice has non-null email AND is active
-        var results = await Lite.Users().Where(u => u.Email != null).Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(1));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
     }
@@ -230,20 +238,21 @@ internal class CrossDialectWhereTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var lt = Lite.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).ToDiagnostics(),
-            My.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).ToDiagnostics(),
-            Ss.Users().Where(u => u.IsActive).Select(u => (u.UserId, u.UserName)).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"IsActive\" = 1",
             pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"IsActive\" = TRUE",
             mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `IsActive` = 1",
             ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [IsActive] = 1");
 
         // Execution: 2 active users
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
         Assert.That(results[1], Is.EqualTo((2, "Bob")));
@@ -255,20 +264,21 @@ internal class CrossDialectWhereTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
-        var lite = Lite.Users().Where(u => u.IsActive).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var lt = Lite.Users().Where(u => u.IsActive).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var pg = Pg.Users().Where(u => u.IsActive).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var my = My.Users().Where(u => u.IsActive).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
+        var ss = Ss.Users().Where(u => u.IsActive).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).Prepare();
 
         QueryTestHarness.AssertDialects(
-            lite.ToDiagnostics(),
-            Pg.Users().Where(u => u.IsActive).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            My.Users().Where(u => u.IsActive).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
-            Ss.Users().Where(u => u.IsActive).Select(u => new UserSummaryDto { UserId = u.UserId, UserName = u.UserName, IsActive = u.IsActive }).ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"IsActive\" = 1",
             pg:     "SELECT \"UserId\", \"UserName\", \"IsActive\" FROM \"users\" WHERE \"IsActive\" = TRUE",
             mysql:  "SELECT `UserId`, `UserName`, `IsActive` FROM `users` WHERE `IsActive` = 1",
             ss:     "SELECT [UserId], [UserName], [IsActive] FROM [users] WHERE [IsActive] = 1");
 
         // Execution: 2 active users as DTOs
-        var results = await lite.ExecuteFetchAllAsync();
+        var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(2));
         Assert.That(results[0].UserId, Is.EqualTo(1));
         Assert.That(results[0].UserName, Is.EqualTo("Alice"));


### PR DESCRIPTION
## Summary
- Closes #125
- Standardizes all 17 `CrossDialect*.cs` test files to a uniform structure where every test prepares all 4 dialect queries as separate variables (`lt`, `pg`, `my`, `ss`), always executes `lt` against SQLite for integration verification, and never builds a separate query for execution.

## Reason for Change
The cross-dialect tests had inconsistent patterns (A, B, C, D) across files: some inlined Pg/My/Ss in `AssertDialects`, some had separate execution queries, some lacked integration tests, and variable naming was inconsistent (`lite`/`liteSql` vs `lt`). This made the test suite harder to maintain and reason about.

## Impact
- **17 test files** modified, **~120 test methods** standardized
- **0 test logic changes** — all existing assertions preserved, SQL string updates only where projections changed
- **+385 net lines** — from added integration tests and extracted variables
- All 2178 tests pass

## Plan items implemented as specified
- Phase 1: Renamed `lite`/`liteSql` → `lt` across all Pattern B files (JoinTests, InsertTests, ComplexTests, CompositionTests, TypeMappingTests, SchemaTests, BatchInsertTests, SubqueryTests)
- Phase 2: Extracted inlined Pg/My/Ss into separate `.Prepare()` vars for Pattern A files (OrderByTests, DeleteTests, UpdateTests, AggregateTests, EnumTests)
- Phase 3: Full conversion of Pattern C/D tests — added `.Select()` projections, updated SQL strings, unified execution queries (WhereTests, SelectTests, StringOpTests, MiscTests)
- Phase 4: Converted 9 Lite-only tests to cross-dialect (3 EnumTests, 5 CompositionTests conditional tests, 1 TypeMappingTests round-trip test)
- Region organization added to SelectTests, updated in EnumTests
- Out-of-scope files/tests left untouched as specified

## Deviations from plan implemented
- BatchInsert execution tests unified — the plan said "leave two-query pattern as-is" but per user feedback, `CreatedAt` was included in the main `lt` query so the prepared query is directly executable (no separate `ltExec`)
- Variable alignment normalized — `var pg   =` padding removed since all vars are 2 chars

## Gaps in original plan implemented
- None identified

## Migration Steps
No migration needed — test-only changes.

## Performance Considerations
No runtime performance impact — test infrastructure only.

## Security Considerations
None — test code only.

## Breaking Changes
- Consumer-facing: None
- Internal: None