### PR TITLE
Fix captured variable typed as object for identity Select projections

### DIFF
--- a/src/Quarry.Generator/Parsing/DisplayClassNameResolver.cs
+++ b/src/Quarry.Generator/Parsing/DisplayClassNameResolver.cs
@@ -590,7 +590,12 @@ internal static class DisplayClassNameResolver
         // (e.g., fetchedPackage.Id). Nullable wrapping would make member access invalid.
         // The UnsafeAccessor field type is resolved separately by CarrierAnalyzer.
         if (selectLambda != null)
-            return ResolveProjectionType(selectLambda, entityInfo, isListResult);
+        {
+            var projectionType = ResolveProjectionType(selectLambda, entityInfo, isListResult);
+            if (projectionType != null)
+                return projectionType;
+            // Identity projection (f => f) returns null — fall through to entity type path
+        }
 
         var contextNs = FindContextNamespaceForEntityInfo(entityInfo, entityRegistry);
         var entityNs = contextNs ?? entityInfo.SchemaNamespace;

--- a/src/Quarry.Tests/Parsing/DisplayClassEnricherTests.cs
+++ b/src/Quarry.Tests/Parsing/DisplayClassEnricherTests.cs
@@ -874,6 +874,33 @@ namespace App
     }
 
     [Test]
+    public void ChainResult_IdentitySelect_ResolvesEntityType()
+    {
+        var registry = BuildTestRegistry();
+        var source = ChainInterfaceStub + @"
+namespace App.Data { public partial class AppDb { } }
+namespace App
+{
+    using App.Data;
+    class S
+    {
+        AppDb CreateDb() => throw new NotImplementedException();
+        async Task DoWork()
+        {
+            var db = CreateDb();
+            var pkg = await db.Packages()
+                .Where(p => p.Id == 1)
+                .Select(p => p)
+                .ExecuteFetchFirstOrDefaultAsync();
+            Func<bool> c = () => pkg != null;
+        }
+    }
+}";
+        var resolved = ResolveChainCaptures(source, registry);
+        Assert.That(resolved!["pkg"], Is.EqualTo("global::App.Data.Package"));
+    }
+
+    [Test]
     public void ChainResult_MultiContext_DisambiguatesByImportedNamespace()
     {
         // Two contexts reference UserSchema, but the source file imports Quarry.Tests.Samples


### PR DESCRIPTION
## Summary
Fix captured variables typed as `object` when a Quarry chain uses an identity `Select(f => f)` projection. `ResolveProjectionType` intentionally returns null for identity projections (comment: "handled by caller"), but the caller unconditionally returned that null instead of falling through to the entity type construction path.

## Reason for Change
Chains like `db.Files().Where(...).Select(f => f).ExecuteFetchFirstOrDefaultAsync()` produced captured variables typed as `object` in the generated UnsafeAccessor helpers, causing CS1061 errors when accessing members (e.g., `file.Id`). This affected `PackageController.cs` while `UploadServerNexus.cs` worked because it uses tuple/column projections rather than identity Select.

## Impact
- Captured variables from chains with `Select(f => f)` now correctly resolve to the entity type (e.g., `global::App.Data.File`) instead of `object`
- No effect on chains without Select or with tuple/single-column projections (those paths are unchanged)

## Plan items implemented as specified
- Fix `TryResolveChainInvocation` to fall through to entity type path when `ResolveProjectionType` returns null for identity projections

## Deviations from plan implemented
None.

## Gaps in original plan implemented
None.

## Migration Steps
None — no consumer-facing API changes.

## Performance Considerations
None — adds one null check in an existing code path.

## Security Considerations
None.

## Breaking Changes
### Consumer-facing
None.
### Internal
None.
