### PR TITLE
Fix captured variable typed as object for multi-hop entity derivation chains

### DIFF
--- a/src/Quarry.Generator/CodeGen/CarrierAnalyzer.cs
+++ b/src/Quarry.Generator/CodeGen/CarrierAnalyzer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Quarry.Generators.Generation;
 using Quarry.Generators.IR;
 using Quarry.Generators.Models;
+using Quarry.Generators.Parsing;
 using Quarry.Generators.Sql;
 using Quarry.Generators.Translation;
 using Quarry.Generators.Utilities;
@@ -62,7 +63,7 @@ internal static class CarrierAnalyzer
     /// <summary>
     /// Analyzes an AssembledPlan to produce a CarrierPlan for the new pipeline.
     /// </summary>
-    public static CarrierPlan AnalyzeNew(AssembledPlan assembled)
+    public static CarrierPlan AnalyzeNew(AssembledPlan assembled, EntityRegistry? entityRegistry = null)
     {
         var plan = assembled.Plan;
 
@@ -162,11 +163,10 @@ internal static class CarrierAnalyzer
             {
                 // When param.ClrType is unresolved ("?" or "object"), try to use
                 // the resolved type from CapturedVariableTypes if available.
-                // Only apply the hint for simple captures where the variable IS the
-                // value (ValueExpression == CapturedFieldName). For property chains
-                // like source.UserName, the variable type (User) differs from the
-                // expression type (string), so the hint would be wrong.
                 var effectiveClrType = param.ClrType;
+
+                // Case 1: Simple capture where the variable IS the value
+                // (ValueExpression == CapturedFieldName). Direct type hint.
                 if ((effectiveClrType == "?" || effectiveClrType == "object")
                     && param.CapturedFieldName != null
                     && param.ValueExpression == param.CapturedFieldName
@@ -176,6 +176,25 @@ internal static class CarrierAnalyzer
                     && hintType != "object" && hintType != "?")
                 {
                     effectiveClrType = hintType;
+                }
+                // Case 2: Member access on captured variable (e.g., dbEquip.Id).
+                // Resolve the base variable type, then walk the member chain
+                // through EntityRegistry to derive the final property type.
+                else if ((effectiveClrType == "?" || effectiveClrType == "object")
+                    && param.CapturedFieldName != null
+                    && param.ValueExpression != null
+                    && param.ValueExpression.Length > param.CapturedFieldName.Length + 1
+                    && param.ValueExpression.StartsWith(param.CapturedFieldName + ".")
+                    && entityRegistry != null
+                    && displayClassByParam.TryGetValue(param.GlobalIndex, out var dcTypeHint2)
+                    && dcTypeHint2.VarTypes != null
+                    && dcTypeHint2.VarTypes.TryGetValue(param.CapturedFieldName, out var baseVarType)
+                    && baseVarType != "object" && baseVarType != "?")
+                {
+                    var memberPath = param.ValueExpression.Substring(param.CapturedFieldName.Length + 1);
+                    var resolvedType = ResolveMemberChain(baseVarType, memberPath, entityRegistry);
+                    if (resolvedType != null)
+                        effectiveClrType = resolvedType;
                 }
 
                 var fieldType = NormalizeFieldType(effectiveClrType);
@@ -243,6 +262,23 @@ internal static class CarrierAnalyzer
             maskType: maskType,
             maskBitCount: maskBitCount,
             extractionPlans: extractionPlans);
+    }
+
+    /// <summary>
+    /// Resolves a dotted member path (e.g., "Id" or "Address.City") on a base type
+    /// by walking each member through ChainResultTypeResolver.ResolveMemberOnType.
+    /// </summary>
+    private static string? ResolveMemberChain(string baseType, string memberPath, EntityRegistry entityRegistry)
+    {
+        var currentType = baseType;
+        foreach (var member in memberPath.Split('.'))
+        {
+            var resolved = ChainResultTypeResolver.ResolveMemberOnType(currentType, member, entityRegistry);
+            if (resolved == null)
+                return null;
+            currentType = resolved;
+        }
+        return currentType;
     }
 
     /// <summary>

--- a/src/Quarry.Generator/IR/PipelineOrchestrator.cs
+++ b/src/Quarry.Generator/IR/PipelineOrchestrator.cs
@@ -69,7 +69,7 @@ internal static class PipelineOrchestrator
         var carrierPlans = new List<CarrierPlan>(assembledPlans.Count);
         foreach (var assembled in assembledPlans)
         {
-            var carrier = CarrierAnalyzer.AnalyzeNew(assembled);
+            var carrier = CarrierAnalyzer.AnalyzeNew(assembled, registry);
             carrierPlans.Add(carrier);
         }
 

--- a/src/Quarry.Generator/Parsing/ChainResultTypeResolver.cs
+++ b/src/Quarry.Generator/Parsing/ChainResultTypeResolver.cs
@@ -39,6 +39,11 @@ internal static class ChainResultTypeResolver
             return null;
 
         var declSyntax = declRef.GetSyntax();
+
+        // Handle out var declarations: out var dbEquip from receiver.TryGetValue(key, out var dbEquip)
+        if (declSyntax is SingleVariableDesignationSyntax svd)
+            return TryResolveOutVarType(svd, entityRegistry, depth);
+
         if (declSyntax is not VariableDeclaratorSyntax { Initializer.Value: { } initValue })
             return null;
 
@@ -124,10 +129,16 @@ internal static class ChainResultTypeResolver
         if (initValue is AwaitExpressionSyntax awaitExpr)
             initValue = awaitExpr.Expression;
 
-        // Chain invocation
+        // Chain invocation (Quarry terminal or element-extracting method)
         if (initValue is InvocationExpressionSyntax invocation)
         {
-            return TryResolveChainInvocation(invocation, entityRegistry);
+            var quarryResult = TryResolveChainInvocation(invocation, entityRegistry);
+            if (quarryResult != null)
+                return quarryResult;
+
+            // Non-Quarry invocations: single-element methods (First, FirstOrDefault, etc.)
+            // return the collection's element type directly.
+            return TryResolveSingleElementMethod(invocation, declarator, entityRegistry, depth);
         }
 
         // Member access: sourceVar.Property
@@ -336,6 +347,165 @@ internal static class ChainResultTypeResolver
     {
         var entry = entityRegistry.Resolve(entityInfo.EntityName);
         return entry?.Context.Namespace;
+    }
+
+    /// <summary>
+    /// Resolves an <c>out var</c> declaration by walking up the syntax tree to the containing
+    /// invocation, then tracing the receiver's collection element type.
+    /// For <c>dict.TryGetValue(key, out var entity)</c>, the out var type equals the dictionary's
+    /// value type, which traces back to the original collection's element type.
+    /// </summary>
+    private static string? TryResolveOutVarType(
+        SingleVariableDesignationSyntax designation, EntityRegistry entityRegistry, int depth)
+    {
+        if (depth > 3) return null;
+
+        // Walk up: SingleVariableDesignation → DeclarationExpression → Argument → ArgumentList → Invocation
+        if (designation.Parent is not DeclarationExpressionSyntax)
+            return null;
+        if (designation.Parent.Parent is not ArgumentSyntax)
+            return null;
+        if (designation.Parent.Parent.Parent is not ArgumentListSyntax)
+            return null;
+        if (designation.Parent.Parent.Parent.Parent is not InvocationExpressionSyntax invocation)
+            return null;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return null;
+
+        var methodName = memberAccess.Name.Identifier.Text;
+
+        // TryGetValue(key, out var entity) — the out param type is the collection element type
+        if (methodName == "TryGetValue")
+            return TryResolveCollectionElementType(memberAccess.Expression, designation, entityRegistry, depth + 1);
+
+        return null;
+    }
+
+    /// <summary>
+    /// Traces the element type of a collection expression through variable declarations
+    /// and element-preserving method chains back to a Quarry chain result.
+    /// </summary>
+    private static string? TryResolveCollectionElementType(
+        ExpressionSyntax expression, SyntaxNode contextNode, EntityRegistry entityRegistry, int depth)
+    {
+        if (depth > 3) return null;
+
+        if (expression is IdentifierNameSyntax ident)
+        {
+            var decl = FindLocalDeclarator(ident.Identifier.Text, contextNode);
+            if (decl == null || decl.Initializer?.Value == null)
+                return null;
+
+            var initValue = decl.Initializer.Value;
+            if (initValue is AwaitExpressionSyntax awaitExpr)
+                initValue = awaitExpr.Expression;
+
+            // Quarry chain invocation → extract element type from List<T> / T result
+            if (initValue is InvocationExpressionSyntax invocation)
+            {
+                var chainResult = TryResolveChainInvocation(invocation, entityRegistry);
+                if (chainResult != null)
+                    return ExtractCollectionElementType(chainResult) ?? chainResult;
+
+                // Element-preserving method (ToDictionary, ToList, Where, etc.) → recurse on receiver
+                if (invocation.Expression is MemberAccessExpressionSyntax ma)
+                {
+                    var methodName = ma.Name.Identifier.Text;
+                    if (IsElementPreservingMethod(methodName))
+                    {
+                        // ToDictionary with value selector (2+ lambda args) changes the value type — bail
+                        if (methodName == "ToDictionary" && invocation.ArgumentList.Arguments.Count > 1
+                            && invocation.ArgumentList.Arguments[1].Expression is LambdaExpressionSyntax)
+                            return null;
+
+                        return TryResolveCollectionElementType(ma.Expression, decl, entityRegistry, depth + 1);
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves single-element extraction methods (First, FirstOrDefault, Single, etc.)
+    /// on collections to their element type.
+    /// </summary>
+    private static string? TryResolveSingleElementMethod(
+        InvocationExpressionSyntax invocation, SyntaxNode contextNode, EntityRegistry entityRegistry, int depth)
+    {
+        if (depth > 3) return null;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax ma)
+            return null;
+
+        var methodName = ma.Name.Identifier.Text;
+        if (methodName != "First" && methodName != "FirstOrDefault"
+            && methodName != "Single" && methodName != "SingleOrDefault"
+            && methodName != "Last" && methodName != "LastOrDefault"
+            && methodName != "ElementAt" && methodName != "ElementAtOrDefault")
+            return null;
+
+        return TryResolveCollectionElementType(ma.Expression, contextNode, entityRegistry, depth + 1);
+    }
+
+    /// <summary>
+    /// Returns true for methods that preserve the collection's element type as
+    /// either the output element type or the dictionary value type.
+    /// </summary>
+    private static bool IsElementPreservingMethod(string methodName)
+    {
+        switch (methodName)
+        {
+            case "ToDictionary":
+            case "ToLookup":
+            case "ToList":
+            case "ToArray":
+            case "ToHashSet":
+            case "AsEnumerable":
+            case "Where":
+            case "OrderBy":
+            case "OrderByDescending":
+            case "ThenBy":
+            case "ThenByDescending":
+            case "Distinct":
+            case "Take":
+            case "Skip":
+            case "Reverse":
+            case "First":
+            case "FirstOrDefault":
+            case "Single":
+            case "SingleOrDefault":
+            case "Last":
+            case "LastOrDefault":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Extracts the element type from a collection type string.
+    /// <c>global::System.Collections.Generic.List&lt;T&gt;</c> → <c>T</c>.
+    /// Returns null if the type is not a recognized collection wrapper.
+    /// </summary>
+    internal static string? ExtractCollectionElementType(string typeString)
+    {
+        // Find the outermost generic argument: List<T> → T, IReadOnlyList<T> → T
+        var genericStart = typeString.IndexOf('<');
+        if (genericStart < 0) return null;
+
+        // Verify it's a single-type-arg collection (not Dictionary<K,V>)
+        var prefix = typeString.Substring(0, genericStart);
+        if (prefix.Contains("Dictionary") || prefix.Contains("IDictionary"))
+            return null;
+
+        // Extract content between outermost < and >
+        var genericEnd = typeString.LastIndexOf('>');
+        if (genericEnd <= genericStart) return null;
+
+        return typeString.Substring(genericStart + 1, genericEnd - genericStart - 1);
     }
 
     /// <summary>

--- a/src/Quarry.Generator/Parsing/DisplayClassNameResolver.cs
+++ b/src/Quarry.Generator/Parsing/DisplayClassNameResolver.cs
@@ -115,7 +115,18 @@ internal static class DisplayClassNameResolver
         foreach (var usingDir in root.Usings)
         {
             if (usingDir.Alias == null && usingDir.Name != null)
+            {
                 importedNamespaces.Add(usingDir.Name.ToString());
+            }
+            else if (usingDir.Alias != null && usingDir.Name != null)
+            {
+                // Extract namespace from using aliases: using DbUser = My.Namespace.User
+                // → adds "My.Namespace" so schema lookup can find "My.Namespace.UserSchema"
+                var fullName = usingDir.Name.ToString();
+                var lastDot = fullName.LastIndexOf('.');
+                if (lastDot > 0)
+                    importedNamespaces.Add(fullName.Substring(0, lastDot));
+            }
         }
 
         foreach (var ns in importedNamespaces)


### PR DESCRIPTION
## Summary
- Closes #142 (partial — addresses captured variable type resolution; batch insert returning IDs is a separate feature)

Extends `ChainResultTypeResolver` to resolve entity types for captured variables that flow through multi-hop derivation chains (`Quarry chain → ToDictionary → TryGetValue out var`), and fixes `CarrierAnalyzer` to derive member-access parameter types from EntityRegistry.

## Reason for Change

When a lambda captures `dbEquip.Id` where `dbEquip` is an entity obtained via a multi-hop chain (e.g., `dictionary.TryGetValue(key, out var dbEquip)`), the generator typed the captured variable as `object` instead of the correct entity type. This caused CS1061 errors in generated interceptor code (`'object' does not contain a definition for 'Id'`), forcing users to apply workarounds like extracting properties to local variables before capture.

**Root cause:** `context.CompilationProvider` doesn't include Pipeline A's generated entity types. The existing type resolution cascade handled direct Quarry chain results but failed for multi-hop derivations:
```
db.Equipments()...ExecuteFetchAllAsync() → equipmentRows    (resolved ✓)
  → .ToDictionary(e => e.Id)            → equipmentLookup   (NOT resolved ✗)
  → .TryGetValue(key, out var dbEquip)  → dbEquip           (NOT resolved ✗)
```

## Impact

**4 files changed** in `Quarry.Generator`:

### `ChainResultTypeResolver.cs` — Primary fix
- **`TryResolveOutVarType`**: Handles `SingleVariableDesignationSyntax` (from `out var`) by walking up the syntax tree to the containing invocation, then tracing the receiver's collection element type. For `TryGetValue`, the out param type equals the dictionary's value type.
- **`TryResolveCollectionElementType`**: Traces the element type of a collection expression through variable declarations and element-preserving method chains (ToDictionary, ToList, Where, OrderBy, etc.) back to a Quarry chain result.
- **`TryResolveSingleElementMethod`**: Resolves `First`/`FirstOrDefault`/`Single`/`SingleOrDefault`/`Last`/`LastOrDefault` to their collection's element type.
- **`ExtractCollectionElementType`**: Strips `List<T>`/`IReadOnlyList<T>` wrappers to extract element type.
- **`IsElementPreservingMethod`**: Recognizes 20 LINQ methods that preserve element types.
- **Extended `TryResolveInitializerType`**: Falls back to single-element method resolution when Quarry chain resolution returns null.

### `CarrierAnalyzer.cs` — Member-access parameter type derivation
- **Case 2 hint**: When `ValueExpression` is member access on `CapturedFieldName` (e.g., `"dbEquip.Id"`), looks up base type from `CapturedVariableTypes`, then resolves member type via `ResolveMemberOnType` through EntityRegistry.
- **`ResolveMemberChain`**: Walks dotted member paths through EntityRegistry column lookups.
- Accepts optional `EntityRegistry` parameter (threaded from PipelineOrchestrator).

### `DisplayClassNameResolver.cs` — Using alias namespace extraction
- `TryQualifyErrorTypeFromUsings` now also extracts namespaces from using aliases (`using DbUser = My.Namespace.User` → adds `My.Namespace` to search space).

### `PipelineOrchestrator.cs` — Threading
- Passes `EntityRegistry` to `CarrierAnalyzer.AnalyzeNew`.

## Plan items implemented as specified
- `SingleVariableDesignationSyntax` handling in `TryResolveChainResultTypeCore`
- `TryResolveOutVarType` with syntax tree walk to `InvocationExpressionSyntax`
- `TryResolveCollectionElementType` with element-preserving method chain tracing
- `ExtractCollectionElementType` helper
- `TryResolveInitializerType` extension for non-Quarry invocations
- CarrierAnalyzer Case 2 member-access hint with `ResolveMemberChain`
- EntityRegistry threading through PipelineOrchestrator
- Using alias namespace extraction in `TryQualifyErrorTypeFromUsings`

## Deviations from plan implemented
None.

## Gaps in original plan implemented
None identified.

## Migration Steps
None — additive change only.

## Performance Considerations
- New resolution paths are only attempted when existing paths return null (fallback, not replacement)
- Depth-guarded recursion (limit 3) prevents unbounded traversal
- `IsElementPreservingMethod` uses switch statement for O(1) lookup

## Security Considerations
None.

## Breaking Changes
- **Consumer-facing**: None
- **Internal**: `CarrierAnalyzer.AnalyzeNew` now accepts an optional `EntityRegistry?` parameter (default null, backwards compatible)