### PR TITLE
Unify buffered multi-row execution onto IAsyncEnumerable codepath

### DIFF
--- a/src/Quarry/Internal/QueryExecutor.cs
+++ b/src/Quarry/Internal/QueryExecutor.cs
@@ -16,40 +16,17 @@ public static class QueryExecutor
 {
     /// <summary>
     /// Executes a carrier-optimized query with a pre-built command and returns all results as a list.
+    /// Delegates to <see cref="ToCarrierAsyncEnumerableWithCommandAsync{TResult}"/> for the actual execution.
     /// </summary>
     public static async Task<List<TResult>> ExecuteCarrierWithCommandAsync<TResult>(
         long opId, QuarryContext ctx,
         DbCommand command, Func<DbDataReader, TResult> reader, CancellationToken ct)
     {
-        await using var _cmd = command;
-        await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
-
-        var startTimestamp = Stopwatch.GetTimestamp();
-        await using var dbReader = await command.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess, ct).ConfigureAwait(false);
-
         var results = new List<TResult>();
-        try
+        await foreach (var item in ToCarrierAsyncEnumerableWithCommandAsync(opId, ctx, command, reader, ct).ConfigureAwait(false))
         {
-            while (await dbReader.ReadAsync(ct).ConfigureAwait(false))
-            {
-                results.Add(reader(dbReader));
-            }
+            results.Add(item);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Error, QueryLog.CategoryName) == true)
-                QueryLog.QueryFailed(opId, ex);
-
-            throw new QuarryQueryException($"Error reading query results: {ex.Message}", command.CommandText, ex);
-        }
-
-        var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-        if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
-            QueryLog.FetchCompleted(opId, results.Count, elapsedMs);
-
-        CheckSlowQuery(opId, ctx, elapsedMs, command.CommandText);
-
         return results;
     }
 


### PR DESCRIPTION
## Summary
- Closes #171

## Reason for Change
`QueryExecutor` maintained two parallel execution paths for multi-row queries: a buffered `ExecuteCarrierWithCommandAsync` (while/ReadAsync loop into `List<T>`) and a streaming `ToCarrierAsyncEnumerableWithCommandAsync` (yield return via `IAsyncEnumerable<T>`). Both duplicated CommandBehavior flag handling, logging, error wrapping, slow-query diagnostics, and command lifecycle management. Unifying onto the streaming path means one place for all cross-cutting concerns and less code to maintain.

## Impact
- `ExecuteCarrierWithCommandAsync` is now a thin `await foreach` wrapper over `ToCarrierAsyncEnumerableWithCommandAsync`
- 26 lines removed, 3 added in `QueryExecutor.cs`
- All 2612 existing tests pass unchanged
- Benchmark overhead: 4-6% with +170 bytes allocation (statistically equivalent per #105 rules)

## Plan items implemented as specified
- Phase 1: Replace `ExecuteCarrierWithCommandAsync` body with `await foreach` accumulating into `List<TResult>`

## Deviations from plan implemented
None.

## Gaps in original plan implemented
- Added `.ConfigureAwait(false)` to the `await foreach` call (caught during review — every other `await` in the file uses it)

## Migration Steps
None required. No public API changes.

## Performance Considerations
Benchmark (`EnumerableOverheadBenchmarks.cs`) measured 4-6% overhead with +170 bytes allocation for the async state machine. Per #105 equivalency rules, this is statistically equivalent. On any real database with network latency, the difference vanishes entirely.

## Security Considerations
None.

## Breaking Changes
- **Consumer-facing:** None. Method signatures unchanged.
- **Internal:** `ReadAsync` errors during buffered execution now propagate as raw `DbException` instead of being wrapped in `QuarryQueryException`. This matches the streaming path's existing behavior and was accepted as a design decision (more consistent, no tests relied on the old wrapping).