### PR TITLE
Refactor: remove duplicated ImplicitJoinInfo construction in BindSubquery

### DIFF
--- a/src/Quarry.Generator/IR/SqlExprBinder.cs
+++ b/src/Quarry.Generator/IR/SqlExprBinder.cs
@@ -447,7 +447,7 @@ internal static class SqlExprBinder
             {
                 // For HasManyThrough: predicate columns resolve on the implicit join alias
                 // We'll set the alias after creating the implicit join below
-                innerAliases[sub.InnerParameterName] = alias; // temporary; will be overridden
+                innerAliases[sub.InnerParameterName] = alias; // placeholder until joinAlias is computed below; dictionary is shared by reference with BindContext
             }
             else
             {
@@ -538,26 +538,10 @@ internal static class SqlExprBinder
                             joinKind: joinKind,
                             targetPkColumnName: targetPkCol));
 
-                        // Override the predicate's table alias to the implicit join alias
+                        // Override the predicate's table alias to the implicit join alias.
+                        // innerAliases is shared by reference with innerCtx.TableAliases,
+                        // so this mutation is visible without rebuilding the context.
                         innerAliases[sub.InnerParameterName] = joinAlias;
-
-                        // Rebuild context with updated aliases
-                        innerCtx = new BindContext(
-                            predicateEntity, ctx.Dialect, sub.InnerParameterName, innerColumnLookup,
-                            innerJoined, innerAliases, ctx.EntityLookup);
-                        innerCtx.SubqueryAliasCounter = ctx.SubqueryAliasCounter;
-                        // Re-add the implicit join to the new context
-                        innerCtx.ImplicitJoins.Add(new ImplicitJoinInfo(
-                            sourceAlias: alias,
-                            fkColumnName: junctionFkCol,
-                            fkColumnQuoted: QuoteIdentifier(junctionFkCol, ctx.Dialect),
-                            targetTableName: throughTargetEntity.TableName,
-                            targetTableQuoted: QuoteIdentifier(throughTargetEntity.TableName, ctx.Dialect),
-                            targetSchemaQuoted: null,
-                            targetAlias: joinAlias,
-                            targetPkColumnQuoted: QuoteIdentifier(targetPkCol, ctx.Dialect),
-                            joinKind: joinKind,
-                            targetPkColumnName: targetPkCol));
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Closes #163

## Reason for Change
The `HasManyThrough` junction expansion in `SqlExprBinder.BindSubquery()` constructed the same `ImplicitJoinInfo` twice — once before rebuilding the `BindContext`, and again after. The rebuild was unnecessary because `BindContext.TableAliases` stores a reference to the caller's dictionary, so alias mutations are visible without reconstruction.

## Impact
- Removes 20 lines of duplicated code, adds 4 lines of clarifying comments
- Net reduction of 16 lines in `SqlExprBinder.cs`
- Also fixes a latent bug where the `BindContext` rebuild reset `ImplicitJoinAliasCounter` to 0 (not currently reachable in practice, but would cause alias collisions if multiple implicit joins were created within a single subquery predicate)

## Plan items implemented as specified
- Removed unnecessary `BindContext` rebuild (old lines 544-548)
- Removed duplicate `ImplicitJoinInfo` addition (old lines 549-560)
- Updated comment on placeholder alias assignment to document reference-sharing behavior
- Added explanatory comment at alias override site

## Deviations from plan implemented
None.

## Gaps in original plan implemented
None.

## Migration Steps
None required — internal refactor only.

## Performance Considerations
No impact — removes redundant object construction.

## Security Considerations
No impact — all SQL identifier quoting preserved, internal code only.

## Breaking Changes
- Consumer-facing: None
- Internal: None (`BindContext` is `private sealed`, `BindSubquery` is `private static`)