### PR TITLE
Optimize RawSqlAsync reader with struct-based ordinal caching (#190)

### DIFF
--- a/src/Quarry.Generator/CodeGen/FileEmitter.cs
+++ b/src/Quarry.Generator/CodeGen/FileEmitter.cs
@@ -182,6 +182,25 @@ internal sealed class FileEmitter
             }
         }
 
+        // Emit file struct row readers for RawSql DTO sites at namespace scope
+        var rawSqlStructNames = new Dictionary<string, string>();
+        {
+            int rawSqlStructIndex = 0;
+            foreach (var site in _sites)
+            {
+                if (site.Kind == InterceptorKind.RawSqlAsync
+                    && site.RawSqlTypeInfo != null
+                    && site.RawSqlTypeInfo.TypeKind != RawSqlTypeKind.Scalar
+                    && site.RawSqlTypeInfo.Properties.Count > 0)
+                {
+                    var structName = $"RawSqlReader_{site.RawSqlTypeInfo.ResultTypeName}_{rawSqlStructIndex}";
+                    rawSqlStructNames[site.UniqueId] = structName;
+                    RawSqlBodyEmitter.EmitRowReaderStruct(sb, site.RawSqlTypeInfo, structName);
+                    rawSqlStructIndex++;
+                }
+            }
+        }
+
         // File-scoped interceptor class
         sb.AppendLine($"/// <summary>");
         sb.AppendLine($"/// Generated interceptors for {_contextClassName} query methods.");
@@ -354,7 +373,7 @@ internal sealed class FileEmitter
             }
             foreach (var site in sites)
             {
-                EmitInterceptorMethod(sb, site, staticFields, staticFieldsByMethod, chainLookup, clauseBitMap, chainClauseLookup, firstClauseIds, carrierLookup, carrierClauseLookup, carrierFirstClauseIds);
+                EmitInterceptorMethod(sb, site, staticFields, staticFieldsByMethod, chainLookup, clauseBitMap, chainClauseLookup, firstClauseIds, carrierLookup, carrierClauseLookup, carrierFirstClauseIds, rawSqlStructNames);
             }
             sb.AppendLine($"    #endregion");
             sb.AppendLine();
@@ -382,7 +401,8 @@ internal sealed class FileEmitter
         HashSet<string> firstClauseIds,
         Dictionary<string, (CarrierPlan Carrier, AssembledPlan Chain)>? carrierLookup = null,
         Dictionary<string, (CarrierPlan Carrier, AssembledPlan Chain)>? carrierClauseLookup = null,
-        HashSet<string>? carrierFirstClauseIds = null)
+        HashSet<string>? carrierFirstClauseIds = null,
+        Dictionary<string, string>? rawSqlStructNames = null)
     {
         // Trace sites are compile-time-only signals — no interceptor generated
         if (site.Kind == InterceptorKind.Trace)
@@ -663,7 +683,11 @@ internal sealed class FileEmitter
                 break;
 
             case InterceptorKind.RawSqlAsync:
-                RawSqlBodyEmitter.EmitRawSqlAsync(sb, site, methodName);
+                {
+                    string? structName = null;
+                    rawSqlStructNames?.TryGetValue(site.UniqueId, out structName);
+                    RawSqlBodyEmitter.EmitRawSqlAsync(sb, site, methodName, structName);
+                }
                 break;
 
             case InterceptorKind.RawSqlScalarAsync:

--- a/src/Quarry.Generator/CodeGen/RawSqlBodyEmitter.cs
+++ b/src/Quarry.Generator/CodeGen/RawSqlBodyEmitter.cs
@@ -12,9 +12,74 @@ namespace Quarry.Generators.CodeGen;
 internal static class RawSqlBodyEmitter
 {
     /// <summary>
-    /// Emits a RawSqlAsync&lt;T&gt; interceptor with a typed reader delegate.
+    /// Emits a file struct implementing IRowReader&lt;T&gt; at namespace scope.
+    /// The struct resolves column ordinals once and caches them for per-row reads.
     /// </summary>
-    public static void EmitRawSqlAsync(StringBuilder sb, TranslatedCallSite site, string methodName)
+    public static void EmitRowReaderStruct(StringBuilder sb, RawSqlTypeInfo rawSqlInfo, string structName)
+    {
+        var resultType = rawSqlInfo.ResultTypeName;
+        var props = rawSqlInfo.Properties;
+
+        sb.AppendLine($"file struct {structName} : IRowReader<{resultType}>");
+        sb.AppendLine("{");
+
+        // Ordinal fields
+        for (int i = 0; i < props.Count; i++)
+        {
+            sb.AppendLine($"    int _ord{i};");
+        }
+
+        sb.AppendLine();
+
+        // Resolve method — discover ordinals once
+        sb.AppendLine($"    public void Resolve(DbDataReader r)");
+        sb.AppendLine($"    {{");
+        for (int i = 0; i < props.Count; i++)
+        {
+            sb.AppendLine($"        _ord{i} = -1;");
+        }
+        sb.AppendLine($"        for (var i = 0; i < r.FieldCount; i++)");
+        sb.AppendLine($"        {{");
+        sb.AppendLine($"            switch (r.GetName(i))");
+        sb.AppendLine($"            {{");
+        for (int i = 0; i < props.Count; i++)
+        {
+            sb.AppendLine($"                case \"{props[i].PropertyName}\": _ord{i} = i; break;");
+        }
+        sb.AppendLine($"            }}");
+        sb.AppendLine($"        }}");
+        sb.AppendLine($"    }}");
+
+        sb.AppendLine();
+
+        // Read method — per-row materialization using cached ordinals
+        sb.AppendLine($"    public {resultType} Read(DbDataReader r)");
+        sb.AppendLine($"    {{");
+        sb.AppendLine($"        var item = new {resultType}();");
+        for (int i = 0; i < props.Count; i++)
+        {
+            var prop = props[i];
+            var assignment = GeneratePropertyAssignment(prop, $"_ord{i}");
+            if (prop.IsNullable)
+            {
+                sb.AppendLine($"        if (_ord{i} >= 0 && !r.IsDBNull(_ord{i})) item.{prop.PropertyName} = {assignment};");
+            }
+            else
+            {
+                sb.AppendLine($"        if (_ord{i} >= 0) item.{prop.PropertyName} = {assignment};");
+            }
+        }
+        sb.AppendLine($"        return item;");
+        sb.AppendLine($"    }}");
+
+        sb.AppendLine("}");
+        sb.AppendLine();
+    }
+
+    /// <summary>
+    /// Emits a RawSqlAsync&lt;T&gt; interceptor with a typed reader delegate or struct reader.
+    /// </summary>
+    public static void EmitRawSqlAsync(StringBuilder sb, TranslatedCallSite site, string methodName, string? structName = null)
     {
         var rawSqlInfo = site.RawSqlTypeInfo;
         if (rawSqlInfo == null)
@@ -54,38 +119,46 @@ internal static class RawSqlBodyEmitter
             sb.AppendLine($"            {ctArg},");
             sb.AppendLine($"            parameters);");
         }
+        else if (structName != null && rawSqlInfo.Properties.Count > 0)
+        {
+            // Struct-based reader path
+            sb.AppendLine($"        return self.RawSqlAsyncWithReader<{resultType}, {structName}>(");
+            sb.AppendLine($"            sql,");
+            sb.AppendLine($"            {ctArg},");
+            sb.AppendLine($"            parameters);");
+        }
+        else if (rawSqlInfo.Properties.Count > 0)
+        {
+            // Fallback: lambda-based reader (no struct name provided)
+            sb.AppendLine($"        return self.RawSqlAsyncWithReader(");
+            sb.AppendLine($"            sql,");
+            sb.AppendLine($"            static r =>");
+            sb.AppendLine($"            {{");
+            sb.AppendLine($"                var item = new {resultType}();");
+            sb.AppendLine($"                for (var i = 0; i < r.FieldCount; i++)");
+            sb.AppendLine($"                {{");
+            sb.AppendLine($"                    if (r.IsDBNull(i)) continue;");
+            sb.AppendLine($"                    switch (r.GetName(i))");
+            sb.AppendLine($"                    {{");
+
+            foreach (var prop in rawSqlInfo.Properties)
+            {
+                var assignment = GeneratePropertyAssignment(prop, "i");
+                sb.AppendLine($"                        case \"{prop.PropertyName}\": item.{prop.PropertyName} = {assignment}; break;");
+            }
+
+            sb.AppendLine($"                    }}");
+            sb.AppendLine($"                }}");
+            sb.AppendLine($"                return item;");
+            sb.AppendLine($"            }},");
+            sb.AppendLine($"            {ctArg},");
+            sb.AppendLine($"            parameters);");
+        }
         else
         {
             sb.AppendLine($"        return self.RawSqlAsyncWithReader(");
             sb.AppendLine($"            sql,");
-
-            if (rawSqlInfo.Properties.Count > 0)
-            {
-                sb.AppendLine($"            static r =>");
-                sb.AppendLine($"            {{");
-                sb.AppendLine($"                var item = new {resultType}();");
-                sb.AppendLine($"                for (var i = 0; i < r.FieldCount; i++)");
-                sb.AppendLine($"                {{");
-                sb.AppendLine($"                    if (r.IsDBNull(i)) continue;");
-                sb.AppendLine($"                    switch (r.GetName(i))");
-                sb.AppendLine($"                    {{");
-
-                foreach (var prop in rawSqlInfo.Properties)
-                {
-                    var assignment = GeneratePropertyAssignment(prop);
-                    sb.AppendLine($"                        case \"{prop.PropertyName}\": item.{prop.PropertyName} = {assignment}; break;");
-                }
-
-                sb.AppendLine($"                    }}");
-                sb.AppendLine($"                }}");
-                sb.AppendLine($"                return item;");
-                sb.AppendLine($"            }},");
-            }
-            else
-            {
-                sb.AppendLine($"            static _ => new {resultType}(),");
-            }
-
+            sb.AppendLine($"            static _ => new {resultType}(),");
             sb.AppendLine($"            {ctArg},");
             sb.AppendLine($"            parameters);");
         }
@@ -134,35 +207,35 @@ internal static class RawSqlBodyEmitter
         sb.AppendLine($"    }}");
     }
 
-    private static string GeneratePropertyAssignment(RawSqlPropertyInfo prop)
+    private static string GeneratePropertyAssignment(RawSqlPropertyInfo prop, string ordinalExpr)
     {
         if (prop.CustomTypeMappingClass != null)
         {
             var dbReaderMethod = prop.DbReaderMethodName ?? "GetValue";
-            return $"new {prop.CustomTypeMappingClass}().FromDb(r.{dbReaderMethod}(i))";
+            return $"new {prop.CustomTypeMappingClass}().FromDb(r.{dbReaderMethod}({ordinalExpr}))";
         }
 
         if (prop.IsForeignKey && prop.ReferencedEntityName != null)
         {
-            return $"new EntityRef<{prop.ReferencedEntityName}, {prop.ClrType}>(r.{prop.ReaderMethodName}(i))";
+            return $"new EntityRef<{prop.ReferencedEntityName}, {prop.ClrType}>(r.{prop.ReaderMethodName}({ordinalExpr}))";
         }
 
         if (prop.IsEnum)
         {
-            return $"({prop.FullClrType})r.{prop.ReaderMethodName}(i)";
+            return $"({prop.FullClrType})r.{prop.ReaderMethodName}({ordinalExpr})";
         }
 
         if (TypeClassification.NeedsSignCast(prop.ClrType))
         {
-            return $"({prop.ClrType})r.{prop.ReaderMethodName}(i)";
+            return $"({prop.ClrType})r.{prop.ReaderMethodName}({ordinalExpr})";
         }
 
         if (prop.ReaderMethodName == "GetValue")
         {
-            return $"({prop.FullClrType})r.GetValue(i)";
+            return $"({prop.FullClrType})r.GetValue({ordinalExpr})";
         }
 
-        return $"r.{prop.ReaderMethodName}(i)";
+        return $"r.{prop.ReaderMethodName}({ordinalExpr})";
     }
 
     private static string GenerateScalarConverter(string resultType)

--- a/src/Quarry.Tests/RawSqlGeneratorPipelineTests.cs
+++ b/src/Quarry.Tests/RawSqlGeneratorPipelineTests.cs
@@ -416,25 +416,28 @@ public class Service
         var code = GetInterceptorsCode(result);
         Assert.That(code, Is.Not.Null, "Should generate interceptors file");
 
-        // Interceptor should be generated for the entity type
-        Assert.That(code, Does.Contain("RawSqlAsyncWithReader"),
-            "Should generate RawSqlAsync interceptor for entity T");
+        // Interceptor should be generated with struct-based row reader
+        Assert.That(code, Does.Contain("RawSqlAsyncWithReader<Order,"),
+            "Should generate struct-based RawSqlAsync interceptor for entity T");
         Assert.That(code, Does.Contain("IAsyncEnumerable<Order>"),
             "Interceptor return type should use the entity type Order");
+        Assert.That(code, Does.Contain("IRowReader<Order>"),
+            "Should emit struct implementing IRowReader<Order>");
         Assert.That(code, Does.Contain("new Order()"),
-            "Interceptor reader should construct the entity");
+            "Struct Read method should construct the entity");
 
-        // Entity enrichment should produce a full property-reading switch, not a no-op
+        // Struct Resolve: ordinal discovery via switch
         Assert.That(code, Does.Contain("switch (r.GetName(i))"),
-            "Should generate switch-based reader for enriched entity type");
+            "Should generate switch-based ordinal discovery in Resolve");
         Assert.That(code, Does.Contain("case \"OrderId\""),
             "Should generate switch case for OrderId column");
         Assert.That(code, Does.Contain("case \"Total\""),
             "Should generate switch case for Total column");
         Assert.That(code, Does.Contain("case \"Priority\""),
             "Should generate switch case for Priority column");
-        Assert.That(code, Does.Contain("(global::TestApp.OrderPriority)r.GetInt32(i)"),
-            "Should generate enum cast for Priority column");
+        // Struct Read: typed reads with cached ordinals
+        Assert.That(code, Does.Contain("(global::TestApp.OrderPriority)r.GetInt32(_ord"),
+            "Should generate enum cast for Priority column with cached ordinal");
         Assert.That(code, Does.Contain("case \"UserId\""),
             "Should generate switch case for FK UserId column");
         Assert.That(code, Does.Contain("EntityRef<User, int>"),

--- a/src/Quarry.Tests/RawSqlInterceptorTests.cs
+++ b/src/Quarry.Tests/RawSqlInterceptorTests.cs
@@ -32,13 +32,19 @@ public class RawSqlInterceptorTests
         var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
             "AppDbContext", "TestApp", "test0000", new[] { site });
 
-        // Assert
+        // Assert — struct-based row reader
         Assert.That(result, Does.Contain("IAsyncEnumerable<UserDto>"));
         Assert.That(result, Does.Contain("this QuarryContext self"));
-        Assert.That(result, Does.Contain("RawSqlAsyncWithReader"));
+        Assert.That(result, Does.Contain("RawSqlAsyncWithReader<UserDto, RawSqlReader_UserDto_0>"));
+        Assert.That(result, Does.Contain("file struct RawSqlReader_UserDto_0 : IRowReader<UserDto>"));
         Assert.That(result, Does.Contain("var item = new UserDto()"));
-        Assert.That(result, Does.Contain("case \"Name\": item.Name = r.GetString(i); break;"));
-        Assert.That(result, Does.Contain("case \"Email\": item.Email = r.GetString(i); break;"));
+        // Resolve: ordinal discovery
+        Assert.That(result, Does.Contain("case \"Name\": _ord0 = i; break;"));
+        Assert.That(result, Does.Contain("case \"Email\": _ord1 = i; break;"));
+        // Read: non-nullable Name has no IsDBNull guard
+        Assert.That(result, Does.Contain("if (_ord0 >= 0) item.Name = r.GetString(_ord0);"));
+        // Read: nullable Email has IsDBNull guard
+        Assert.That(result, Does.Contain("if (_ord1 >= 0 && !r.IsDBNull(_ord1)) item.Email = r.GetString(_ord1);"));
     }
 
     [Test]
@@ -229,8 +235,8 @@ public class RawSqlInterceptorTests
         var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
             "AppDbContext", "TestApp", "test0000", new[] { site });
 
-        // Assert
-        Assert.That(result, Does.Contain("(UserStatus)r.GetInt32(i)"));
+        // Assert — enum cast uses cached ordinal in struct Read method
+        Assert.That(result, Does.Contain("(UserStatus)r.GetInt32(_ord1)"));
     }
 
     [Test]
@@ -253,8 +259,8 @@ public class RawSqlInterceptorTests
         var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
             "AppDbContext", "TestApp", "test0000", new[] { site });
 
-        // Assert
-        Assert.That(result, Does.Contain("new EntityRef<User, int>(r.GetInt32(i))"));
+        // Assert — FK wrapper uses cached ordinal in struct Read method
+        Assert.That(result, Does.Contain("new EntityRef<User, int>(r.GetInt32(_ord1))"));
     }
 
     [Test]
@@ -277,8 +283,8 @@ public class RawSqlInterceptorTests
         var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
             "AppDbContext", "TestApp", "test0000", new[] { site });
 
-        // Assert
-        Assert.That(result, Does.Contain("new MoneyMapping().FromDb(r.GetDecimal(i))"));
+        // Assert — custom type mapping uses cached ordinal in struct Read method
+        Assert.That(result, Does.Contain("new MoneyMapping().FromDb(r.GetDecimal(_ord1))"));
     }
 
     [Test]
@@ -301,9 +307,9 @@ public class RawSqlInterceptorTests
         var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
             "AppDbContext", "TestApp", "test0000", new[] { site });
 
-        // Assert — should use typed GetFieldValue, not bare GetValue
-        Assert.That(result, Does.Contain("r.GetFieldValue<byte[]>(i)"));
-        Assert.That(result, Does.Not.Contain("r.GetValue(i)"));
+        // Assert — should use typed GetFieldValue with cached ordinal, not bare GetValue
+        Assert.That(result, Does.Contain("r.GetFieldValue<byte[]>(_ord1)"));
+        Assert.That(result, Does.Not.Contain("r.GetValue(_ord"));
     }
 
     [Test]
@@ -326,8 +332,8 @@ public class RawSqlInterceptorTests
         var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
             "AppDbContext", "TestApp", "test0000", new[] { site });
 
-        // Assert — nullable byte[]? should still use GetFieldValue, with IsDBNull guard from the loop
-        Assert.That(result, Does.Contain("case \"Password\": item.Password = r.GetFieldValue<byte[]>(i); break;"));
+        // Assert — nullable byte[]? should use GetFieldValue with IsDBNull guard in struct Read method
+        Assert.That(result, Does.Contain("if (_ord1 >= 0 && !r.IsDBNull(_ord1)) item.Password = r.GetFieldValue<byte[]>(_ord1);"));
     }
 
     #endregion
@@ -354,10 +360,10 @@ public class RawSqlInterceptorTests
         var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
             "AppDbContext", "TestApp", "test0000", new[] { site });
 
-        // Assert - all properties handled (nullable check is via IsDBNull in the for loop)
-        Assert.That(result, Does.Contain("case \"Name\": item.Name = r.GetString(i); break;"));
-        Assert.That(result, Does.Contain("case \"MiddleName\": item.MiddleName = r.GetString(i); break;"));
-        Assert.That(result, Does.Contain("case \"Age\": item.Age = r.GetInt32(i); break;"));
+        // Assert — struct Read method: non-nullable has no IsDBNull, nullable has IsDBNull guard
+        Assert.That(result, Does.Contain("if (_ord0 >= 0) item.Name = r.GetString(_ord0);"));
+        Assert.That(result, Does.Contain("if (_ord1 >= 0 && !r.IsDBNull(_ord1)) item.MiddleName = r.GetString(_ord1);"));
+        Assert.That(result, Does.Contain("if (_ord2 >= 0 && !r.IsDBNull(_ord2)) item.Age = r.GetInt32(_ord2);"));
     }
 
     #endregion
@@ -409,8 +415,8 @@ public class RawSqlInterceptorTests
         var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
             "AppDbContext", "TestApp", "test0000", new[] { site });
 
-        // Assert — GetValue result must be cast to the target type
-        Assert.That(result, Does.Contain("(MyNamespace.SomeCustomType)r.GetValue(i)"));
+        // Assert — GetValue result must be cast to the target type, using cached ordinal
+        Assert.That(result, Does.Contain("(MyNamespace.SomeCustomType)r.GetValue(_ord0)"));
     }
 
     #endregion
@@ -547,12 +553,20 @@ public class RawSqlInterceptorTests
         var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
             "AppDbContext", "TestApp", "test0000", new[] { site });
 
-        Assert.That(result, Does.Contain("case \"Id\": item.Id = r.GetInt32(i); break;"));
-        Assert.That(result, Does.Contain("case \"Name\": item.Name = r.GetString(i); break;"));
-        Assert.That(result, Does.Contain("case \"CreatedAt\": item.CreatedAt = r.GetDateTime(i); break;"));
-        Assert.That(result, Does.Contain("case \"IsActive\": item.IsActive = r.GetBoolean(i); break;"));
-        Assert.That(result, Does.Contain("case \"Balance\": item.Balance = r.GetDecimal(i); break;"));
-        Assert.That(result, Does.Contain("case \"Notes\": item.Notes = r.GetString(i); break;"));
+        // Struct Resolve: ordinal discovery for all properties
+        Assert.That(result, Does.Contain("case \"Id\": _ord0 = i; break;"));
+        Assert.That(result, Does.Contain("case \"Name\": _ord1 = i; break;"));
+        Assert.That(result, Does.Contain("case \"CreatedAt\": _ord2 = i; break;"));
+        Assert.That(result, Does.Contain("case \"IsActive\": _ord3 = i; break;"));
+        Assert.That(result, Does.Contain("case \"Balance\": _ord4 = i; break;"));
+        Assert.That(result, Does.Contain("case \"Notes\": _ord5 = i; break;"));
+        // Struct Read: typed reads with cached ordinals (Notes is nullable, gets IsDBNull)
+        Assert.That(result, Does.Contain("item.Id = r.GetInt32(_ord0)"));
+        Assert.That(result, Does.Contain("item.Name = r.GetString(_ord1)"));
+        Assert.That(result, Does.Contain("item.CreatedAt = r.GetDateTime(_ord2)"));
+        Assert.That(result, Does.Contain("item.IsActive = r.GetBoolean(_ord3)"));
+        Assert.That(result, Does.Contain("item.Balance = r.GetDecimal(_ord4)"));
+        Assert.That(result, Does.Contain("!r.IsDBNull(_ord5)) item.Notes = r.GetString(_ord5)"));
     }
 
     #endregion

--- a/src/Quarry.Tests/RawSqlInterceptorTests.cs
+++ b/src/Quarry.Tests/RawSqlInterceptorTests.cs
@@ -397,6 +397,60 @@ public class RawSqlInterceptorTests
     }
 
     [Test]
+    public void GenerateInterceptorsFile_MultipleDtoSites_GeneratesUniqueStructNames()
+    {
+        // Arrange — two DTO sites for different types in the same file
+        var userSite = CreateRawSqlCallSite(
+            InterceptorKind.RawSqlAsync, "UserDto",
+            new RawSqlTypeInfo("UserDto", RawSqlTypeKind.Dto,
+                new[] { new RawSqlPropertyInfo("Name", "string", "GetString", false) }),
+            uniqueId: "site_user");
+
+        var orderSite = CreateRawSqlCallSite(
+            InterceptorKind.RawSqlAsync, "OrderDto",
+            new RawSqlTypeInfo("OrderDto", RawSqlTypeKind.Dto,
+                new[] { new RawSqlPropertyInfo("Total", "decimal", "GetDecimal", false) }),
+            uniqueId: "site_order");
+
+        // Act
+        var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
+            "AppDbContext", "TestApp", "test0000", new[] { userSite, orderSite });
+
+        // Assert — each DTO site gets a uniquely named struct
+        Assert.That(result, Does.Contain("file struct RawSqlReader_UserDto_0 : IRowReader<UserDto>"));
+        Assert.That(result, Does.Contain("file struct RawSqlReader_OrderDto_1 : IRowReader<OrderDto>"));
+        Assert.That(result, Does.Contain("RawSqlAsyncWithReader<UserDto, RawSqlReader_UserDto_0>"));
+        Assert.That(result, Does.Contain("RawSqlAsyncWithReader<OrderDto, RawSqlReader_OrderDto_1>"));
+    }
+
+    [Test]
+    public void RawSqlAsync_AllNonNullableDto_NoIsDBNullGuards()
+    {
+        // Arrange — all properties are non-nullable
+        var rawSqlTypeInfo = new RawSqlTypeInfo(
+            "StrictDto",
+            RawSqlTypeKind.Dto,
+            new[]
+            {
+                new RawSqlPropertyInfo("Id", "int", "GetInt32", false),
+                new RawSqlPropertyInfo("Name", "string", "GetString", false),
+                new RawSqlPropertyInfo("Value", "decimal", "GetDecimal", false)
+            });
+
+        var site = CreateRawSqlCallSite(InterceptorKind.RawSqlAsync, "StrictDto", rawSqlTypeInfo);
+
+        // Act
+        var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
+            "AppDbContext", "TestApp", "test0000", new[] { site });
+
+        // Assert — no IsDBNull guards since all properties are non-nullable
+        Assert.That(result, Does.Not.Contain("IsDBNull"));
+        Assert.That(result, Does.Contain("if (_ord0 >= 0) item.Id = r.GetInt32(_ord0);"));
+        Assert.That(result, Does.Contain("if (_ord1 >= 0) item.Name = r.GetString(_ord1);"));
+        Assert.That(result, Does.Contain("if (_ord2 >= 0) item.Value = r.GetDecimal(_ord2);"));
+    }
+
+    [Test]
     public void RawSqlAsync_DtoType_WithGetValueFallback_GeneratesCast()
     {
         // Arrange — simulate an unknown type that falls through to GetValue

--- a/src/Quarry.Tests/SignCastReaderTests.cs
+++ b/src/Quarry.Tests/SignCastReaderTests.cs
@@ -248,10 +248,10 @@ public class SignCastReaderTests
         var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
             "AppDbContext", "TestApp", "test0000", new[] { site });
 
-        Assert.That(result, Does.Contain("case \"Ipv4\": item.Ipv4 = (uint)r.GetInt32(i); break;"),
-            "uint DTO property should have cast from GetInt32");
-        Assert.That(result, Does.Contain("case \"Name\": item.Name = r.GetString(i); break;"),
-            "string property should not have cast");
+        Assert.That(result, Does.Contain("item.Ipv4 = (uint)r.GetInt32(_ord0)"),
+            "uint DTO property should have cast from GetInt32 using cached ordinal");
+        Assert.That(result, Does.Contain("item.Name = r.GetString(_ord1)"),
+            "string property should not have cast, using cached ordinal");
     }
 
     #endregion

--- a/src/Quarry/Context/QuarryContext.cs
+++ b/src/Quarry/Context/QuarryContext.cs
@@ -339,6 +339,41 @@ public abstract class QuarryContext : IAsyncDisposable, IDisposable
     }
 
     /// <summary>
+    /// Executes a raw SQL query using a struct-based row reader that caches column ordinals.
+    /// Called by source-generated interceptors for RawSqlAsync&lt;T&gt; (DTO path).
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public IAsyncEnumerable<T> RawSqlAsyncWithReader<T, TReader>(
+        string sql,
+        CancellationToken cancellationToken,
+        params object?[] parameters)
+        where TReader : struct, IRowReader<T>
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+
+        var opId = OpId.Next();
+
+        if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Debug, RawSqlLog.CategoryName) == true)
+            RawSqlLog.SqlGenerated(opId, sql);
+
+        LogRawParameters(opId, parameters);
+
+        var command = _connection.CreateCommand();
+        command.CommandText = sql;
+        command.CommandTimeout = (int)_defaultTimeout.TotalSeconds;
+
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            var param = command.CreateParameter();
+            param.ParameterName = $"@p{i}";
+            param.Value = (parameters[i] is SensitiveParameter sp ? sp.Value : parameters[i]) ?? DBNull.Value;
+            command.Parameters.Add(param);
+        }
+
+        return QueryExecutor.ToCarrierAsyncEnumerableWithCommandAsync<T, TReader>(opId, this, command, cancellationToken);
+    }
+
+    /// <summary>
     /// Executes a raw SQL scalar query with typed conversion instead of Convert.ChangeType.
     /// Called by source-generated interceptors for RawSqlScalarAsync&lt;T&gt;.
     /// </summary>

--- a/src/Quarry/IRowReader.cs
+++ b/src/Quarry/IRowReader.cs
@@ -1,0 +1,23 @@
+using System.Data.Common;
+
+namespace Quarry;
+
+/// <summary>
+/// Interface for struct-based row readers used by generated RawSqlAsync interceptors.
+/// Implementations resolve column ordinals once via <see cref="Resolve"/> and then
+/// read rows efficiently via cached ordinals in <see cref="Read"/>.
+/// </summary>
+/// <typeparam name="T">The result type to materialize from each row.</typeparam>
+public interface IRowReader<T>
+{
+    /// <summary>
+    /// Resolves column ordinals from the reader. Called once after ExecuteReaderAsync,
+    /// before the first ReadAsync.
+    /// </summary>
+    void Resolve(DbDataReader reader);
+
+    /// <summary>
+    /// Reads a single row using cached ordinals.
+    /// </summary>
+    T Read(DbDataReader reader);
+}

--- a/src/Quarry/Internal/QueryExecutor.cs
+++ b/src/Quarry/Internal/QueryExecutor.cs
@@ -341,6 +341,53 @@ public static class QueryExecutor
     }
 
     /// <summary>
+    /// Executes a carrier-optimized query using a struct-based row reader that caches column ordinals.
+    /// The reader's Resolve method is called once after ExecuteReaderAsync, then Read is called per row.
+    /// </summary>
+    public static async IAsyncEnumerable<TResult> ToCarrierAsyncEnumerableWithCommandAsync<TResult, TReader>(
+        long opId, QuarryContext ctx,
+        DbCommand command,
+        [EnumeratorCancellation] CancellationToken ct)
+        where TReader : struct, IRowReader<TResult>
+    {
+        await using var _cmd = command;
+        await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
+
+        var startTimestamp = Stopwatch.GetTimestamp();
+        await using var dbReader = await command.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess, ct).ConfigureAwait(false);
+
+        var reader = new TReader();
+        reader.Resolve(dbReader);
+
+        int rowCount = 0;
+        while (await dbReader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            TResult result;
+            try
+            {
+                result = reader.Read(dbReader);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Error, QueryLog.CategoryName) == true)
+                    QueryLog.QueryFailed(opId, ex);
+
+                throw new QuarryQueryException($"Error reading query results: {ex.Message}", command.CommandText, ex);
+            }
+
+            rowCount++;
+            yield return result;
+        }
+
+        var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
+
+        if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
+            QueryLog.FetchCompleted(opId, rowCount, elapsedMs);
+
+        CheckSlowQuery(opId, ctx, elapsedMs, command.CommandText);
+    }
+
+    /// <summary>
     /// Checks if a query exceeded the slow query threshold and emits a warning.
     /// </summary>
     private static void CheckSlowQuery(long opId, QuarryContext context, double elapsedMs, string sql)


### PR DESCRIPTION
## Summary
- Closes #190

## Reason for Change
The current `RawSqlAsync<T>` reader uses a `Func<DbDataReader, T>` lambda that calls `r.GetName(i)` per column per row, allocating a string per call, and blanket-checks `IsDBNull` for all columns. This PR replaces it with a generated `file struct` implementing `IRowReader<T>` that resolves ordinals once and caches them for all subsequent row reads.

## Impact
- **Zero extra heap allocation**: struct hoisted into async state machine
- **`GetName` called once per column total** (not per row)
- **`IsDBNull` only for nullable properties**: non-nullable properties throw on DB null (intentional — surfaces data integrity issues)
- **Partial column selection preserved**: ordinals default to -1 for missing columns
- **JIT specializes per struct type** (no boxing)

## Plan items implemented as specified
- Phase 1: `IRowReader<T>` interface with `Resolve`/`Read` methods, `RawSqlAsyncWithReader<T, TReader>` overload on `QuarryContext`, `ToCarrierAsyncEnumerableWithCommandAsync<TResult, TReader>` overload on `QueryExecutor`
- Phase 2: `RawSqlBodyEmitter.EmitRowReaderStruct` for namespace-scope `file struct` emission, `FileEmitter` loops RawSql DTO sites to emit structs before the interceptor class, struct naming via `RawSqlReader_{ResultType}_{index}`
- Phase 3: Updated all test assertions for struct-based codegen shape

## Deviations from plan implemented
- `EmitRowReaderStruct` takes `RawSqlTypeInfo` instead of `TranslatedCallSite` (cleaner — passes only needed data)
- Lambda fallback path retained in `EmitRawSqlAsync` for defensiveness (dead code in normal execution)

## Gaps in original plan implemented
- Added multi-DTO struct uniqueness test (review finding)
- Added all-non-nullable DTO test verifying no `IsDBNull` guards (review finding)

## Migration Steps
None — this is a compile-time code generation change. Generated interceptors now emit `file struct` readers instead of lambdas. No runtime API changes for consumers.

## Performance Considerations
Primary motivation. Eliminates per-row `GetName` string allocations and per-row `IsDBNull` checks for non-nullable columns. Struct-based reader avoids heap allocation.

## Security Considerations
No new input boundaries. Parameterized queries and `SensitiveParameter` handling preserved identically. `file struct` visibility prevents external access to generated reader types.

## Breaking Changes
- Consumer-facing: None
- Internal: Generated code shape changes from lambda to struct call. `IRowReader<T>` added as new public interface (required for generic constraint).