### PR TITLE
Add Many<T> aggregate extensions: Sum, Min, Max, Avg (#179)

### DIFF
--- a/llm.md
+++ b/llm.md
@@ -377,7 +377,7 @@ All model types implement `IEquatable<T>` for Roslyn incremental caching. `Equat
 
 ### Navigation Subquery Pipeline
 
-`Many<T>` exposes compile-time markers: `Any()`, `Any(pred)`, `All(pred)`, `Count()`, `Count(pred)`. `SqlExprParser` detects `<param>.<nav>.<Method>()` → `SubqueryExpr`. FK-to-PK correlation via `NavigationInfo.ForeignKeyPropertyName`. Scope stack in `SqlExprBinder` enables nesting. SQL: `EXISTS (SELECT 1 ...)`, `NOT EXISTS (... AND NOT ...)`, `(SELECT COUNT(*) ...)`.
+`Many<T>` exposes compile-time markers: `Any()`, `Any(pred)`, `All(pred)`, `Count()`, `Count(pred)`, `Sum(selector)`, `Min(selector)`, `Max(selector)`, `Avg(selector)`/`Average(selector)`. `SqlExprParser` detects `<param>.<nav>.<Method>()` → `SubqueryExpr`. FK-to-PK correlation via `NavigationInfo.ForeignKeyPropertyName`. Scope stack in `SqlExprBinder` enables nesting. SQL: `EXISTS (SELECT 1 ...)`, `NOT EXISTS (... AND NOT ...)`, `(SELECT COUNT(*) ...)`, `(SELECT SUM/MIN/MAX/AVG(column) ...)`.
 
 ### Insert Pipeline
 

--- a/src/Quarry.Generator/IR/SqlExpr.cs
+++ b/src/Quarry.Generator/IR/SqlExpr.cs
@@ -105,5 +105,13 @@ internal enum SubqueryKind
     /// <summary>.All(predicate) -> NOT EXISTS (SELECT 1 FROM ... AND NOT predicate)</summary>
     All,
     /// <summary>.Count() or .Count(predicate) -> (SELECT COUNT(*) FROM ...)</summary>
-    Count
+    Count,
+    /// <summary>.Sum(selector) -> (SELECT SUM(column) FROM ...)</summary>
+    Sum,
+    /// <summary>.Min(selector) -> (SELECT MIN(column) FROM ...)</summary>
+    Min,
+    /// <summary>.Max(selector) -> (SELECT MAX(column) FROM ...)</summary>
+    Max,
+    /// <summary>.Avg(selector) -> (SELECT AVG(column) FROM ...)</summary>
+    Avg
 }

--- a/src/Quarry.Generator/IR/SqlExprBinder.cs
+++ b/src/Quarry.Generator/IR/SqlExprBinder.cs
@@ -430,10 +430,11 @@ internal static class SqlExprBinder
             throughTargetEntity = tte;
         }
 
-        // Bind predicate if present
+        // Bind predicate and/or selector if present
         SqlExpr? boundPredicate = sub.Predicate;
+        SqlExpr? boundSelector = sub.Selector;
         BindContext? innerCtx = null;
-        if (boundPredicate != null && sub.InnerParameterName != null)
+        if ((boundPredicate != null || boundSelector != null) && sub.InnerParameterName != null)
         {
             // For through-navigations, bind predicate in the target entity context
             var predicateEntity = throughTargetEntity ?? targetEntity;
@@ -546,11 +547,14 @@ internal static class SqlExprBinder
                 }
             }
 
-            boundPredicate = BindExpr(boundPredicate, innerCtx, false);
+            if (boundPredicate != null)
+                boundPredicate = BindExpr(boundPredicate, innerCtx, false);
+            if (boundSelector != null)
+                boundSelector = BindExpr(boundSelector, innerCtx, false);
             ctx.SubqueryAliasCounter = innerCtx.SubqueryAliasCounter;
         }
 
-        // For HasManyThrough without predicate: still create junction→target implicit join
+        // For HasManyThrough without predicate or selector: still create junction→target implicit join
         // so that Count()/Any()/All() operate against the target table, not the junction.
         List<ImplicitJoinInfo>? noPredicateThroughJoins = null;
         if (throughTargetEntity != null && innerCtx == null)
@@ -618,7 +622,8 @@ internal static class SqlExprBinder
             sub.InnerParameterName,
             innerTableQuoted,
             innerAliasQuoted,
-            correlationSql);
+            correlationSql,
+            selector: boundSelector);
 
         // Propagate implicit joins from subquery predicate binding or no-predicate through-join
         if (innerCtx != null && innerCtx.ImplicitJoins.Count > 0)

--- a/src/Quarry.Generator/IR/SqlExprNodes.cs
+++ b/src/Quarry.Generator/IR/SqlExprNodes.cs
@@ -608,6 +608,7 @@ internal sealed class SubqueryExpr : SqlExpr
     public string NavigationPropertyName { get; }
     public SubqueryKind SubqueryKind { get; }
     public SqlExpr? Predicate { get; }
+    public SqlExpr? Selector { get; }
     public string? InnerParameterName { get; }
 
     // --- Binder-assigned fields (resolved) ---
@@ -621,13 +622,15 @@ internal sealed class SubqueryExpr : SqlExpr
         string navigationPropertyName,
         SubqueryKind subqueryKind,
         SqlExpr? predicate,
-        string? innerParameterName)
-        : base(ComputeHash(outerParameterName, navigationPropertyName, subqueryKind, predicate))
+        string? innerParameterName,
+        SqlExpr? selector = null)
+        : base(ComputeHash(outerParameterName, navigationPropertyName, subqueryKind, predicate, selector))
     {
         OuterParameterName = outerParameterName;
         NavigationPropertyName = navigationPropertyName;
         SubqueryKind = subqueryKind;
         Predicate = predicate;
+        Selector = selector;
         InnerParameterName = innerParameterName;
         IsResolved = false;
     }
@@ -640,13 +643,15 @@ internal sealed class SubqueryExpr : SqlExpr
         string? innerParameterName,
         string innerTableQuoted,
         string innerAliasQuoted,
-        string correlationSql)
-        : base(ComputeHash(outerParameterName, navigationPropertyName, subqueryKind, predicate))
+        string correlationSql,
+        SqlExpr? selector = null)
+        : base(ComputeHash(outerParameterName, navigationPropertyName, subqueryKind, predicate, selector))
     {
         OuterParameterName = outerParameterName;
         NavigationPropertyName = navigationPropertyName;
         SubqueryKind = subqueryKind;
         Predicate = predicate;
+        Selector = selector;
         InnerParameterName = innerParameterName;
         InnerTableQuoted = innerTableQuoted;
         InnerAliasQuoted = innerAliasQuoted;
@@ -654,7 +659,7 @@ internal sealed class SubqueryExpr : SqlExpr
         IsResolved = true;
     }
 
-    private static int ComputeHash(string outerParam, string navProp, SubqueryKind kind, SqlExpr? predicate)
+    private static int ComputeHash(string outerParam, string navProp, SubqueryKind kind, SqlExpr? predicate, SqlExpr? selector = null)
     {
         var hc = new HashCode();
         hc.Add(SqlExprKind.Subquery);
@@ -662,6 +667,7 @@ internal sealed class SubqueryExpr : SqlExpr
         hc.Add(navProp);
         hc.Add((int)kind);
         if (predicate != null) hc.Add(predicate.GetHashCode());
+        if (selector != null) hc.Add(selector.GetHashCode());
         return hc.ToHashCode();
     }
 
@@ -682,7 +688,7 @@ internal sealed class SubqueryExpr : SqlExpr
             OuterParameterName, NavigationPropertyName, SubqueryKind,
             Predicate, InnerParameterName,
             InnerTableQuoted!, InnerAliasQuoted!, CorrelationSql!,
-            implicitJoins);
+            Selector, implicitJoins);
     }
 
     private SubqueryExpr(
@@ -694,13 +700,15 @@ internal sealed class SubqueryExpr : SqlExpr
         string innerTableQuoted,
         string innerAliasQuoted,
         string correlationSql,
+        SqlExpr? selector,
         IReadOnlyList<ImplicitJoinInfo>? implicitJoins)
-        : base(ComputeHash(outerParameterName, navigationPropertyName, subqueryKind, predicate))
+        : base(ComputeHash(outerParameterName, navigationPropertyName, subqueryKind, predicate, selector))
     {
         OuterParameterName = outerParameterName;
         NavigationPropertyName = navigationPropertyName;
         SubqueryKind = subqueryKind;
         Predicate = predicate;
+        Selector = selector;
         InnerParameterName = innerParameterName;
         InnerTableQuoted = innerTableQuoted;
         InnerAliasQuoted = innerAliasQuoted;
@@ -716,7 +724,8 @@ internal sealed class SubqueryExpr : SqlExpr
             && NavigationPropertyName == o.NavigationPropertyName
             && SubqueryKind == o.SubqueryKind
             && InnerParameterName == o.InnerParameterName
-            && Equals(Predicate, o.Predicate);
+            && Equals(Predicate, o.Predicate)
+            && Equals(Selector, o.Selector);
     }
 }
 

--- a/src/Quarry.Generator/IR/SqlExprParser.cs
+++ b/src/Quarry.Generator/IR/SqlExprParser.cs
@@ -751,7 +751,8 @@ internal static class SqlExprParser
 
     private static bool IsSubqueryMethod(string methodName)
     {
-        return methodName == "Any" || methodName == "All" || methodName == "Count";
+        return methodName == "Any" || methodName == "All" || methodName == "Count"
+            || methodName == "Sum" || methodName == "Min" || methodName == "Max" || methodName == "Avg";
     }
 
     private static SqlExpr ParseSubqueryCall(
@@ -766,10 +767,17 @@ internal static class SqlExprParser
             "Any" => SubqueryKind.Exists,
             "All" => SubqueryKind.All,
             "Count" => SubqueryKind.Count,
+            "Sum" => SubqueryKind.Sum,
+            "Min" => SubqueryKind.Min,
+            "Max" => SubqueryKind.Max,
+            "Avg" => SubqueryKind.Avg,
             _ => SubqueryKind.Exists
         };
 
+        var isAggregate = kind is SubqueryKind.Sum or SubqueryKind.Min or SubqueryKind.Max or SubqueryKind.Avg;
+
         SqlExpr? predicate = null;
+        SqlExpr? selector = null;
         string? innerParamName = null;
 
         if (argumentList.Arguments.Count == 1)
@@ -782,18 +790,24 @@ internal static class SqlExprParser
                 var body = simpleLambda.Body as ExpressionSyntax;
                 if (body != null)
                 {
+                    SqlExpr parsed;
                     if (context != null)
                     {
                         context.Push("Arguments[1]");
                         context.Push("LambdaBody");
-                        predicate = ParseExpression(body, innerParams, context);
+                        parsed = ParseExpression(body, innerParams, context);
                         context.Pop();
                         context.Pop();
                     }
                     else
                     {
-                        predicate = ParseExpression(body, innerParams, null);
+                        parsed = ParseExpression(body, innerParams, null);
                     }
+
+                    if (isAggregate)
+                        selector = parsed;
+                    else
+                        predicate = parsed;
                 }
             }
             else if (argExpr is ParenthesizedLambdaExpressionSyntax parenLambda
@@ -804,18 +818,24 @@ internal static class SqlExprParser
                 var body = parenLambda.Body as ExpressionSyntax;
                 if (body != null)
                 {
+                    SqlExpr parsed;
                     if (context != null)
                     {
                         context.Push("Arguments[1]");
                         context.Push("LambdaBody");
-                        predicate = ParseExpression(body, innerParams, context);
+                        parsed = ParseExpression(body, innerParams, context);
                         context.Pop();
                         context.Pop();
                     }
                     else
                     {
-                        predicate = ParseExpression(body, innerParams, null);
+                        parsed = ParseExpression(body, innerParams, null);
                     }
+
+                    if (isAggregate)
+                        selector = parsed;
+                    else
+                        predicate = parsed;
                 }
             }
         }
@@ -825,6 +845,7 @@ internal static class SqlExprParser
             navRef.PropertyName,
             kind,
             predicate,
-            innerParamName);
+            innerParamName,
+            selector: selector);
     }
 }

--- a/src/Quarry.Generator/IR/SqlExprParser.cs
+++ b/src/Quarry.Generator/IR/SqlExprParser.cs
@@ -752,7 +752,8 @@ internal static class SqlExprParser
     private static bool IsSubqueryMethod(string methodName)
     {
         return methodName == "Any" || methodName == "All" || methodName == "Count"
-            || methodName == "Sum" || methodName == "Min" || methodName == "Max" || methodName == "Avg";
+            || methodName == "Sum" || methodName == "Min" || methodName == "Max"
+            || methodName == "Avg" || methodName == "Average";
     }
 
     private static SqlExpr ParseSubqueryCall(
@@ -770,7 +771,7 @@ internal static class SqlExprParser
             "Sum" => SubqueryKind.Sum,
             "Min" => SubqueryKind.Min,
             "Max" => SubqueryKind.Max,
-            "Avg" => SubqueryKind.Avg,
+            "Avg" or "Average" => SubqueryKind.Avg,
             _ => SubqueryKind.Exists
         };
 

--- a/src/Quarry.Generator/IR/SqlExprRenderer.cs
+++ b/src/Quarry.Generator/IR/SqlExprRenderer.cs
@@ -441,6 +441,35 @@ internal static class SqlExprRenderer
                 AppendSubqueryPredicate(sub.Predicate, " AND ", dialect, paramBase, sb, genericParams);
                 sb.Append(')');
                 break;
+
+            case SubqueryKind.Sum:
+            case SubqueryKind.Min:
+            case SubqueryKind.Max:
+            case SubqueryKind.Avg:
+                var aggFunc = sub.SubqueryKind switch
+                {
+                    SubqueryKind.Sum => "SUM",
+                    SubqueryKind.Min => "MIN",
+                    SubqueryKind.Max => "MAX",
+                    SubqueryKind.Avg => "AVG",
+                    _ => "SUM"
+                };
+                sb.Append("(SELECT ");
+                sb.Append(aggFunc);
+                sb.Append('(');
+                if (sub.Selector != null)
+                    RenderExpr(sub.Selector, dialect, paramBase, sb, genericParams);
+                else
+                    sb.Append('*');
+                sb.Append(") FROM ");
+                sb.Append(sub.InnerTableQuoted);
+                sb.Append(" AS ");
+                sb.Append(sub.InnerAliasQuoted);
+                AppendImplicitJoins(sub, dialect, sb);
+                sb.Append(" WHERE ");
+                sb.Append(sub.CorrelationSql);
+                sb.Append(')');
+                break;
         }
     }
 

--- a/src/Quarry.Tests/ManifestOutput/quarry-manifest.mysql.md
+++ b/src/Quarry.Tests/ManifestOutput/quarry-manifest.mysql.md
@@ -1143,6 +1143,14 @@ SELECT `UserName`, `Email` FROM `users` WHERE `IsActive` = 1 AND EXISTS (SELECT 
 ### Users().Where(...).Prepare().ToDiagnostics()
 
 ```sql
+SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (SELECT AVG(`sq0`.`Total`) FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId`) > 160
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
 SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (SELECT COUNT(*) FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId` AND (`sq0`.`Status` = 'paid')) >= 1
 ```
 
@@ -1180,6 +1188,50 @@ SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM 
 
 ```sql
 SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (SELECT COUNT(*) FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId`) > 5
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (SELECT MAX(`sq0`.`OrderDate`) FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId`) > ?
+```
+
+| Parameter | Type |
+|-----------|------|
+| `@p0` | `DateTime` |
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (SELECT MAX(`sq0`.`Total`) FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId`) > 200
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (SELECT MIN(`sq0`.`Total`) FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId`) < 100
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (SELECT SUM(`sq0`.`Total`) FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId`) = 0 OR NOT (EXISTS (SELECT 1 FROM `orders` AS `sq1` WHERE `sq1`.`UserId` = `users`.`UserId`))
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (SELECT SUM(`sq0`.`Total`) FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId`) > 200
 ```
 
 ---
@@ -1965,7 +2017,7 @@ SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM 
 
 | Metric | Count |
 |--------|------:|
-| Total discovered | 256 |
+| Total discovered | 262 |
 | Skipped (errors) | 0 |
 | Consolidated (deduped) | 44 |
-| Rendered | 212 |
+| Rendered | 218 |

--- a/src/Quarry.Tests/ManifestOutput/quarry-manifest.postgresql.md
+++ b/src/Quarry.Tests/ManifestOutput/quarry-manifest.postgresql.md
@@ -1188,6 +1188,14 @@ SELECT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLogin" FROM 
 ### Users().Where(...).Prepare().ToDiagnostics()
 
 ```sql
+SELECT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLogin" FROM "users" WHERE (SELECT AVG("sq0"."Total") FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId") > 160
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
 SELECT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLogin" FROM "users" WHERE (SELECT COUNT(*) FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId" AND ("sq0"."Status" = 'paid')) >= 1
 ```
 
@@ -1225,6 +1233,50 @@ SELECT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLogin" FROM 
 
 ```sql
 SELECT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLogin" FROM "users" WHERE (SELECT COUNT(*) FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId") > 5
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLogin" FROM "users" WHERE (SELECT MAX("sq0"."OrderDate") FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId") > $1
+```
+
+| Parameter | Type |
+|-----------|------|
+| `@p0` | `DateTime` |
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLogin" FROM "users" WHERE (SELECT MAX("sq0"."Total") FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId") > 200
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLogin" FROM "users" WHERE (SELECT MIN("sq0"."Total") FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId") < 100
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLogin" FROM "users" WHERE (SELECT SUM("sq0"."Total") FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId") = 0 OR NOT (EXISTS (SELECT 1 FROM "orders" AS "sq1" WHERE "sq1"."UserId" = "users"."UserId"))
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLogin" FROM "users" WHERE (SELECT SUM("sq0"."Total") FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId") > 200
 ```
 
 ---
@@ -1978,7 +2030,7 @@ SELECT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLogin" FROM 
 
 | Metric | Count |
 |--------|------:|
-| Total discovered | 257 |
+| Total discovered | 263 |
 | Skipped (errors) | 0 |
 | Consolidated (deduped) | 44 |
-| Rendered | 213 |
+| Rendered | 219 |

--- a/src/Quarry.Tests/ManifestOutput/quarry-manifest.sqlite.md
+++ b/src/Quarry.Tests/ManifestOutput/quarry-manifest.sqlite.md
@@ -2307,6 +2307,14 @@ SELECT "UserId", "UserName" FROM "users" WHERE "UserName" LIKE 'User0%'
 ### Users().Where(...).Select(...).Prepare().ToDiagnostics()
 
 ```sql
+SELECT "UserId", "UserName" FROM "users" WHERE (SELECT AVG("sq0"."Total") FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId") > 160
+```
+
+---
+
+### Users().Where(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
 SELECT "UserId", "UserName" FROM "users" WHERE (SELECT COUNT(*) FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId" AND ("sq0"."Priority" = 3)) > 2
 ```
 
@@ -2352,6 +2360,50 @@ SELECT "UserId", "UserName" FROM "users" WHERE (SELECT COUNT(*) FROM "orders" AS
 
 ```sql
 SELECT "UserId", "UserName" FROM "users" WHERE (SELECT COUNT(*) FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId") > 5
+```
+
+---
+
+### Users().Where(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "UserId", "UserName" FROM "users" WHERE (SELECT MAX("sq0"."OrderDate") FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId") > @p0
+```
+
+| Parameter | Type |
+|-----------|------|
+| `@p0` | `DateTime` |
+
+---
+
+### Users().Where(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "UserId", "UserName" FROM "users" WHERE (SELECT MAX("sq0"."Total") FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId") > 200
+```
+
+---
+
+### Users().Where(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "UserId", "UserName" FROM "users" WHERE (SELECT MIN("sq0"."Total") FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId") < 100
+```
+
+---
+
+### Users().Where(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "UserId", "UserName" FROM "users" WHERE (SELECT SUM("sq0"."Total") FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId") = 0 OR NOT (EXISTS (SELECT 1 FROM "orders" AS "sq1" WHERE "sq1"."UserId" = "users"."UserId"))
+```
+
+---
+
+### Users().Where(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "UserId", "UserName" FROM "users" WHERE (SELECT SUM("sq0"."Total") FROM "orders" AS "sq0" WHERE "sq0"."UserId" = "users"."UserId") > 200
 ```
 
 ---
@@ -3114,7 +3166,7 @@ SELECT "WidgetId", "WidgetName", "Secret" FROM "widgets" WHERE "Secret" = @p0
 
 | Metric | Count |
 |--------|------:|
-| Total discovered | 473 |
+| Total discovered | 479 |
 | Skipped (errors) | 0 |
 | Consolidated (deduped) | 148 |
-| Rendered | 325 |
+| Rendered | 331 |

--- a/src/Quarry.Tests/ManifestOutput/quarry-manifest.sqlserver.md
+++ b/src/Quarry.Tests/ManifestOutput/quarry-manifest.sqlserver.md
@@ -1151,6 +1151,14 @@ SELECT [UserName], [Email] FROM [users] WHERE [IsActive] = 1 AND EXISTS (SELECT 
 ### Users().Where(...).Prepare().ToDiagnostics()
 
 ```sql
+SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT AVG([sq0].[Total]) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) > 160
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
 SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT COUNT(*) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId] AND ([sq0].[Status] = 'paid')) >= 1
 ```
 
@@ -1188,6 +1196,50 @@ SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM 
 
 ```sql
 SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT COUNT(*) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) > 5
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT MAX([sq0].[OrderDate]) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) > @p0
+```
+
+| Parameter | Type |
+|-----------|------|
+| `@p0` | `DateTime` |
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT MAX([sq0].[Total]) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) > 200
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT MIN([sq0].[Total]) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) < 100
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT SUM([sq0].[Total]) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) = 0 OR NOT (EXISTS (SELECT 1 FROM [orders] AS [sq1] WHERE [sq1].[UserId] = [users].[UserId]))
+```
+
+---
+
+### Users().Where(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT SUM([sq0].[Total]) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) > 200
 ```
 
 ---
@@ -1965,7 +2017,7 @@ SELECT [UserName], [Email] FROM [users] WHERE ([Email] IS NOT NULL) AND ([IsActi
 
 | Metric | Count |
 |--------|------:|
-| Total discovered | 256 |
+| Total discovered | 262 |
 | Skipped (errors) | 0 |
 | Consolidated (deduped) | 44 |
-| Rendered | 212 |
+| Rendered | 218 |

--- a/src/Quarry.Tests/SqlOutput/CrossDialectSubqueryTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectSubqueryTests.cs
@@ -297,6 +297,157 @@ internal class CrossDialectSubqueryTests
 
     #endregion
 
+    #region Sum
+
+    [Test]
+    public async Task Where_Sum_GreaterThan()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var lt = Lite.Users().Where(u => u.Orders.Sum(o => o.Total) > 200).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Sum(o => o.Total) > 200).Prepare();
+        var my = My.Users().Where(u => u.Orders.Sum(o => o.Total) > 200).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Sum(o => o.Total) > 200).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(),
+            pg.ToDiagnostics(),
+            my.ToDiagnostics(),
+            ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (SELECT SUM(\"sq0\".\"Total\") FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\") > 200",
+            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (SELECT SUM(\"sq0\".\"Total\") FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\") > 200",
+            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (SELECT SUM(`sq0`.`Total`) FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId`) > 200",
+            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT SUM([sq0].[Total]) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) > 200");
+
+        // Alice: 250.00 + 75.50 = 325.50 > 200 ✓, Bob: 150.00 ✗
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0], Is.EqualTo((1, "Alice")));
+    }
+
+    [Test]
+    public async Task Where_Sum_EqualsZero()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var lt = Lite.Users().Where(u => u.Orders.Sum(o => o.Total) == 0 || !u.Orders.Any()).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Sum(o => o.Total) == 0 || !u.Orders.Any()).Prepare();
+        var my = My.Users().Where(u => u.Orders.Sum(o => o.Total) == 0 || !u.Orders.Any()).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Sum(o => o.Total) == 0 || !u.Orders.Any()).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(),
+            pg.ToDiagnostics(),
+            my.ToDiagnostics(),
+            ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (SELECT SUM(\"sq0\".\"Total\") FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\") = 0 OR NOT (EXISTS (SELECT 1 FROM \"orders\" AS \"sq1\" WHERE \"sq1\".\"UserId\" = \"users\".\"UserId\"))",
+            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (SELECT SUM(\"sq0\".\"Total\") FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\") = 0 OR NOT (EXISTS (SELECT 1 FROM \"orders\" AS \"sq1\" WHERE \"sq1\".\"UserId\" = \"users\".\"UserId\"))",
+            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (SELECT SUM(`sq0`.`Total`) FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId`) = 0 OR NOT (EXISTS (SELECT 1 FROM `orders` AS `sq1` WHERE `sq1`.`UserId` = `users`.`UserId`))",
+            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT SUM([sq0].[Total]) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) = 0 OR NOT (EXISTS (SELECT 1 FROM [orders] AS [sq1] WHERE [sq1].[UserId] = [users].[UserId]))");
+
+        // Charlie has no orders (SUM is NULL, but NOT EXISTS is true)
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0], Is.EqualTo((3, "Charlie")));
+    }
+
+    #endregion
+
+    #region Min
+
+    [Test]
+    public async Task Where_Min_LessThan()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var lt = Lite.Users().Where(u => u.Orders.Min(o => o.Total) < 100).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Min(o => o.Total) < 100).Prepare();
+        var my = My.Users().Where(u => u.Orders.Min(o => o.Total) < 100).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Min(o => o.Total) < 100).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(),
+            pg.ToDiagnostics(),
+            my.ToDiagnostics(),
+            ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (SELECT MIN(\"sq0\".\"Total\") FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\") < 100",
+            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (SELECT MIN(\"sq0\".\"Total\") FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\") < 100",
+            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (SELECT MIN(`sq0`.`Total`) FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId`) < 100",
+            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT MIN([sq0].[Total]) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) < 100");
+
+        // Alice's min order is 75.50 < 100, Bob's min is 150.00
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0], Is.EqualTo((1, "Alice")));
+    }
+
+    #endregion
+
+    #region Max
+
+    [Test]
+    public async Task Where_Max_GreaterThan()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var lt = Lite.Users().Where(u => u.Orders.Max(o => o.Total) > 200).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Max(o => o.Total) > 200).Prepare();
+        var my = My.Users().Where(u => u.Orders.Max(o => o.Total) > 200).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Max(o => o.Total) > 200).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(),
+            pg.ToDiagnostics(),
+            my.ToDiagnostics(),
+            ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (SELECT MAX(\"sq0\".\"Total\") FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\") > 200",
+            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (SELECT MAX(\"sq0\".\"Total\") FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\") > 200",
+            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (SELECT MAX(`sq0`.`Total`) FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId`) > 200",
+            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT MAX([sq0].[Total]) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) > 200");
+
+        // Alice max: 250.00 > 200, Bob max: 150.00 ✗
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0], Is.EqualTo((1, "Alice")));
+    }
+
+    #endregion
+
+    #region Avg
+
+    [Test]
+    public async Task Where_Avg_GreaterThan()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var lt = Lite.Users().Where(u => u.Orders.Average(o => o.Total) > 160).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Average(o => o.Total) > 160).Prepare();
+        var my = My.Users().Where(u => u.Orders.Average(o => o.Total) > 160).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Average(o => o.Total) > 160).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(),
+            pg.ToDiagnostics(),
+            my.ToDiagnostics(),
+            ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (SELECT AVG(\"sq0\".\"Total\") FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\") > 160",
+            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (SELECT AVG(\"sq0\".\"Total\") FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\") > 160",
+            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (SELECT AVG(`sq0`.`Total`) FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId`) > 160",
+            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT AVG([sq0].[Total]) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) > 160");
+
+        // Alice avg: (250 + 75.50) / 2 = 162.75 > 160 ✓, Bob avg: 150.00 ✗
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0], Is.EqualTo((1, "Alice")));
+    }
+
+    #endregion
+
     #region Nested Subqueries
 
     [Test]

--- a/src/Quarry.Tests/SqlOutput/CrossDialectSubqueryTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectSubqueryTests.cs
@@ -415,6 +415,34 @@ internal class CrossDialectSubqueryTests
         Assert.That(results[0], Is.EqualTo((1, "Alice")));
     }
 
+    [Test]
+    public async Task Where_Max_DateTime_GreaterThan()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var cutoff = new DateTime(2024, 6, 30);
+        var lt = Lite.Users().Where(u => u.Orders.Max(o => o.OrderDate) > cutoff).Select(u => (u.UserId, u.UserName)).Prepare();
+        var pg = Pg.Users().Where(u => u.Orders.Max(o => o.OrderDate) > cutoff).Prepare();
+        var my = My.Users().Where(u => u.Orders.Max(o => o.OrderDate) > cutoff).Prepare();
+        var ss = Ss.Users().Where(u => u.Orders.Max(o => o.OrderDate) > cutoff).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(),
+            pg.ToDiagnostics(),
+            my.ToDiagnostics(),
+            ss.ToDiagnostics(),
+            sqlite: "SELECT \"UserId\", \"UserName\" FROM \"users\" WHERE (SELECT MAX(\"sq0\".\"OrderDate\") FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\") > @p0",
+            pg:     "SELECT \"UserId\", \"UserName\", \"Email\", \"IsActive\", \"CreatedAt\", \"LastLogin\" FROM \"users\" WHERE (SELECT MAX(\"sq0\".\"OrderDate\") FROM \"orders\" AS \"sq0\" WHERE \"sq0\".\"UserId\" = \"users\".\"UserId\") > $1",
+            mysql:  "SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM `users` WHERE (SELECT MAX(`sq0`.`OrderDate`) FROM `orders` AS `sq0` WHERE `sq0`.`UserId` = `users`.`UserId`) > ?",
+            ss:     "SELECT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLogin] FROM [users] WHERE (SELECT MAX([sq0].[OrderDate]) FROM [orders] AS [sq0] WHERE [sq0].[UserId] = [users].[UserId]) > @p0");
+
+        // Alice max: 2024-06-15 (< cutoff), Bob max: 2024-07-01 (> cutoff)
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0], Is.EqualTo((2, "Bob")));
+    }
+
     #endregion
 
     #region Avg

--- a/src/Quarry/Schema/Many.cs
+++ b/src/Quarry/Schema/Many.cs
@@ -33,6 +33,48 @@ public readonly struct Many<T> where T : Schema
     public int Count() => throw MarkerException();
 
     /// <summary>
+    /// Compile-time marker for SUM aggregate subquery.
+    /// Translated to: (SELECT SUM(column) FROM ... WHERE correlation).
+    /// </summary>
+    public int Sum(Func<T, int> selector) => throw MarkerException();
+
+    /// <inheritdoc cref="Sum(Func{T, int})"/>
+    public long Sum(Func<T, long> selector) => throw MarkerException();
+
+    /// <inheritdoc cref="Sum(Func{T, int})"/>
+    public decimal Sum(Func<T, decimal> selector) => throw MarkerException();
+
+    /// <inheritdoc cref="Sum(Func{T, int})"/>
+    public double Sum(Func<T, double> selector) => throw MarkerException();
+
+    /// <summary>
+    /// Compile-time marker for AVG aggregate subquery.
+    /// Translated to: (SELECT AVG(column) FROM ... WHERE correlation).
+    /// </summary>
+    public double Avg(Func<T, int> selector) => throw MarkerException();
+
+    /// <inheritdoc cref="Avg(Func{T, int})"/>
+    public double Avg(Func<T, long> selector) => throw MarkerException();
+
+    /// <inheritdoc cref="Avg(Func{T, int})"/>
+    public decimal Avg(Func<T, decimal> selector) => throw MarkerException();
+
+    /// <inheritdoc cref="Avg(Func{T, int})"/>
+    public double Avg(Func<T, double> selector) => throw MarkerException();
+
+    /// <summary>
+    /// Compile-time marker for MIN aggregate subquery.
+    /// Translated to: (SELECT MIN(column) FROM ... WHERE correlation).
+    /// </summary>
+    public TResult Min<TResult>(Func<T, TResult> selector) => throw MarkerException();
+
+    /// <summary>
+    /// Compile-time marker for MAX aggregate subquery.
+    /// Translated to: (SELECT MAX(column) FROM ... WHERE correlation).
+    /// </summary>
+    public TResult Max<TResult>(Func<T, TResult> selector) => throw MarkerException();
+
+    /// <summary>
     /// Implicitly converts a RelationshipBuilder to a Many.
     /// </summary>
     public static implicit operator Many<T>(RelationshipBuilder<T> builder) => default;

--- a/src/Quarry/Schema/Many.cs
+++ b/src/Quarry/Schema/Many.cs
@@ -62,6 +62,18 @@ public readonly struct Many<T> where T : Schema
     /// <inheritdoc cref="Avg(Func{T, int})"/>
     public double Avg(Func<T, double> selector) => throw MarkerException();
 
+    /// <inheritdoc cref="Avg(Func{T, int})"/>
+    public double Average(Func<T, int> selector) => throw MarkerException();
+
+    /// <inheritdoc cref="Avg(Func{T, int})"/>
+    public double Average(Func<T, long> selector) => throw MarkerException();
+
+    /// <inheritdoc cref="Avg(Func{T, int})"/>
+    public decimal Average(Func<T, decimal> selector) => throw MarkerException();
+
+    /// <inheritdoc cref="Avg(Func{T, int})"/>
+    public double Average(Func<T, double> selector) => throw MarkerException();
+
     /// <summary>
     /// Compile-time marker for MIN aggregate subquery.
     /// Translated to: (SELECT MIN(column) FROM ... WHERE correlation).


### PR DESCRIPTION
## Summary
- Closes #179
- Adds `Sum(selector)`, `Min(selector)`, `Max(selector)`, `Avg(selector)`/`Average(selector)` methods to `Many<T>` for correlated scalar subqueries
- Each translates to `(SELECT SUM/MIN/MAX/AVG(column) FROM ... WHERE correlation)` following the existing `Count()` pattern

## Reason for Change
Users needing aggregate values from related collections (e.g., total order amount, most recent order date) had to use `RawSqlAsync` or `Sql.Raw<T>`. These are common patterns that should be first-class.

## Impact
- `Many<T>` gains 14 new marker methods (4 Sum, 4 Avg, 4 Average, 1 Min, 1 Max)
- `SubqueryKind` enum extended with Sum, Min, Max, Avg values
- `SubqueryExpr` gains a `Selector` field (separate from `Predicate`) for the aggregate column expression
- Parser recognizes both `Avg` (Quarry convention) and `Average` (LINQ convention)
- 6 new cross-dialect tests covering Where-clause usage with decimal and DateTime selectors

## Plan items implemented as specified
- Phase 1: Marker methods on `Many<T>` with typed overloads
- Phase 2: `SubqueryKind` enum extension + `Selector` field on `SubqueryExpr`
- Phase 3: Parser recognition of Sum/Min/Max/Avg/Average
- Phase 4: Binder resolution of selector column references
- Phase 5: Renderer SQL output for aggregate subqueries

## Deviations from plan implemented
- Added `Average()` aliases on `Many<T>` (not in original plan) for LINQ naming consistency, since `NavigationList<T>` uses LINQ extension methods at compile time
- Tests use Where-clause context instead of Select-projection context (existing generator limitation: carrier type resolution doesn't support subquery expressions in tuple projections — affects Count() equally)

## Gaps in original plan implemented
- DateTime Max test added to verify generic `TResult` Min/Max with non-numeric columns

## Migration Steps
None required. Purely additive.

## Performance Considerations
No runtime overhead — all methods are compile-time markers translated by the source generator.

## Security Considerations
None. Selector expressions are column references resolved at compile time — no user input reaches SQL.

## Breaking Changes
- Consumer-facing: None. Additive only.
- Internal: `SubqueryExpr` constructors accept optional `selector` parameter (default null), backward compatible.