### PR TITLE
Fix nullable collection element type in Contains fallback path

### DIFF
--- a/src/Quarry.Generator/IR/CallSiteTranslator.cs
+++ b/src/Quarry.Generator/IR/CallSiteTranslator.cs
@@ -808,18 +808,27 @@ internal static class CallSiteTranslator
                             col.PropertyName == kvp.Key)
                         {
                             elementType = col.FullClrType ?? col.ClrType;
+                            // ColumnInfo stores nullable value types without the '?' suffix
+                            // (e.g., Col<long?> → ClrType="long", IsNullable=true).
+                            // Reconstruct the nullable type so the carrier field/cast uses
+                            // IReadOnlyList<long?> instead of IReadOnlyList<long>.
+                            if (col.IsNullable && col.IsValueType && !elementType.EndsWith("?"))
+                                elementType += "?";
                             break;
                         }
                     }
                 }
-                // Apply element type to collection parameters in the values list
+                // Apply element type to collection parameters that don't already have one.
+                // Skip parameters where ExtractElementType already resolved the type from
+                // the collection's own CLR type — that is more accurate than column inference.
                 if (elementType != null)
                 {
                     foreach (var val in inExpr.Values)
                     {
                         if (val is ParamSlotExpr param && param.IsCollection)
                         {
-                            if (param.LocalIndex < parameters.Count && parameters[param.LocalIndex].IsCollection)
+                            if (param.LocalIndex < parameters.Count && parameters[param.LocalIndex].IsCollection
+                                && parameters[param.LocalIndex].CollectionElementType == null)
                             {
                                 parameters[param.LocalIndex].CollectionElementType = elementType;
                             }

--- a/src/Quarry.Tests/GeneratorTests.cs
+++ b/src/Quarry.Tests/GeneratorTests.cs
@@ -1005,4 +1005,97 @@ class Service
 
     #endregion
 
+    #region Nullable collection Contains — CS0030 regression
+
+    [Test]
+    public void NullableArrayContains_NullableColumn_NoCS0030()
+    {
+        // Regression: long?[] used in .Contains() on a Col<long?> column should generate
+        // IReadOnlyList<long?>, not IReadOnlyList<long>. CS0030 = "Cannot convert type".
+        var source = @"
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Quarry;
+
+namespace TestApp;
+
+public class EquipmentOptionSchema : Schema
+{
+    public static string Table => ""equipment_options"";
+    public Key<long> Id => Identity();
+    public Col<string> Name => Length(200);
+}
+
+public class EquipmentPropertySchema : Schema
+{
+    public static string Table => ""equipment_properties"";
+    public Key<long> Id => Identity();
+    public Col<long?> EquipmentOptionId { get; }
+    public Col<string> Value => Length(500);
+}
+
+[QuarryContext(Dialect = SqlDialect.SQLite)]
+public partial class TestDbContext : QuarryContext
+{
+    public partial IEntityAccessor<EquipmentOption> EquipmentOptions();
+    public partial IEntityAccessor<EquipmentProperty> EquipmentProperties();
+}
+
+class Service
+{
+    async Task DeleteEquipmentProperty(TestDbContext db)
+    {
+        // Simulates the user pattern: Select non-nullable Id, cast to nullable, ToArray()
+        var optionRows = await db.EquipmentOptions().Select(o => o).ExecuteFetchAllAsync();
+        var optionIdValues = optionRows.Select(o => (long?)o.Id).ToArray(); // long?[]
+
+        // Contains on nullable column with nullable collection
+        await db.EquipmentProperties()
+            .Delete()
+            .Where(ep => optionIdValues.Contains(ep.EquipmentOptionId))
+            .ExecuteNonQueryAsync();
+    }
+}
+";
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest)
+            .WithFeatures(new[] { new KeyValuePair<string, string>("InterceptorsNamespaces", "TestApp") });
+        var syntaxTrees = new[] { CSharpSyntaxTree.ParseText(source, parseOptions) };
+
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        var references = new MetadataReference[]
+        {
+            MetadataReference.CreateFromFile(QuarryCoreAssemblyPath),
+            MetadataReference.CreateFromFile(SystemRuntimeAssemblyPath),
+            MetadataReference.CreateFromFile(typeof(System.Data.IDbConnection).Assembly.Location),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Linq.dll")),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Linq.Expressions.dll")),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "netstandard.dll")),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.ComponentModel.Primitives.dll")),
+        };
+
+        var compilation = CSharpCompilation.Create("TestAssembly", syntaxTrees, references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+
+        var generator = new QuarryGenerator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            new[] { generator.AsSourceGenerator() },
+            parseOptions: parseOptions);
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out _);
+
+        var errors = outputCompilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+
+        var cs0030 = errors.Where(d => d.Id == "CS0030").ToList();
+        Assert.That(cs0030, Is.Empty,
+            "Nullable collection Contains produced CS0030: " +
+            string.Join("; ", cs0030.Select(d => d.GetMessage())));
+    }
+
+    #endregion
+
 }

--- a/src/Quarry.Tests/SqlOutput/CrossDialectNullableValueTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectNullableValueTests.cs
@@ -288,4 +288,60 @@ internal class CrossDialectNullableValueTests
     }
 
     #endregion
+
+    #region Nullable element type collection Contains (regression: IReadOnlyList<T> vs IReadOnlyList<T?>)
+
+    [Test]
+    public async Task Where_NullableArrayContains_NullableColumn()
+    {
+        // Regression: long?[] (or DateTime?[]) used in .Contains() on a nullable column
+        // should generate IReadOnlyList<DateTime?>, not IReadOnlyList<DateTime>.
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        DateTime?[] dates = [new DateTime(2024, 6, 1), new DateTime(2024, 5, 15)];
+        var lt = Lite.Users().Where(u => dates.Contains(u.LastLogin)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => dates.Contains(u.LastLogin)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var my = My.Users().Where(u => dates.Contains(u.LastLogin)).Select(u => (u.UserId, u.UserName)).Prepare();
+        var ss = Ss.Users().Where(u => dates.Contains(u.LastLogin)).Select(u => (u.UserId, u.UserName)).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"LastLogin\" IN (@p0, @p1)",
+            pg:     "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE \"LastLogin\" IN ($1, $2)",
+            mysql:  "SELECT `UserId`, `UserName` FROM `users` WHERE `LastLogin` IN (?, ?)",
+            ss:     "SELECT [UserId], [UserName] FROM [users] WHERE [LastLogin] IN (@p0, @p1)");
+
+        // Execution: Alice (2024-06-01) and Charlie (2024-05-15) have matching LastLogin dates
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(2));
+        Assert.That(results[0], Is.EqualTo((1, "Alice")));
+        Assert.That(results[1], Is.EqualTo((3, "Charlie")));
+    }
+
+    [Test]
+    public async Task Where_NullableListContains_NonNullableColumn()
+    {
+        // Nullable collection element type (int?) against a non-nullable column (Key<int>).
+        // Verifies the generator emits IReadOnlyList<int?> even when the column itself isn't nullable.
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var ids = new List<int?> { 1, 3 };
+        var lt = Lite.Users().Where(u => ids.Contains(u.UserId)).Select(u => u.UserName).Prepare();
+        var pg = Pg.Users().Where(u => ids.Contains(u.UserId)).Select(u => u.UserName).Prepare();
+        var my = My.Users().Where(u => ids.Contains(u.UserId)).Select(u => u.UserName).Prepare();
+        var ss = Ss.Users().Where(u => ids.Contains(u.UserId)).Select(u => u.UserName).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserName\" FROM \"users\" WHERE \"UserId\" IN (@p0, @p1)",
+            pg:     "SELECT \"UserName\" FROM \"users\" WHERE \"UserId\" IN ($1, $2)",
+            mysql:  "SELECT `UserName` FROM `users` WHERE `UserId` IN (?, ?)",
+            ss:     "SELECT [UserName] FROM [users] WHERE [UserId] IN (@p0, @p1)");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
When a nullable-element-type collection (e.g., `long?[]`) is used in `.Contains()` on a nullable column (`Col<long?>`), the generator's fallback type-resolution path emits `IReadOnlyList<long>` instead of `IReadOnlyList<long?>`, producing CS0030 at compile time. This fixes the fallback to reconstruct the nullable suffix and prevents it from overwriting correctly-resolved types.

 - Closes #147

## Reason for Change
Reported by an end user migrating to Quarry v0.2.1-13. Three call sites in their codebase using the pattern:
```csharp
var optionIdValues = optionRows.Select(o => (long?)o.Id).ToArray(); // long?[]
db.EquipmentProperties()
    .Delete()
    .Where(ep => optionIdValues.Contains(ep.EquipmentOptionId)) // Col<long?>
    .ExecuteNonQueryAsync();
```
All three produced `CS0030: Cannot convert type 'long?[]' to 'System.Collections.Generic.IReadOnlyList<long>'`.

## Impact
Fixes a compile-time error (CS0030) for any query using a nullable-value-type collection in a `.Contains()` clause when the generator's primary type-resolution path (`ExtractElementType` on the captured variable's CLR type) fails to resolve the collection type — typically during incremental compilation where the semantic model returns error types.

## Plan items implemented as specified
- Root-caused the bug to `CallSiteTranslator.FindCollectionElementTypes` — the fallback that infers element type from `ColumnInfo` metadata
- `ColumnInfo` stores nullable value types without the `?` suffix (`ClrType="long"`, `IsNullable=true`); the fallback didn't reconstruct it
- Added nullable suffix reconstruction: `if (col.IsNullable && col.IsValueType && !elementType.EndsWith("?")) elementType += "?"`
- Added guard to not overwrite element types already resolved by the primary path

## Deviations from plan implemented
None.

## Gaps in original plan implemented
- The fallback also unconditionally overwrote `CollectionElementType` even when the primary path had already correctly resolved it (e.g., `"long?"` from `ExtractElementType`). Added a `CollectionElementType == null` guard to prevent this.

## Migration Steps
None required. Drop-in fix — no API or behavior changes.

## Performance Considerations
None. The fix adds a single boolean check and string concatenation in a cold path that only fires when primary type resolution fails.

## Security Considerations
None.

## Breaking Changes
  - Consumer-facing: None
  - Internal: None