### PR TITLE
Fix sign-mismatched integer reader casts and make RawSql helpers public

### DIFF
--- a/src/Quarry.Generator/CodeGen/RawSqlBodyEmitter.cs
+++ b/src/Quarry.Generator/CodeGen/RawSqlBodyEmitter.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Quarry.Generators.IR;
 using Quarry.Generators.Models;
+using Quarry.Generators.Utilities;
 
 namespace Quarry.Generators.CodeGen;
 
@@ -44,7 +45,7 @@ internal static class RawSqlBodyEmitter
         if (rawSqlInfo.TypeKind == RawSqlTypeKind.Scalar)
         {
             var readerMethod = rawSqlInfo.ScalarReaderMethod ?? "GetValue";
-            var scalarRead = NeedsSignCast(resultType)
+            var scalarRead = TypeClassification.NeedsSignCast(resultType)
                 ? $"({resultType})r.{readerMethod}(0)"
                 : $"r.{readerMethod}(0)";
             sb.AppendLine($"        return self.RawSqlAsyncWithReader(");
@@ -151,7 +152,7 @@ internal static class RawSqlBodyEmitter
             return $"({prop.FullClrType})r.{prop.ReaderMethodName}(i)";
         }
 
-        if (NeedsSignCast(prop.ClrType))
+        if (TypeClassification.NeedsSignCast(prop.ClrType))
         {
             return $"({prop.ClrType})r.{prop.ReaderMethodName}(i)";
         }
@@ -184,9 +185,4 @@ internal static class RawSqlBodyEmitter
         };
     }
 
-    private static bool NeedsSignCast(string clrType)
-        => clrType is "uint" or "UInt32" or "System.UInt32"
-            or "ushort" or "UInt16" or "System.UInt16"
-            or "ulong" or "UInt64" or "System.UInt64"
-            or "sbyte" or "SByte" or "System.SByte";
 }

--- a/src/Quarry.Generator/Generation/InterceptorCodeGenerator.Utilities.cs
+++ b/src/Quarry.Generator/Generation/InterceptorCodeGenerator.Utilities.cs
@@ -8,6 +8,7 @@ using Quarry.Generators.Sql;
 using Quarry;
 using Quarry.Generators.Projection;
 using Quarry.Generators.Translation;
+using Quarry.Generators.Utilities;
 
 namespace Quarry.Generators.Generation;
 
@@ -374,27 +375,17 @@ internal static partial class InterceptorCodeGenerator
         {
             var baseType = GetNonNullableType(clrType);
             var baseReaderMethod = GetReaderMethod(baseType);
-            var readExpr = NeedsSignCast(baseType)
+            var readExpr = TypeClassification.NeedsSignCast(baseType)
                 ? $"({baseType})r.{baseReaderMethod}({ordinal})"
                 : $"r.{baseReaderMethod}({ordinal})";
             return $"r.IsDBNull({ordinal}) ? default({clrType}) : {readExpr}";
         }
 
         var readerMethod = GetReaderMethod(clrType);
-        if (NeedsSignCast(clrType))
+        if (TypeClassification.NeedsSignCast(clrType))
             return $"({clrType})r.{readerMethod}({ordinal})";
         return $"r.{readerMethod}({ordinal})";
     }
-
-    /// <summary>
-    /// Returns true if the CLR type needs an explicit cast from its DbDataReader method
-    /// due to a sign mismatch (e.g., GetInt32 → uint, GetByte → sbyte).
-    /// </summary>
-    private static bool NeedsSignCast(string clrType)
-        => clrType is "uint" or "UInt32" or "System.UInt32"
-            or "ushort" or "UInt16" or "System.UInt16"
-            or "ulong" or "UInt64" or "System.UInt64"
-            or "sbyte" or "SByte" or "System.SByte";
 
     /// <summary>
     /// Gets the appropriate DbDataReader method for a CLR type.

--- a/src/Quarry.Generator/Projection/ReaderCodeGenerator.cs
+++ b/src/Quarry.Generator/Projection/ReaderCodeGenerator.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Quarry.Generators.Generation;
 using Quarry.Generators.Models;
 using Quarry.Generators.Sql;
+using Quarry.Generators.Utilities;
 using Quarry;
 
 namespace Quarry.Generators.Projection;
@@ -223,7 +224,7 @@ internal static class ReaderCodeGenerator
 
         // Handle mismatched-sign integer types — cast from reader method to target type
         // (e.g., (uint)r.GetInt32(0) for unsigned, (sbyte)r.GetByte(0) for signed byte)
-        if (NeedsSignCast(column.ClrType))
+        if (TypeClassification.NeedsSignCast(column.ClrType))
         {
             if (column.IsNullable)
             {
@@ -320,13 +321,4 @@ internal static class ReaderCodeGenerator
         return sb.ToString();
     }
 
-    /// <summary>
-    /// Returns true if the CLR type needs an explicit cast from its DbDataReader method
-    /// due to a sign mismatch (e.g., GetInt32 → uint, GetByte → sbyte).
-    /// </summary>
-    private static bool NeedsSignCast(string clrType)
-        => clrType is "uint" or "UInt32" or "System.UInt32"
-            or "ushort" or "UInt16" or "System.UInt16"
-            or "ulong" or "UInt64" or "System.UInt64"
-            or "sbyte" or "SByte" or "System.SByte";
 }

--- a/src/Quarry.Generator/Utilities/TypeClassification.cs
+++ b/src/Quarry.Generator/Utilities/TypeClassification.cs
@@ -1,0 +1,17 @@
+namespace Quarry.Generators.Utilities;
+
+/// <summary>
+/// Shared CLR type classification helpers used by code-generation emitters.
+/// </summary>
+internal static class TypeClassification
+{
+    /// <summary>
+    /// Returns true if the CLR type needs an explicit cast from its DbDataReader method
+    /// due to a sign mismatch (e.g., GetInt32 → uint, GetByte → sbyte).
+    /// </summary>
+    public static bool NeedsSignCast(string clrType)
+        => clrType is "uint" or "UInt32" or "System.UInt32"
+            or "ushort" or "UInt16" or "System.UInt16"
+            or "ulong" or "UInt64" or "System.UInt64"
+            or "sbyte" or "SByte" or "System.SByte";
+}

--- a/src/Quarry.Tests/SignCastReaderTests.cs
+++ b/src/Quarry.Tests/SignCastReaderTests.cs
@@ -261,7 +261,7 @@ public class SignCastReaderTests
     [TestCase("uint", "(uint)Convert.ToInt64")]
     [TestCase("ushort", "(ushort)Convert.ToInt64")]
     [TestCase("ulong", "(ulong)Convert.ToInt64")]
-    public void RawSqlScalarAsync_UnsignedType_GeneratesCorrectConverter(string clrType, string expectedConvert)
+    public void RawSqlScalarAsync_UnsignedType_NonNullable_GeneratesCorrectConverter(string clrType, string expectedConvert)
     {
         var rawSqlTypeInfo = new RawSqlTypeInfo(
             clrType,
@@ -283,6 +283,33 @@ public class SignCastReaderTests
         Assert.That(result, Does.Contain("RawSqlScalarAsyncWithConverter"));
         Assert.That(result, Does.Contain(expectedConvert),
             $"Scalar converter for {clrType} should use {expectedConvert}");
+    }
+
+    [TestCase("uint?", "(uint?)Convert.ToUInt32")]
+    [TestCase("ushort?", "(ushort?)Convert.ToUInt16")]
+    [TestCase("ulong?", "(ulong?)Convert.ToUInt64")]
+    public void RawSqlScalarAsync_UnsignedType_Nullable_GeneratesCorrectConverter(string clrType, string expectedConvert)
+    {
+        var rawSqlTypeInfo = new RawSqlTypeInfo(
+            clrType,
+            RawSqlTypeKind.Scalar,
+            System.Array.Empty<RawSqlPropertyInfo>(),
+            scalarReaderMethod: "GetInt32");
+
+        var site = new TestCallSiteBuilder()
+            .WithMethodName("RawSqlScalarAsync")
+            .WithKind(InterceptorKind.RawSqlScalarAsync)
+            .WithEntityType(clrType)
+            .WithRawSqlTypeInfo(rawSqlTypeInfo)
+            .WithUniqueId("test_scalar_nullable_uint")
+            .Build();
+
+        var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
+            "AppDbContext", "TestApp", "test0000", new[] { site });
+
+        Assert.That(result, Does.Contain("RawSqlScalarAsyncWithConverter"));
+        Assert.That(result, Does.Contain(expectedConvert),
+            $"Nullable scalar converter for {clrType} should use {expectedConvert}");
     }
 
     #endregion

--- a/src/Quarry/Context/QuarryContext.cs
+++ b/src/Quarry/Context/QuarryContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
@@ -368,6 +369,7 @@ public abstract class QuarryContext : IAsyncDisposable, IDisposable
     /// Executes a raw SQL query using a generated reader delegate instead of reflection.
     /// Called by source-generated interceptors for RawSqlAsync&lt;T&gt;.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public async Task<List<T>> RawSqlAsyncWithReader<T>(
         string sql,
         Func<DbDataReader, T> reader,
@@ -420,6 +422,7 @@ public abstract class QuarryContext : IAsyncDisposable, IDisposable
     /// Executes a raw SQL scalar query with typed conversion instead of Convert.ChangeType.
     /// Called by source-generated interceptors for RawSqlScalarAsync&lt;T&gt;.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public async Task<T> RawSqlScalarAsyncWithConverter<T>(
         string sql,
         Func<object, T> converter,


### PR DESCRIPTION
## Summary
Fix generated interceptor code that fails to compile in consuming projects due to sign-mismatched integer reader casts (CS0266) and inaccessible internal RawSql helper methods (CS1061).

 - Closes #130

## Reason for Change
Consuming projects using Quarry as a ProjectReference (rather than NuGet) encountered compile errors in generated `.g.cs` interceptor files:
- **CS0266**: `Cannot implicitly convert type 'int' to 'uint'` — generated reader code like `entity.Ipv4 = r.GetInt32(ordinal)` for `Col<uint>` columns lacked an explicit cast
- **CS1061**: `QuarryContext does not contain 'RawSqlAsyncWithReader'` — these methods were `internal`, inaccessible from interceptors generated in external assemblies

## Impact
- Generated interceptor code now compiles correctly for `uint`, `ushort`, `ulong`, and `sbyte` column types across all code-generation paths (entity readers, single-column, tuple, DTO, and raw SQL)
- `RawSqlAsyncWithReader` and `RawSqlScalarAsyncWithConverter` are now `public` (hidden from IntelliSense via `[EditorBrowsable(Never)]`)

## Plan items implemented as specified
- Sign-cast fix for unsigned integer types in `ReaderCodeGenerator`, `InterceptorCodeGenerator.Utilities`, and `RawSqlBodyEmitter`
- `internal` → `public` visibility change for RawSql helper methods (same pattern as #129)
- Unsigned type entries added to `GenerateScalarConverter` switch

## Deviations from plan implemented
- Also fixed `sbyte` (reverse direction: `GetByte()` → `sbyte`) which has the same class of bug
- Extracted `NeedsSignCast` into shared `TypeClassification` utility to avoid 3x duplication
- Added `[EditorBrowsable(EditorBrowsableState.Never)]` to public helpers to match `QueryExecutor` pattern

## Gaps in original plan implemented
- The CS0029/CS9144 nullable return type issue for `ExecuteFetchFirstOrDefaultAsync` on value-type scalar projections could not be reproduced — the generator's return type chain appears correct (`Task<long?>` throughout). May require the actual generated output from the consuming project to diagnose further.

## Migration Steps
None — this is a backwards-compatible fix. No API changes for end users.

## Performance Considerations
None — the casts are zero-cost at runtime (bitwise reinterpretation in unchecked context).

## Security Considerations
None.

## Breaking Changes
  - Consumer-facing: None
  - Internal: `RawSqlAsyncWithReader` and `RawSqlScalarAsyncWithConverter` changed from `internal` to `public` (additive, not breaking)
