### PR TITLE
Make interceptor-referenced types public for consuming projects

### DIFF
--- a/src/Quarry/Internal/OpId.cs
+++ b/src/Quarry/Internal/OpId.cs
@@ -1,14 +1,18 @@
+using System.ComponentModel;
+
 namespace Quarry.Internal;
 
 /// <summary>
 /// Generates monotonically increasing operation IDs for correlating log entries.
+/// This type is used by generated interceptor code and is not intended for direct use.
 /// </summary>
-internal static class OpId
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class OpId
 {
     private static long _next;
 
     /// <summary>
     /// Returns the next operation ID.
     /// </summary>
-    internal static long Next() => Interlocked.Increment(ref _next);
+    public static long Next() => Interlocked.Increment(ref _next);
 }

--- a/src/Quarry/Internal/QueryExecutor.cs
+++ b/src/Quarry/Internal/QueryExecutor.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
@@ -20,10 +21,11 @@ internal enum ExecutionMode
 }
 
 /// <summary>
-/// Internal helper for executing carrier-optimized queries.
-/// All methods accept a pre-built DbCommand from the generated carrier interceptor.
+/// Executes carrier-optimized queries with pre-built commands.
+/// This type is used by generated interceptor code and is not intended for direct use.
 /// </summary>
-internal static class QueryExecutor
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class QueryExecutor
 {
     /// <summary>
     /// Executes a carrier-optimized query with a pre-built command and returns all results as a list.

--- a/src/Quarry/Logging/ParameterLog.cs
+++ b/src/Quarry/Logging/ParameterLog.cs
@@ -1,11 +1,17 @@
+using System.ComponentModel;
+
 namespace Quarry.Logging;
 
+/// <summary>
+/// Parameter logging infrastructure used by generated interceptor code. Not intended for direct use.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 [LogCategory("Quarry.Parameters")]
-internal static partial class ParameterLog
+public static partial class ParameterLog
 {
     [LogMessage(LogLevel.Trace, "[{opId}] @p{index} = {value}", AlwaysEmit = true)]
-    internal static partial void Bound(long opId, int index, string value);
+    public static partial void Bound(long opId, int index, string value);
 
     [LogMessage(LogLevel.Trace, "[{opId}] @p{index} = [SENSITIVE]", AlwaysEmit = true)]
-    internal static partial void BoundSensitive(long opId, int index);
+    public static partial void BoundSensitive(long opId, int index);
 }

--- a/src/Quarry/Logging/QueryLog.cs
+++ b/src/Quarry/Logging/QueryLog.cs
@@ -1,17 +1,23 @@
+using System.ComponentModel;
+
 namespace Quarry.Logging;
 
+/// <summary>
+/// Query logging infrastructure used by generated interceptor code. Not intended for direct use.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 [LogCategory("Quarry.Query")]
-internal static partial class QueryLog
+public static partial class QueryLog
 {
     [LogMessage(LogLevel.Debug, "[{opId}] SQL: {sql}", AlwaysEmit = true)]
-    internal static partial void SqlGenerated(long opId, string sql);
+    public static partial void SqlGenerated(long opId, string sql);
 
     [LogMessage(LogLevel.Debug, "[{opId}] Fetched {rowCount} rows in {elapsedMs:F1}ms", AlwaysEmit = true)]
-    internal static partial void FetchCompleted(long opId, int rowCount, double elapsedMs);
+    public static partial void FetchCompleted(long opId, int rowCount, double elapsedMs);
 
     [LogMessage(LogLevel.Debug, "[{opId}] Scalar result: {result}", AlwaysEmit = true)]
-    internal static partial void ScalarResult(long opId, string result);
+    public static partial void ScalarResult(long opId, string result);
 
     [LogMessage(LogLevel.Error, "[{opId}] Query failed")]
-    internal static partial void QueryFailed(long opId, Exception ex);
+    public static partial void QueryFailed(long opId, Exception ex);
 }


### PR DESCRIPTION
The source generator emits interceptor code into consuming projects that directly calls `OpId`, `QueryLog`, `ParameterLog`, and `QueryExecutor`. These types were `internal` to the Quarry assembly, causing 72 CS0122 accessibility errors in any external project using Quarry (e.g. MepSuite). This PR makes them `public` with `[EditorBrowsable(Never)]` so they are accessible to generated code but hidden from IntelliSense.

## Reason for Change
Generated interceptor code runs in the consuming project's compilation context, not within the Quarry assembly. When the generator emits calls to `OpId.Next()`, `QueryLog.SqlGenerated()`, `ParameterLog.Bound()`, and `QueryExecutor.Execute*()`, those types must be publicly accessible from the consumer. Logsmith-generated types (`LogsmithOutput`, `LogLevel`) were already public; these four hand-written types were not.

## Impact
Eliminates all 72 CS0122 build errors in consuming projects that use Quarry's source generator. No behavioral change — only accessibility modifiers and `[EditorBrowsable]` attributes added.

## Plan items implemented as specified
- `OpId` — class and `Next()` method changed from `internal` to `public`
- `QueryLog` — class and all four partial methods changed from `internal` to `public`; Logsmith mirrors the change automatically
- `ParameterLog` — class and both partial methods changed from `internal` to `public`; Logsmith mirrors the change automatically
- `QueryExecutor` — class changed from `internal` to `public` (methods were already `public`)
- All four types annotated with `[EditorBrowsable(EditorBrowsableState.Never)]`

## Deviations from plan implemented
None.

## Gaps in original plan implemented
None.

## Migration Steps
No migration needed. Drop-in fix — consumers rebuild and the CS0122 errors disappear.

## Performance Considerations
None. Only accessibility metadata changes; no runtime behavior affected.

## Security Considerations
Types that were previously internal are now public. They are implementation infrastructure (operation ID counter, logging stubs, ADO.NET command executor) and expose no sensitive functionality. `[EditorBrowsable(Never)]` discourages direct use.

## Breaking Changes
  - Consumer-facing: None (previously these types were inaccessible; now they are accessible but hidden from IntelliSense)
  - Internal: `InternalsVisibleTo` grants to test/sample projects still work but are no longer required for these four types