### PR TITLE
Fix Raw benchmark baselines to use CommandBehavior flags

### DIFF
--- a/src/Quarry.Benchmarks/Benchmarks/ColdStartBenchmarks.cs
+++ b/src/Quarry.Benchmarks/Benchmarks/ColdStartBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using BenchmarkDotNet.Attributes;
 using Dapper;
 using Microsoft.Data.Sqlite;
@@ -42,7 +43,7 @@ public class ColdStartBenchmarks
     {
         await using var cmd = _connection.CreateCommand();
         cmd.CommandText = "SELECT UserId, UserName, Email, IsActive, CreatedAt, LastLogin FROM users WHERE IsActive = 1";
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         var results = new List<RawUser>();
         while (await reader.ReadAsync())
         {

--- a/src/Quarry.Benchmarks/Benchmarks/ComplexQueryBenchmarks.cs
+++ b/src/Quarry.Benchmarks/Benchmarks/ComplexQueryBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using BenchmarkDotNet.Attributes;
 using Dapper;
 using Microsoft.Data.Sqlite;
@@ -23,7 +24,7 @@ public class ComplexQueryBenchmarks : BenchmarkBase
             WHERE u.IsActive = 1
             LIMIT 10 OFFSET 5
             """;
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         var results = new List<UserOrderDto>();
         while (await reader.ReadAsync())
         {

--- a/src/Quarry.Benchmarks/Benchmarks/ConditionalBranchBenchmarks.cs
+++ b/src/Quarry.Benchmarks/Benchmarks/ConditionalBranchBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using BenchmarkDotNet.Attributes;
 using Dapper;
 using Microsoft.Data.Sqlite;
@@ -40,7 +41,7 @@ public class ConditionalBranchBenchmarks : BenchmarkBase
 
         await using var cmd = Connection.CreateCommand();
         cmd.CommandText = sql;
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         var results = new List<RawUser>();
         while (await reader.ReadAsync())
         {

--- a/src/Quarry.Benchmarks/Benchmarks/FilterBenchmarks.cs
+++ b/src/Quarry.Benchmarks/Benchmarks/FilterBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using BenchmarkDotNet.Attributes;
 using Dapper;
 using Microsoft.Data.Sqlite;
@@ -28,7 +29,7 @@ public class FilterBenchmarks : BenchmarkBase
     {
         await using var cmd = Connection.CreateCommand();
         cmd.CommandText = "SELECT UserId, UserName, Email, IsActive, CreatedAt, LastLogin FROM users WHERE IsActive = 1";
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         var results = new List<RawUser>();
         while (await reader.ReadAsync())
         {
@@ -107,7 +108,7 @@ public class FilterBenchmarks : BenchmarkBase
     {
         await using var cmd = Connection.CreateCommand();
         cmd.CommandText = "SELECT UserId, UserName, IsActive FROM users WHERE IsActive = 1 AND Email IS NOT NULL";
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         var results = new List<UserSummaryDto>();
         while (await reader.ReadAsync())
         {
@@ -193,7 +194,7 @@ public class FilterBenchmarks : BenchmarkBase
         await using var cmd = Connection.CreateCommand();
         cmd.CommandText = "SELECT UserId, UserName, Email, IsActive, CreatedAt, LastLogin FROM users WHERE UserId = @id";
         cmd.Parameters.AddWithValue("@id", 42);
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess | CommandBehavior.SingleRow);
         if (await reader.ReadAsync())
         {
             return new RawUser

--- a/src/Quarry.Benchmarks/Benchmarks/JoinBenchmarks.cs
+++ b/src/Quarry.Benchmarks/Benchmarks/JoinBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using BenchmarkDotNet.Attributes;
 using Dapper;
 using Microsoft.Data.Sqlite;
@@ -17,7 +18,7 @@ public class JoinBenchmarks : BenchmarkBase
     {
         await using var cmd = Connection.CreateCommand();
         cmd.CommandText = "SELECT u.UserName, o.Total FROM users u INNER JOIN orders o ON u.UserId = o.UserId";
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         var results = new List<UserOrderDto>();
         while (await reader.ReadAsync())
         {
@@ -98,7 +99,7 @@ public class JoinBenchmarks : BenchmarkBase
             INNER JOIN orders o ON u.UserId = o.UserId
             INNER JOIN order_items oi ON o.OrderId = oi.OrderId
             """;
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         var results = new List<UserOrderItemDto>();
         while (await reader.ReadAsync())
         {

--- a/src/Quarry.Benchmarks/Benchmarks/PaginationBenchmarks.cs
+++ b/src/Quarry.Benchmarks/Benchmarks/PaginationBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using BenchmarkDotNet.Attributes;
 using Dapper;
 using Microsoft.Data.Sqlite;
@@ -17,7 +18,7 @@ public class PaginationBenchmarks : BenchmarkBase
     {
         await using var cmd = Connection.CreateCommand();
         cmd.CommandText = "SELECT UserId, UserName, Email, IsActive, CreatedAt, LastLogin FROM users LIMIT 10 OFFSET 20";
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         var results = new List<RawUser>();
         while (await reader.ReadAsync())
         {
@@ -99,7 +100,7 @@ public class PaginationBenchmarks : BenchmarkBase
     {
         await using var cmd = Connection.CreateCommand();
         cmd.CommandText = "SELECT UserId, UserName, Email, IsActive, CreatedAt, LastLogin FROM users LIMIT 10";
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         var results = new List<RawUser>();
         while (await reader.ReadAsync())
         {

--- a/src/Quarry.Benchmarks/Benchmarks/SelectBenchmarks.cs
+++ b/src/Quarry.Benchmarks/Benchmarks/SelectBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using BenchmarkDotNet.Attributes;
 using Dapper;
 using Microsoft.Data.Sqlite;
@@ -17,7 +18,7 @@ public class SelectBenchmarks : BenchmarkBase
     {
         await using var cmd = Connection.CreateCommand();
         cmd.CommandText = "SELECT UserId, UserName, Email, IsActive, CreatedAt, LastLogin FROM users";
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         var results = new List<RawUser>();
         while (await reader.ReadAsync())
         {
@@ -88,7 +89,7 @@ public class SelectBenchmarks : BenchmarkBase
     {
         await using var cmd = Connection.CreateCommand();
         cmd.CommandText = "SELECT UserId, UserName, IsActive FROM users";
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         var results = new List<UserSummaryDto>();
         while (await reader.ReadAsync())
         {

--- a/src/Quarry.Benchmarks/Benchmarks/StringOpBenchmarks.cs
+++ b/src/Quarry.Benchmarks/Benchmarks/StringOpBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using BenchmarkDotNet.Attributes;
 using Dapper;
 using Microsoft.Data.Sqlite;
@@ -17,7 +18,7 @@ public class StringOpBenchmarks : BenchmarkBase
     {
         await using var cmd = Connection.CreateCommand();
         cmd.CommandText = "SELECT UserId, UserName, IsActive FROM users WHERE UserName LIKE '%User05%'";
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         var results = new List<UserSummaryDto>();
         while (await reader.ReadAsync())
         {
@@ -101,7 +102,7 @@ public class StringOpBenchmarks : BenchmarkBase
     {
         await using var cmd = Connection.CreateCommand();
         cmd.CommandText = "SELECT UserId, UserName, IsActive FROM users WHERE UserName LIKE 'User0%'";
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         var results = new List<UserSummaryDto>();
         while (await reader.ReadAsync())
         {

--- a/src/Quarry.Benchmarks/Benchmarks/ThroughputBenchmarks.cs
+++ b/src/Quarry.Benchmarks/Benchmarks/ThroughputBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using BenchmarkDotNet.Attributes;
 using Dapper;
 using Microsoft.Data.Sqlite;
@@ -26,7 +27,7 @@ public class ThroughputBenchmarks : BenchmarkBase
             await using var cmd = Connection.CreateCommand();
             cmd.CommandText = "SELECT UserId, UserName, Email, IsActive, CreatedAt, LastLogin FROM users WHERE UserId = @id";
             cmd.Parameters.AddWithValue("@id", id);
-            await using var reader = await cmd.ExecuteReaderAsync();
+            await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess | CommandBehavior.SingleRow);
             if (await reader.ReadAsync())
             {
                 _ = new RawUser


### PR DESCRIPTION
## Summary
- Closes #168

## Reason for Change
Raw ADO.NET benchmark baselines called `ExecuteReaderAsync()` without any `CommandBehavior` flags, while Dapper internally uses `CommandBehavior.SequentialAccess | CommandBehavior.SingleResult`. This made Raw baselines artificially slower, producing misleading sub-1.00x Dapper ratios (e.g., InnerJoin 0.69x, ThreeTableJoin 0.78x).

## Impact
- Raw baselines now use the same provider-level optimizations as Dapper, producing accurate overhead ratios.
- Benchmark results will change: Raw baselines will be faster, and Dapper ratios should be >= 1.00x.
- Also corrected issue #105's BenchmarkConfig documentation (`Job.MediumRun` → `Job.Default`).

## Plan items implemented as specified
- Added `CommandBehavior.SingleResult | CommandBehavior.SequentialAccess` to 13 multi-row Raw `ExecuteReaderAsync()` calls across 8 benchmark files.
- Added `CommandBehavior.SingleResult | CommandBehavior.SequentialAccess | CommandBehavior.SingleRow` to 2 single-row Raw calls (`Raw_WhereById`, `Raw_Throughput`).
- Added `using System.Data;` import to all 9 affected files.
- Updated issue #105 body to reflect `Job.Default` instead of `Job.MediumRun`.

## Deviations from plan implemented
- `Raw_FirstPage` was listed as single-row in the issue but implemented with multi-row flags per design decision — it returns up to 10 rows via `while` loop with `LIMIT 10`.

## Gaps in original plan implemented
None.

## Migration Steps
None required.

## Performance Considerations
This change is specifically about benchmark accuracy — Raw baselines will now reflect realistic ADO.NET performance with standard provider optimizations.

## Security Considerations
None — changes are limited to benchmark infrastructure, not production code.

## Breaking Changes
- Consumer-facing: None
- Internal: Benchmark result ratios will shift (expected/intended)