### PR TITLE
Add benchmark constant-inlining variants and remove unused views

### DIFF
--- a/src/Quarry.Benchmarks/Benchmarks/DeleteBenchmarks.cs
+++ b/src/Quarry.Benchmarks/Benchmarks/DeleteBenchmarks.cs
@@ -75,9 +75,22 @@ public class DeleteBenchmarks : BenchmarkBase
     [Benchmark]
     public async Task<int> Quarry_DeleteSingleRow()
     {
+        // Uses field _targetId → parameterized WHERE (@p0).
+        // This is the apples-to-apples comparison against Raw's parameterized @id.
         return await QuarryDb.Users()
             .Delete()
             .Where(u => u.UserId == _targetId)
+            .ExecuteNonQueryAsync();
+    }
+
+    [Benchmark]
+    public async Task<int> Quarry_DeleteSingleRow_Inlined()
+    {
+        // Constant 999 is inlined into SQL by the source generator (no DbParameter).
+        // Demonstrates Quarry's compile-time constant elimination.
+        return await QuarryDb.Users()
+            .Delete()
+            .Where(u => u.UserId == 999)
             .ExecuteNonQueryAsync();
     }
 

--- a/src/Quarry.Benchmarks/Benchmarks/FilterBenchmarks.cs
+++ b/src/Quarry.Benchmarks/Benchmarks/FilterBenchmarks.cs
@@ -10,6 +10,17 @@ namespace Quarry.Benchmarks.Benchmarks;
 
 public class FilterBenchmarks : BenchmarkBase
 {
+    // Static field forces the source generator to parameterize the value.
+    // Compare Quarry_WhereById (constant → inlined into SQL) vs
+    // Quarry_WhereById_Parameterized (field → @p0 parameter).
+    private static int _whereByIdTarget;
+
+    public override void GlobalSetup()
+    {
+        base.GlobalSetup();
+        _whereByIdTarget = 42;
+    }
+
     // --- Where Active ---
 
     [Benchmark(Baseline = true)]
@@ -216,8 +227,20 @@ public class FilterBenchmarks : BenchmarkBase
     [Benchmark]
     public async Task<User?> Quarry_WhereById()
     {
+        // Constant 42 is inlined into SQL by the source generator (no DbParameter).
         return await QuarryDb.Users()
             .Where(u => u.UserId == 42)
+            .Select(u => u)
+            .ExecuteFetchFirstOrDefaultAsync();
+    }
+
+    [Benchmark]
+    public async Task<User?> Quarry_WhereById_Parameterized()
+    {
+        // Field variable forces the source generator to emit a @p0 parameter,
+        // matching what Raw/Dapper do. This is the apples-to-apples comparison.
+        return await QuarryDb.Users()
+            .Where(u => u.UserId == _whereByIdTarget)
             .Select(u => u)
             .ExecuteFetchFirstOrDefaultAsync();
     }

--- a/src/Quarry.Benchmarks/Benchmarks/UpdateBenchmarks.cs
+++ b/src/Quarry.Benchmarks/Benchmarks/UpdateBenchmarks.cs
@@ -74,10 +74,26 @@ public class UpdateBenchmarks : BenchmarkBase
     [Benchmark]
     public async Task<int> Quarry_UpdateSingleRow()
     {
+        // Uses field _targetId → parameterized WHERE. SET value "UpdatedUser" is a
+        // constant that the generator inlines. This is the apples-to-apples comparison
+        // for the WHERE clause (matches Raw's parameterized @id).
         return await QuarryDb.Users()
             .Update()
             .Set(u => u.UserName = "UpdatedUser")
             .Where(u => u.UserId == _targetId)
+            .ExecuteNonQueryAsync();
+    }
+
+    [Benchmark]
+    public async Task<int> Quarry_UpdateSingleRow_Inlined()
+    {
+        // Constant 1 is inlined into SQL by the source generator (no DbParameter for
+        // WHERE). Demonstrates Quarry's compile-time constant elimination — fewer
+        // allocations than Raw/Dapper which must always parameterize.
+        return await QuarryDb.Users()
+            .Update()
+            .Set(u => u.UserName = "UpdatedUser")
+            .Where(u => u.UserId == 1)
             .ExecuteNonQueryAsync();
     }
 

--- a/src/Quarry.Benchmarks/Infrastructure/DatabaseSetup.cs
+++ b/src/Quarry.Benchmarks/Infrastructure/DatabaseSetup.cs
@@ -40,11 +40,6 @@ public static class DatabaseSetup
                 LineTotal REAL NOT NULL,
                 FOREIGN KEY (OrderId) REFERENCES orders(OrderId)
             );
-
-            -- Views mapping entity class names to actual table names.
-            -- The Quarry join interceptor uses entity type names as table identifiers.
-            CREATE VIEW IF NOT EXISTS "Order" AS SELECT * FROM orders;
-            CREATE VIEW IF NOT EXISTS "OrderItem" AS SELECT * FROM order_items;
             """;
         cmd.ExecuteNonQuery();
 


### PR DESCRIPTION
## Summary
- Closes #150 (partial — items 2 and 3 only; item 1 Throughput rewrite depends on #149)

Benchmark audit found fairness issues and improvement opportunities. This PR adds
paired benchmark variants showing Quarry's compile-time constant inlining vs
parameterized queries, and removes unused database views.

## Reason for Change
Benchmark review revealed that some Quarry benchmarks used compile-time constants
(inlined into SQL, eliminating DbParameter allocations) while Raw ADO.NET baselines
always parameterized. This made allocation comparisons non-apples-to-apples. Adding
explicit paired variants makes the optimization visible and gives readers the fair
comparison alongside the optimized one.

The Order/OrderItem views in DatabaseSetup.cs were unused artifacts — generated
interceptors already use actual table names from the schema's Table property.

## Impact
- **FilterBenchmarks**: Added `Quarry_WhereById_Parameterized` (field variable → @p0)
  alongside existing `Quarry_WhereById` (constant 42 → inlined)
- **UpdateBenchmarks**: Added `Quarry_UpdateSingleRow_Inlined` (constant 1 → inlined)
  alongside existing `Quarry_UpdateSingleRow` (field → @p0)
- **DeleteBenchmarks**: Added `Quarry_DeleteSingleRow_Inlined` (constant 999 → inlined)
  alongside existing `Quarry_DeleteSingleRow` (field → @p0)
- **DatabaseSetup**: Removed `CREATE VIEW "Order"` and `CREATE VIEW "OrderItem"`

## Plan items implemented as specified
- Add constant-inlining paired variants for WhereById, UpdateSingleRow, DeleteSingleRow
- Remove unused views from DatabaseSetup.cs

## Deviations from plan implemented
None.

## Gaps in original plan implemented
None. Throughput rewrite (item 1 of #150) is blocked on #149 (RawSqlAsync interceptor bug).

## Migration Steps
None — benchmark-only changes.

## Performance Considerations
No runtime impact. Adds 3 new benchmark methods to the suite, increasing full-suite
run time by ~30 seconds.

## Security Considerations
None.

## Breaking Changes
- Consumer-facing: None
- Internal: None