### PR TITLE
Add CROSS JOIN and FULL OUTER JOIN support (#180)

### DIFF
--- a/src/Quarry.Analyzers.Tests/DialectRuleTests.cs
+++ b/src/Quarry.Analyzers.Tests/DialectRuleTests.cs
@@ -125,6 +125,48 @@ public class DialectRuleTests
     }
 
     [Test]
+    public void QRA502_SqliteFullOuterJoin_Reports()
+    {
+        var rule = new SuboptimalForDialectRule();
+        var site = CreateSite(InterceptorKind.FullOuterJoin, methodName: "FullOuterJoin");
+        var context = CreateContext(site, GenSqlDialect.SQLite);
+        var diagnostics = rule.Analyze(context).ToList();
+        Assert.That(diagnostics, Has.Count.EqualTo(1));
+        Assert.That(diagnostics[0].GetMessage(), Does.Contain("FULL OUTER JOIN"));
+    }
+
+    [Test]
+    public void QRA502_MysqlFullOuterJoin_Reports()
+    {
+        var rule = new SuboptimalForDialectRule();
+        var site = CreateSite(InterceptorKind.FullOuterJoin, methodName: "FullOuterJoin");
+        var context = CreateContext(site, GenSqlDialect.MySQL);
+        var diagnostics = rule.Analyze(context).ToList();
+        Assert.That(diagnostics, Has.Count.EqualTo(1));
+        Assert.That(diagnostics[0].GetMessage(), Does.Contain("FULL OUTER JOIN"));
+    }
+
+    [Test]
+    public void QRA502_PostgresFullOuterJoin_NoReport()
+    {
+        var rule = new SuboptimalForDialectRule();
+        var site = CreateSite(InterceptorKind.FullOuterJoin, methodName: "FullOuterJoin");
+        var context = CreateContext(site, GenSqlDialect.PostgreSQL);
+        var diagnostics = rule.Analyze(context).ToList();
+        Assert.That(diagnostics, Is.Empty);
+    }
+
+    [Test]
+    public void QRA502_SqlServerFullOuterJoin_NoReport()
+    {
+        var rule = new SuboptimalForDialectRule();
+        var site = CreateSite(InterceptorKind.FullOuterJoin, methodName: "FullOuterJoin");
+        var context = CreateContext(site, GenSqlDialect.SqlServer);
+        var diagnostics = rule.Analyze(context).ToList();
+        Assert.That(diagnostics, Is.Empty);
+    }
+
+    [Test]
     public void QRA502_SqlServerOffsetWithoutOrderBy_Reports()
     {
         var rule = new SuboptimalForDialectRule();

--- a/src/Quarry.Analyzers/Rules/Dialect/SuboptimalForDialectRule.cs
+++ b/src/Quarry.Analyzers/Rules/Dialect/SuboptimalForDialectRule.cs
@@ -56,7 +56,7 @@ internal sealed class SuboptimalForDialectRule : IQueryAnalysisRule
             yield return Diagnostic.Create(
                 Descriptor,
                 context.InvocationSyntax.GetLocation(),
-                "SQLite does not support FULL OUTER JOIN; consider using UNION of LEFT JOIN and RIGHT JOIN");
+                "SQLite does not support FULL OUTER JOIN; consider using UNION of two LEFT JOINs with swapped table order");
         }
 
         // MySQL: FULL OUTER JOIN not supported

--- a/src/Quarry.Analyzers/Rules/Dialect/SuboptimalForDialectRule.cs
+++ b/src/Quarry.Analyzers/Rules/Dialect/SuboptimalForDialectRule.cs
@@ -41,14 +41,31 @@ internal sealed class SuboptimalForDialectRule : IQueryAnalysisRule
                 "SQLite does not support RIGHT JOIN; consider restructuring as LEFT JOIN");
         }
 
-        // MySQL: FULL OUTER JOIN not supported -- check for potential patterns
-        // Note: Quarry doesn't have a direct FullOuterJoin, so this is mostly informational
+        // MySQL: RIGHT JOIN has limited optimization
         if (dialect == SqlDialect.MySQL && site.Kind == InterceptorKind.RightJoin)
         {
             yield return Diagnostic.Create(
                 Descriptor,
                 context.InvocationSyntax.GetLocation(),
                 "MySQL has limited RIGHT JOIN optimization; consider restructuring as LEFT JOIN");
+        }
+
+        // SQLite: FULL OUTER JOIN not supported
+        if (dialect == SqlDialect.SQLite && site.Kind == InterceptorKind.FullOuterJoin)
+        {
+            yield return Diagnostic.Create(
+                Descriptor,
+                context.InvocationSyntax.GetLocation(),
+                "SQLite does not support FULL OUTER JOIN; consider using UNION of LEFT JOIN and RIGHT JOIN");
+        }
+
+        // MySQL: FULL OUTER JOIN not supported
+        if (dialect == SqlDialect.MySQL && site.Kind == InterceptorKind.FullOuterJoin)
+        {
+            yield return Diagnostic.Create(
+                Descriptor,
+                context.InvocationSyntax.GetLocation(),
+                "MySQL does not support FULL OUTER JOIN; consider using UNION of LEFT JOIN and RIGHT JOIN");
         }
 
         // SQL Server: OFFSET/FETCH requires ORDER BY -- produces invalid SQL without it

--- a/src/Quarry.Analyzers/Rules/WastedWork/UnusedJoinRule.cs
+++ b/src/Quarry.Analyzers/Rules/WastedWork/UnusedJoinRule.cs
@@ -22,7 +22,9 @@ internal sealed class UnusedJoinRule : IQueryAnalysisRule
         // Only check join call sites
         if (site.Kind != InterceptorKind.Join &&
             site.Kind != InterceptorKind.LeftJoin &&
-            site.Kind != InterceptorKind.RightJoin)
+            site.Kind != InterceptorKind.RightJoin &&
+            site.Kind != InterceptorKind.CrossJoin &&
+            site.Kind != InterceptorKind.FullOuterJoin)
             yield break;
 
         var joinedEntityName = site.JoinedEntityTypeName;

--- a/src/Quarry.Generator/CodeGen/FileEmitter.cs
+++ b/src/Quarry.Generator/CodeGen/FileEmitter.cs
@@ -594,6 +594,8 @@ internal sealed class FileEmitter
             case InterceptorKind.Join:
             case InterceptorKind.LeftJoin:
             case InterceptorKind.RightJoin:
+            case InterceptorKind.CrossJoin:
+            case InterceptorKind.FullOuterJoin:
                 JoinBodyEmitter.EmitJoin(sb, site, methodName, prebuiltClauseChain, isFirstClauseInChain, carrierInfo);
                 break;
 

--- a/src/Quarry.Generator/CodeGen/InterceptorRouter.cs
+++ b/src/Quarry.Generator/CodeGen/InterceptorRouter.cs
@@ -54,6 +54,8 @@ internal static class InterceptorRouter
             case InterceptorKind.Join:
             case InterceptorKind.LeftJoin:
             case InterceptorKind.RightJoin:
+            case InterceptorKind.CrossJoin:
+            case InterceptorKind.FullOuterJoin:
                 return EmitterCategory.Join;
 
             // Prepare terminal

--- a/src/Quarry.Generator/CodeGen/JoinBodyEmitter.cs
+++ b/src/Quarry.Generator/CodeGen/JoinBodyEmitter.cs
@@ -39,6 +39,8 @@ internal static class JoinBodyEmitter
         // Determine if this is a chained join (from JoinedQueryBuilder/3)
         var isChainedJoin = joinedEntityTypeNames != null && joinedEntityTypeNames.Count >= 2;
 
+        var isCrossJoin = site.Kind == InterceptorKind.CrossJoin;
+
         if (isChainedJoin && site.JoinedEntityTypeName != null)
         {
             var joinedType = InterceptorCodeGenerator.GetShortTypeName(site.JoinedEntityTypeName);
@@ -56,8 +58,9 @@ internal static class JoinBodyEmitter
             {
                 // Prebuilt path: AsJoined<T>() — type conversion only, no state mutation
                 sb.AppendLine($"    public static {returnBuilderName}<{returnTypeArgs}> {methodName}(");
-                sb.AppendLine($"        this {receiverBuilderName}<{receiverTypeArgs}> builder,");
-                sb.AppendLine($"        Func<{funcTypeArgs}> _)");
+                sb.AppendLine($"        this {receiverBuilderName}<{receiverTypeArgs}> builder{(isCrossJoin ? ")" : ",")}");
+                if (!isCrossJoin)
+                    sb.AppendLine($"        Func<{funcTypeArgs}> _)");
                 sb.AppendLine($"    {{");
 
                 // Compute carrier site params
@@ -83,7 +86,12 @@ internal static class JoinBodyEmitter
             // Prebuilt path: AsJoined<T>() — type conversion only, no state mutation
             var joinedEntityName = InterceptorCodeGenerator.GetShortTypeName(site.JoinedEntityTypeName ?? site.EntityTypeName);
 
-            if (site.IsNavigationJoin)
+            if (isCrossJoin)
+            {
+                sb.AppendLine($"    public static IJoinedQueryBuilder<{entityType}, {joinedEntityName}> {methodName}(");
+                sb.AppendLine($"        this {thisType}<{entityType}> builder)");
+            }
+            else if (site.IsNavigationJoin)
             {
                 sb.AppendLine($"    public static IJoinedQueryBuilder<{entityType}, {joinedEntityName}> {methodName}(");
                 sb.AppendLine($"        this {thisType}<{entityType}> builder,");

--- a/src/Quarry.Generator/CodeGen/TerminalEmitHelpers.cs
+++ b/src/Quarry.Generator/CodeGen/TerminalEmitHelpers.cs
@@ -587,7 +587,7 @@ internal static class TerminalEmitHelpers
             {
                 var schemaArg = join.Table.SchemaName != null ? $"\"{esc(join.Table.SchemaName)}\"" : "null";
                 var alias = join.Table.Alias ?? join.Table.TableName;
-                var onSql = Quarry.Generators.IR.SqlExprRenderer.Render(join.OnCondition, chain.Dialect);
+                var onSql = join.OnCondition != null ? Quarry.Generators.IR.SqlExprRenderer.Render(join.OnCondition, chain.Dialect) : "";
                 sb.AppendLine($"            new(\"{esc(join.Table.TableName)}\", {schemaArg}, \"{join.Kind}\", \"{esc(alias)}\", @\"{esc(onSql)}\"),");
             }
             sb.AppendLine("        };");

--- a/src/Quarry.Generator/IR/CallSiteBinder.cs
+++ b/src/Quarry.Generator/IR/CallSiteBinder.cs
@@ -113,6 +113,7 @@ internal static class CallSiteBinder
         string? resolvedJoinedEntityTypeName = raw.JoinedEntityTypeName;
 
         if (raw.Kind is InterceptorKind.Join or InterceptorKind.LeftJoin or InterceptorKind.RightJoin
+            or InterceptorKind.CrossJoin or InterceptorKind.FullOuterJoin
             && raw.JoinedEntityTypeName != null)
         {
             // For navigation joins with unresolved types, resolve from navigation metadata

--- a/src/Quarry.Generator/IR/CallSiteTranslator.cs
+++ b/src/Quarry.Generator/IR/CallSiteTranslator.cs
@@ -261,6 +261,8 @@ internal static class CallSiteTranslator
             InterceptorKind.Join => (JoinClauseKind?)JoinClauseKind.Inner,
             InterceptorKind.LeftJoin => JoinClauseKind.Left,
             InterceptorKind.RightJoin => JoinClauseKind.Right,
+            InterceptorKind.CrossJoin => JoinClauseKind.Cross,
+            InterceptorKind.FullOuterJoin => JoinClauseKind.FullOuter,
             _ => null
         };
 
@@ -773,6 +775,8 @@ internal static class CallSiteTranslator
             InterceptorKind.Join => true,
             InterceptorKind.LeftJoin => true,
             InterceptorKind.RightJoin => true,
+            InterceptorKind.CrossJoin => true,
+            InterceptorKind.FullOuterJoin => true,
             _ => false
         };
     }
@@ -1037,6 +1041,7 @@ internal static class CallSiteTranslator
         {
             InterceptorKind.LeftJoin => JoinClauseKind.Left,
             InterceptorKind.RightJoin => JoinClauseKind.Right,
+            InterceptorKind.FullOuterJoin => JoinClauseKind.FullOuter,
             _ => JoinClauseKind.Inner
         };
 

--- a/src/Quarry.Generator/IR/CallSiteTranslator.cs
+++ b/src/Quarry.Generator/IR/CallSiteTranslator.cs
@@ -65,6 +65,20 @@ internal static class CallSiteTranslator
             return new TranslatedCallSite(bound, clause);
         }
 
+        // CrossJoin has no ON condition — produce a join clause with null expression
+        if (raw.Kind == InterceptorKind.CrossJoin)
+        {
+            var crossClause = new TranslatedClause(
+                kind: ClauseKind.Join,
+                resolvedExpression: new LiteralExpr("1", "int"), // placeholder — not rendered for CROSS JOIN
+                parameters: Array.Empty<Translation.ParameterInfo>(),
+                isSuccess: true,
+                joinKind: JoinClauseKind.Cross,
+                joinedTableName: bound.JoinedEntity?.TableName,
+                joinedSchemaName: bound.JoinedEntity?.SchemaName);
+            return new TranslatedCallSite(bound, crossClause);
+        }
+
         // Non-clause sites: Limit, Offset, Distinct, WithTimeout, ChainRoot,
         // execution terminals, insert/delete transitions, Trace
         if (raw.Expression == null || !IsClauseBearingKind(raw.Kind))

--- a/src/Quarry.Generator/IR/QueryPlan.cs
+++ b/src/Quarry.Generator/IR/QueryPlan.cs
@@ -148,7 +148,7 @@ internal sealed class TableRef : IEquatable<TableRef>
 /// </summary>
 internal sealed class JoinPlan : IEquatable<JoinPlan>
 {
-    public JoinPlan(JoinClauseKind kind, TableRef table, SqlExpr onCondition, bool isNavigationJoin = false)
+    public JoinPlan(JoinClauseKind kind, TableRef table, SqlExpr? onCondition, bool isNavigationJoin = false)
     {
         Kind = kind;
         Table = table;
@@ -158,7 +158,7 @@ internal sealed class JoinPlan : IEquatable<JoinPlan>
 
     public JoinClauseKind Kind { get; }
     public TableRef Table { get; }
-    public SqlExpr OnCondition { get; }
+    public SqlExpr? OnCondition { get; }
     public bool IsNavigationJoin { get; }
 
     public bool Equals(JoinPlan? other)
@@ -167,7 +167,7 @@ internal sealed class JoinPlan : IEquatable<JoinPlan>
         if (ReferenceEquals(this, other)) return true;
         return Kind == other.Kind
             && Table.Equals(other.Table)
-            && OnCondition.Equals(other.OnCondition)
+            && Equals(OnCondition, other.OnCondition)
             && IsNavigationJoin == other.IsNavigationJoin;
     }
 

--- a/src/Quarry.Generator/IR/SqlAssembler.cs
+++ b/src/Quarry.Generator/IR/SqlAssembler.cs
@@ -186,11 +186,14 @@ internal static class SqlAssembler
             var alias = join.Table.Alias ?? $"t{i + 1}";
             sb.Append(" AS ");
             sb.Append(SqlFormatting.QuoteIdentifier(dialect, alias));
-            sb.Append(" ON ");
 
-            var paramsBefore = CountParameters(join.OnCondition);
-            sb.Append(SqlExprRenderer.Render(join.OnCondition, dialect, paramIndex, stripOuterParens: true));
-            paramIndex += paramsBefore;
+            if (join.OnCondition != null)
+            {
+                sb.Append(" ON ");
+                var paramsBefore = CountParameters(join.OnCondition);
+                sb.Append(SqlExprRenderer.Render(join.OnCondition, dialect, paramIndex, stripOuterParens: true));
+                paramIndex += paramsBefore;
+            }
         }
 
         // Implicit JOINs from One<T> navigation access

--- a/src/Quarry.Generator/IR/SqlAssembler.cs
+++ b/src/Quarry.Generator/IR/SqlAssembler.cs
@@ -569,6 +569,8 @@ internal static class SqlAssembler
             JoinClauseKind.Inner => "INNER JOIN",
             JoinClauseKind.Left => "LEFT JOIN",
             JoinClauseKind.Right => "RIGHT JOIN",
+            JoinClauseKind.Cross => "CROSS JOIN",
+            JoinClauseKind.FullOuter => "FULL OUTER JOIN",
             _ => "JOIN"
         };
     }

--- a/src/Quarry.Generator/Models/ClauseKind.cs
+++ b/src/Quarry.Generator/Models/ClauseKind.cs
@@ -43,5 +43,7 @@ internal enum JoinClauseKind
 {
     Inner,
     Left,
-    Right
+    Right,
+    Cross,
+    FullOuter
 }

--- a/src/Quarry.Generator/Models/ExecutionInfo.cs
+++ b/src/Quarry.Generator/Models/ExecutionInfo.cs
@@ -248,7 +248,9 @@ internal enum JoinKind
 {
     Inner,
     Left,
-    Right
+    Right,
+    Cross,
+    FullOuter
 }
 
 /// <summary>

--- a/src/Quarry.Generator/Models/InterceptorKind.cs
+++ b/src/Quarry.Generator/Models/InterceptorKind.cs
@@ -56,6 +56,16 @@ internal enum InterceptorKind
     RightJoin,
 
     /// <summary>
+    /// CrossJoin() method - generates CROSS JOIN clause SQL fragment (no ON condition).
+    /// </summary>
+    CrossJoin,
+
+    /// <summary>
+    /// FullOuterJoin() method - generates FULL OUTER JOIN clause SQL fragment.
+    /// </summary>
+    FullOuterJoin,
+
+    /// <summary>
     /// ExecuteFetchAllAsync() - assembles complete SQL and wires reader.
     /// </summary>
     ExecuteFetchAll,

--- a/src/Quarry.Generator/Parsing/ChainAnalyzer.cs
+++ b/src/Quarry.Generator/Parsing/ChainAnalyzer.cs
@@ -519,7 +519,8 @@ internal static class ChainAnalyzer
                             clause.JoinedSchemaName,
                             clause.TableAlias);
                         var joinKind = clause.JoinKind ?? JoinClauseKind.Inner;
-                        joinPlans.Add(new JoinPlan(joinKind, joinTable, expr, raw.IsNavigationJoin));
+                        var onCondition = joinKind == JoinClauseKind.Cross ? null : (SqlExpr?)expr;
+                        joinPlans.Add(new JoinPlan(joinKind, joinTable, onCondition, raw.IsNavigationJoin));
                         break;
                 }
 
@@ -1899,7 +1900,7 @@ internal static class ChainAnalyzer
         if (plan.Joins.Count > 0)
         {
             foreach (var j in plan.Joins)
-                log(chainUid, $"  join: {j.Kind} {j.Table.TableName} ON {FormatExpr(j.OnCondition)}{(j.IsNavigationJoin ? " (navigation)" : "")}");
+                log(chainUid, $"  join: {j.Kind} {j.Table.TableName}{(j.OnCondition != null ? $" ON {FormatExpr(j.OnCondition)}" : "")}{(j.IsNavigationJoin ? " (navigation)" : "")}");
         }
 
         // WHERE terms

--- a/src/Quarry.Generator/Parsing/ChainAnalyzer.cs
+++ b/src/Quarry.Generator/Parsing/ChainAnalyzer.cs
@@ -238,6 +238,7 @@ internal static class ChainAnalyzer
         foreach (var site in clauseSites)
         {
             if (site.Bound.Raw.Kind is InterceptorKind.Join or InterceptorKind.LeftJoin or InterceptorKind.RightJoin
+                or InterceptorKind.CrossJoin or InterceptorKind.FullOuterJoin
                 && site.Bound.JoinedEntity != null)
             {
                 // First check if the Join already has JoinedEntityTypeNames from discovery
@@ -264,7 +265,8 @@ internal static class ChainAnalyzer
             bool seenJoin = false;
             for (int i = 0; i < clauseSites.Count; i++)
             {
-                if (clauseSites[i].Bound.Raw.Kind is InterceptorKind.Join or InterceptorKind.LeftJoin or InterceptorKind.RightJoin)
+                if (clauseSites[i].Bound.Raw.Kind is InterceptorKind.Join or InterceptorKind.LeftJoin or InterceptorKind.RightJoin
+                    or InterceptorKind.CrossJoin or InterceptorKind.FullOuterJoin)
                 {
                     seenJoin = true;
                     continue;
@@ -284,7 +286,8 @@ internal static class ChainAnalyzer
                 seenJoin = false;
                 for (int i = 0; i < clauseSites.Count; i++)
                 {
-                    if (clauseSites[i].Bound.Raw.Kind is InterceptorKind.Join or InterceptorKind.LeftJoin or InterceptorKind.RightJoin)
+                    if (clauseSites[i].Bound.Raw.Kind is InterceptorKind.Join or InterceptorKind.LeftJoin or InterceptorKind.RightJoin
+                    or InterceptorKind.CrossJoin or InterceptorKind.FullOuterJoin)
                     {
                         seenJoin = true;
                         continue;
@@ -1740,6 +1743,8 @@ internal static class ChainAnalyzer
             InterceptorKind.Join => ClauseRole.Join,
             InterceptorKind.LeftJoin => ClauseRole.Join,
             InterceptorKind.RightJoin => ClauseRole.Join,
+            InterceptorKind.CrossJoin => ClauseRole.Join,
+            InterceptorKind.FullOuterJoin => ClauseRole.Join,
             InterceptorKind.Set => ClauseRole.Set,
             InterceptorKind.DeleteWhere => ClauseRole.DeleteWhere,
             InterceptorKind.UpdateSet => ClauseRole.UpdateSet,

--- a/src/Quarry.Generator/Parsing/UsageSiteDiscovery.cs
+++ b/src/Quarry.Generator/Parsing/UsageSiteDiscovery.cs
@@ -60,6 +60,8 @@ internal static class UsageSiteDiscovery
         ["Join"] = InterceptorKind.Join,
         ["LeftJoin"] = InterceptorKind.LeftJoin,
         ["RightJoin"] = InterceptorKind.RightJoin,
+        ["CrossJoin"] = InterceptorKind.CrossJoin,
+        ["FullOuterJoin"] = InterceptorKind.FullOuterJoin,
         ["ExecuteFetchAllAsync"] = InterceptorKind.ExecuteFetchAll,
         ["ExecuteFetchFirstAsync"] = InterceptorKind.ExecuteFetchFirst,
         ["ExecuteFetchFirstOrDefaultAsync"] = InterceptorKind.ExecuteFetchFirstOrDefault,
@@ -605,6 +607,7 @@ internal static class UsageSiteDiscovery
         string? joinedEntityTypeName = null;
         bool isNavigationJoin = false;
         if (kind is InterceptorKind.Join or InterceptorKind.LeftJoin or InterceptorKind.RightJoin
+            or InterceptorKind.CrossJoin or InterceptorKind.FullOuterJoin
             && methodSymbol.TypeArguments.Length > 0)
         {
             var joinedType = methodSymbol.TypeArguments[0];
@@ -670,7 +673,8 @@ internal static class UsageSiteDiscovery
 
         // For join sites, extract ordered lambda parameter names for multi-entity resolution
         ImmutableArray<string>? lambdaParamNames = null;
-        if (expression != null && kind is InterceptorKind.Join or InterceptorKind.LeftJoin or InterceptorKind.RightJoin)
+        if (expression != null && kind is InterceptorKind.Join or InterceptorKind.LeftJoin or InterceptorKind.RightJoin
+            or InterceptorKind.FullOuterJoin)
         {
             if (invocation.ArgumentList.Arguments.Count > 0
                 && invocation.ArgumentList.Arguments[0].Expression is LambdaExpressionSyntax joinLambda)
@@ -1020,6 +1024,8 @@ internal static class UsageSiteDiscovery
             InterceptorKind.Join => ClauseKind.Join,
             InterceptorKind.LeftJoin => ClauseKind.Join,
             InterceptorKind.RightJoin => ClauseKind.Join,
+            InterceptorKind.CrossJoin => ClauseKind.Join,
+            InterceptorKind.FullOuterJoin => ClauseKind.Join,
             _ => ClauseKind.Where
         };
 
@@ -1321,7 +1327,7 @@ internal static class UsageSiteDiscovery
     private static bool IsKnownBuilderMethod(string name)
     {
         return name is "Where" or "OrderBy" or "ThenBy" or "Select" or "GroupBy" or "Having"
-            or "Set" or "Join" or "LeftJoin" or "RightJoin" or "Limit" or "Offset" or "Distinct"
+            or "Set" or "Join" or "LeftJoin" or "RightJoin" or "CrossJoin" or "FullOuterJoin" or "Limit" or "Offset" or "Distinct"
             or "ExecuteFetchAllAsync" or "ExecuteFetchFirstAsync" or "ExecuteFetchFirstOrDefaultAsync"
             or "ExecuteFetchSingleAsync" or "ExecuteFetchSingleOrDefaultAsync"
             or "ExecuteScalarAsync" or "ExecuteNonQueryAsync"

--- a/src/Quarry.Tests/IR/InterceptorRouterTests.cs
+++ b/src/Quarry.Tests/IR/InterceptorRouterTests.cs
@@ -57,6 +57,8 @@ public class InterceptorRouterTests
         Assert.That(InterceptorRouter.Categorize(InterceptorKind.Join), Is.EqualTo(EmitterCategory.Join));
         Assert.That(InterceptorRouter.Categorize(InterceptorKind.LeftJoin), Is.EqualTo(EmitterCategory.Join));
         Assert.That(InterceptorRouter.Categorize(InterceptorKind.RightJoin), Is.EqualTo(EmitterCategory.Join));
+        Assert.That(InterceptorRouter.Categorize(InterceptorKind.CrossJoin), Is.EqualTo(EmitterCategory.Join));
+        Assert.That(InterceptorRouter.Categorize(InterceptorKind.FullOuterJoin), Is.EqualTo(EmitterCategory.Join));
     }
 
     [Test]

--- a/src/Quarry.Tests/ManifestOutput/quarry-manifest.mysql.md
+++ b/src/Quarry.Tests/ManifestOutput/quarry-manifest.mysql.md
@@ -482,6 +482,22 @@ SELECT `t0`.`ShipmentId`, `j0`.`WarehouseName` FROM `shipments` AS `t0` LEFT JOI
 
 ---
 
+### Users().CrossJoin(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` CROSS JOIN `orders` AS `t1`
+```
+
+---
+
+### Users().CrossJoin(...).Where(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` CROSS JOIN `orders` AS `t1` WHERE `t1`.`Total` > 100
+```
+
+---
+
 ### Users().Delete().All().Prepare().ToDiagnostics()
 
 ```sql
@@ -566,6 +582,14 @@ SELECT DISTINCT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLog
 
 ```sql
 SELECT DISTINCT `UserName`, `Email` FROM `users` WHERE `IsActive` = 1
+```
+
+---
+
+### Users().FullOuterJoin(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` FULL OUTER JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId`
 ```
 
 ---
@@ -2017,7 +2041,7 @@ SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM 
 
 | Metric | Count |
 |--------|------:|
-| Total discovered | 262 |
+| Total discovered | 265 |
 | Skipped (errors) | 0 |
 | Consolidated (deduped) | 44 |
-| Rendered | 218 |
+| Rendered | 221 |

--- a/src/Quarry.Tests/ManifestOutput/quarry-manifest.postgresql.md
+++ b/src/Quarry.Tests/ManifestOutput/quarry-manifest.postgresql.md
@@ -495,6 +495,22 @@ SELECT "t0"."ShipmentId", "j0"."WarehouseName" FROM "shipments" AS "t0" LEFT JOI
 
 ---
 
+### Users().CrossJoin(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "t0"."UserName", "t1"."Total" FROM "users" AS "t0" CROSS JOIN "orders" AS "t1"
+```
+
+---
+
+### Users().CrossJoin(...).Where(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "t0"."UserName", "t1"."Total" FROM "users" AS "t0" CROSS JOIN "orders" AS "t1" WHERE "t1"."Total" > 100
+```
+
+---
+
 ### Users().Delete().All().Prepare().ToDiagnostics()
 
 ```sql
@@ -579,6 +595,14 @@ SELECT DISTINCT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLog
 
 ```sql
 SELECT DISTINCT "UserName", "Email" FROM "users" WHERE "IsActive" = TRUE
+```
+
+---
+
+### Users().FullOuterJoin(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "t0"."UserName", "t1"."Total" FROM "users" AS "t0" FULL OUTER JOIN "orders" AS "t1" ON "t0"."UserId" = "t1"."UserId"
 ```
 
 ---
@@ -2030,7 +2054,7 @@ SELECT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLogin" FROM 
 
 | Metric | Count |
 |--------|------:|
-| Total discovered | 263 |
+| Total discovered | 266 |
 | Skipped (errors) | 0 |
 | Consolidated (deduped) | 44 |
-| Rendered | 219 |
+| Rendered | 222 |

--- a/src/Quarry.Tests/ManifestOutput/quarry-manifest.sqlite.md
+++ b/src/Quarry.Tests/ManifestOutput/quarry-manifest.sqlite.md
@@ -753,6 +753,22 @@ SELECT "t0"."ShipmentId", "j0"."WarehouseName" FROM "shipments" AS "t0" LEFT JOI
 
 ---
 
+### Users().CrossJoin(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "t0"."UserName", "t1"."Total" FROM "users" AS "t0" CROSS JOIN "orders" AS "t1"
+```
+
+---
+
+### Users().CrossJoin(...).Where(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "t0"."UserName", "t1"."Total" FROM "users" AS "t0" CROSS JOIN "orders" AS "t1" WHERE "t1"."Total" > 100
+```
+
+---
+
 ### Users().Delete().All().Prepare().ToDiagnostics()
 
 ```sql
@@ -865,6 +881,14 @@ SELECT DISTINCT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLog
 
 ```sql
 SELECT DISTINCT "UserName", "Email" FROM "users" WHERE "IsActive" = 1
+```
+
+---
+
+### Users().FullOuterJoin(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "t0"."UserName", "t1"."Total" FROM "users" AS "t0" FULL OUTER JOIN "orders" AS "t1" ON "t0"."UserId" = "t1"."UserId"
 ```
 
 ---
@@ -3166,7 +3190,7 @@ SELECT "WidgetId", "WidgetName", "Secret" FROM "widgets" WHERE "Secret" = @p0
 
 | Metric | Count |
 |--------|------:|
-| Total discovered | 479 |
+| Total discovered | 482 |
 | Skipped (errors) | 0 |
 | Consolidated (deduped) | 148 |
-| Rendered | 331 |
+| Rendered | 334 |

--- a/src/Quarry.Tests/ManifestOutput/quarry-manifest.sqlserver.md
+++ b/src/Quarry.Tests/ManifestOutput/quarry-manifest.sqlserver.md
@@ -490,6 +490,22 @@ SELECT [t0].[ShipmentId], [j0].[WarehouseName] FROM [shipments] AS [t0] LEFT JOI
 
 ---
 
+### Users().CrossJoin(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] CROSS JOIN [orders] AS [t1]
+```
+
+---
+
+### Users().CrossJoin(...).Where(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] CROSS JOIN [orders] AS [t1] WHERE [t1].[Total] > 100
+```
+
+---
+
 ### Users().Delete().All().Prepare().ToDiagnostics()
 
 ```sql
@@ -574,6 +590,14 @@ SELECT DISTINCT [UserId], [UserName], [Email], [IsActive], [CreatedAt], [LastLog
 
 ```sql
 SELECT DISTINCT [UserName], [Email] FROM [users] WHERE [IsActive] = 1
+```
+
+---
+
+### Users().FullOuterJoin(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] FULL OUTER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId]
 ```
 
 ---
@@ -2017,7 +2041,7 @@ SELECT [UserName], [Email] FROM [users] WHERE ([Email] IS NOT NULL) AND ([IsActi
 
 | Metric | Count |
 |--------|------:|
-| Total discovered | 262 |
+| Total discovered | 265 |
 | Skipped (errors) | 0 |
 | Consolidated (deduped) | 44 |
-| Rendered | 218 |
+| Rendered | 221 |

--- a/src/Quarry.Tests/SqlOutput/CrossDialectJoinTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectJoinTests.cs
@@ -465,15 +465,17 @@ internal class CrossDialectJoinTests
         await using var t = await QueryTestHarness.CreateAsync();
         var (Lite, Pg, My, Ss) = t;
 
+        var lt = Lite.Users().FullOuterJoin<Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
         var pg = Pg.Users().FullOuterJoin<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var my = My.Users().FullOuterJoin<My.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
         var ss = Ss.Users().FullOuterJoin<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
 
         QueryTestHarness.AssertDialects(
-            pg.ToDiagnostics(), pg.ToDiagnostics(),
-            pg.ToDiagnostics(), ss.ToDiagnostics(),
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
             sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" FULL OUTER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
             pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" FULL OUTER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
-            mysql:  "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" FULL OUTER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
+            mysql:  "SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` FULL OUTER JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId`",
             ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] FULL OUTER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId]");
     }
 
@@ -503,6 +505,30 @@ internal class CrossDialectJoinTests
         // Cross join: 3 users × 3 orders = 9 rows
         var results = await lt.ExecuteFetchAllAsync();
         Assert.That(results, Has.Count.EqualTo(9));
+    }
+
+    [Test]
+    public async Task CrossJoin_WithWhere()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var lt = Lite.Users().CrossJoin<Order>().Where((u, o) => o.Total > 100).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var pg = Pg.Users().CrossJoin<Pg.Order>().Where((u, o) => o.Total > 100).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var my = My.Users().CrossJoin<My.Order>().Where((u, o) => o.Total > 100).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var ss = Ss.Users().CrossJoin<Ss.Order>().Where((u, o) => o.Total > 100).Select((u, o) => (u.UserName, o.Total)).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" CROSS JOIN \"orders\" AS \"t1\" WHERE \"t1\".\"Total\" > 100",
+            pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" CROSS JOIN \"orders\" AS \"t1\" WHERE \"t1\".\"Total\" > 100",
+            mysql:  "SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` CROSS JOIN `orders` AS `t1` WHERE `t1`.`Total` > 100",
+            ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] CROSS JOIN [orders] AS [t1] WHERE [t1].[Total] > 100");
+
+        // 3 users × 2 orders with Total > 100 = 6 rows
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(6));
     }
 
     #endregion

--- a/src/Quarry.Tests/SqlOutput/CrossDialectJoinTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectJoinTests.cs
@@ -456,4 +456,26 @@ internal class CrossDialectJoinTests
     }
 
     #endregion
+
+    #region Full Outer Join
+
+    [Test]
+    public async Task FullOuterJoin_OnClause()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var pg = Pg.Users().FullOuterJoin<Pg.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var ss = Ss.Users().FullOuterJoin<Ss.Order>((u, o) => u.UserId == o.UserId.Id).Select((u, o) => (u.UserName, o.Total)).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            pg.ToDiagnostics(), pg.ToDiagnostics(),
+            pg.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" FULL OUTER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
+            pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" FULL OUTER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
+            mysql:  "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" FULL OUTER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
+            ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] FULL OUTER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId]");
+    }
+
+    #endregion
 }

--- a/src/Quarry.Tests/SqlOutput/CrossDialectJoinTests.cs
+++ b/src/Quarry.Tests/SqlOutput/CrossDialectJoinTests.cs
@@ -478,4 +478,32 @@ internal class CrossDialectJoinTests
     }
 
     #endregion
+
+    #region Cross Join
+
+    [Test]
+    public async Task CrossJoin_NoOnClause()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var lt = Lite.Users().CrossJoin<Order>().Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var pg = Pg.Users().CrossJoin<Pg.Order>().Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var my = My.Users().CrossJoin<My.Order>().Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var ss = Ss.Users().CrossJoin<Ss.Order>().Select((u, o) => (u.UserName, o.Total)).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" CROSS JOIN \"orders\" AS \"t1\"",
+            pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" CROSS JOIN \"orders\" AS \"t1\"",
+            mysql:  "SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` CROSS JOIN `orders` AS `t1`",
+            ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] CROSS JOIN [orders] AS [t1]");
+
+        // Cross join: 3 users × 3 orders = 9 rows
+        var results = await lt.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(9));
+    }
+
+    #endregion
 }

--- a/src/Quarry/Query/IEntityAccessor.cs
+++ b/src/Quarry/Query/IEntityAccessor.cs
@@ -48,6 +48,18 @@ public interface IEntityAccessor<T> where T : class
         => throw new InvalidOperationException("Carrier method IEntityAccessor.RightJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
 
     /// <summary>
+    /// Adds a CROSS JOIN with another table (cartesian product, no condition).
+    /// </summary>
+    IJoinedQueryBuilder<T, TJoined> CrossJoin<TJoined>() where TJoined : class
+        => throw new InvalidOperationException("Carrier method IEntityAccessor.CrossJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
+
+    /// <summary>
+    /// Adds a FULL OUTER JOIN with another table using an explicit condition.
+    /// </summary>
+    IJoinedQueryBuilder<T, TJoined> FullOuterJoin<TJoined>(Func<T, TJoined, bool> condition) where TJoined : class
+        => throw new InvalidOperationException("Carrier method IEntityAccessor.FullOuterJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
+
+    /// <summary>
     /// Adds an INNER JOIN via a navigation property relationship.
     /// </summary>
     IJoinedQueryBuilder<T, TJoined> Join<TJoined>(Func<T, NavigationList<TJoined>> navigation) where TJoined : class

--- a/src/Quarry/Query/IJoinedQueryBuilder.g.cs
+++ b/src/Quarry/Query/IJoinedQueryBuilder.g.cs
@@ -35,6 +35,10 @@ public interface IJoinedQueryBuilder<T1, T2>
         => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder.LeftJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
     IJoinedQueryBuilder3<T1, T2, T3> RightJoin<T3>(Func<T1, T2, T3, bool> condition) where T3 : class
         => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder.RightJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
+    IJoinedQueryBuilder3<T1, T2, T3> CrossJoin<T3>() where T3 : class
+        => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder.CrossJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
+    IJoinedQueryBuilder3<T1, T2, T3> FullOuterJoin<T3>(Func<T1, T2, T3, bool> condition) where T3 : class
+        => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder.FullOuterJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
 
     QueryDiagnostics ToDiagnostics()
         => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder.ToDiagnostics is not intercepted in this optimized chain. This indicates a code generation bug.");
@@ -116,6 +120,10 @@ public interface IJoinedQueryBuilder3<T1, T2, T3>
         => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder3.LeftJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
     IJoinedQueryBuilder4<T1, T2, T3, T4> RightJoin<T4>(Func<T1, T2, T3, T4, bool> condition) where T4 : class
         => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder3.RightJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
+    IJoinedQueryBuilder4<T1, T2, T3, T4> CrossJoin<T4>() where T4 : class
+        => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder3.CrossJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
+    IJoinedQueryBuilder4<T1, T2, T3, T4> FullOuterJoin<T4>(Func<T1, T2, T3, T4, bool> condition) where T4 : class
+        => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder3.FullOuterJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
 
     QueryDiagnostics ToDiagnostics()
         => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder3.ToDiagnostics is not intercepted in this optimized chain. This indicates a code generation bug.");
@@ -199,6 +207,10 @@ public interface IJoinedQueryBuilder4<T1, T2, T3, T4>
         => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder4.LeftJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
     IJoinedQueryBuilder5<T1, T2, T3, T4, T5> RightJoin<T5>(Func<T1, T2, T3, T4, T5, bool> condition) where T5 : class
         => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder4.RightJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
+    IJoinedQueryBuilder5<T1, T2, T3, T4, T5> CrossJoin<T5>() where T5 : class
+        => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder4.CrossJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
+    IJoinedQueryBuilder5<T1, T2, T3, T4, T5> FullOuterJoin<T5>(Func<T1, T2, T3, T4, T5, bool> condition) where T5 : class
+        => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder4.FullOuterJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
 
     QueryDiagnostics ToDiagnostics()
         => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder4.ToDiagnostics is not intercepted in this optimized chain. This indicates a code generation bug.");
@@ -284,6 +296,10 @@ public interface IJoinedQueryBuilder5<T1, T2, T3, T4, T5>
         => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder5.LeftJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
     IJoinedQueryBuilder6<T1, T2, T3, T4, T5, T6> RightJoin<T6>(Func<T1, T2, T3, T4, T5, T6, bool> condition) where T6 : class
         => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder5.RightJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
+    IJoinedQueryBuilder6<T1, T2, T3, T4, T5, T6> CrossJoin<T6>() where T6 : class
+        => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder5.CrossJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
+    IJoinedQueryBuilder6<T1, T2, T3, T4, T5, T6> FullOuterJoin<T6>(Func<T1, T2, T3, T4, T5, T6, bool> condition) where T6 : class
+        => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder5.FullOuterJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
 
     QueryDiagnostics ToDiagnostics()
         => throw new InvalidOperationException("Carrier method IJoinedQueryBuilder5.ToDiagnostics is not intercepted in this optimized chain. This indicates a code generation bug.");

--- a/src/Quarry/Query/IJoinedQueryBuilder.tt
+++ b/src/Quarry/Query/IJoinedQueryBuilder.tt
@@ -63,6 +63,10 @@ public interface <#= interfaceName #><<#= typeParams #>>
         => throw new InvalidOperationException("<#= errorMsg #>.LeftJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
     <#= nextInterfaceName #><<#= nextTypeParams #>> RightJoin<T<#= nextArity #>>(<#= nextFuncBool #> condition) where T<#= nextArity #> : class
         => throw new InvalidOperationException("<#= errorMsg #>.RightJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
+    <#= nextInterfaceName #><<#= nextTypeParams #>> CrossJoin<T<#= nextArity #>>() where T<#= nextArity #> : class
+        => throw new InvalidOperationException("<#= errorMsg #>.CrossJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
+    <#= nextInterfaceName #><<#= nextTypeParams #>> FullOuterJoin<T<#= nextArity #>>(<#= nextFuncBool #> condition) where T<#= nextArity #> : class
+        => throw new InvalidOperationException("<#= errorMsg #>.FullOuterJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
 <#      } #>
 
     QueryDiagnostics ToDiagnostics()

--- a/src/Quarry/Query/IQueryBuilder.cs
+++ b/src/Quarry/Query/IQueryBuilder.cs
@@ -90,6 +90,18 @@ public interface IQueryBuilder<T> where T : class
         => throw new InvalidOperationException("Carrier method IQueryBuilder.RightJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
 
     /// <summary>
+    /// Adds a CROSS JOIN with another table (cartesian product, no condition).
+    /// </summary>
+    IJoinedQueryBuilder<T, TJoined> CrossJoin<TJoined>() where TJoined : class
+        => throw new InvalidOperationException("Carrier method IQueryBuilder.CrossJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
+
+    /// <summary>
+    /// Adds a FULL OUTER JOIN with another table using an explicit condition.
+    /// </summary>
+    IJoinedQueryBuilder<T, TJoined> FullOuterJoin<TJoined>(Func<T, TJoined, bool> condition) where TJoined : class
+        => throw new InvalidOperationException("Carrier method IQueryBuilder.FullOuterJoin is not intercepted in this optimized chain. This indicates a code generation bug.");
+
+    /// <summary>
     /// Adds an INNER JOIN via a navigation property relationship.
     /// </summary>
     IJoinedQueryBuilder<T, TJoined> Join<TJoined>(Func<T, NavigationList<TJoined>> navigation) where TJoined : class


### PR DESCRIPTION
## Summary
- Closes #180
- Created #191 for deferred nullable projection analysis work

## Reason for Change
Only INNER, LEFT, and RIGHT JOIN were supported. CROSS JOIN and FULL OUTER JOIN required `RawSqlAsync` workarounds.

## Impact
Adds `CrossJoin<T>()` and `FullOuterJoin<T>(condition)` to the public API (`IEntityAccessor<T>`, `IQueryBuilder<T>`, and all `IJoinedQueryBuilder` arities up to 6 tables). Emits `CROSS JOIN` (no ON clause) and `FULL OUTER JOIN` SQL keywords through the full source generator pipeline.

## Plan items implemented as specified
- Phase 1: FullOuterJoin — same signature as existing joins, different SQL keyword. Wired through all generator stages.
- Phase 2: CrossJoin — nullable `JoinPlan.OnCondition`, no-lambda method signature, SqlAssembler skips ON clause.
- Phase 3: QRA502 analyzer warnings for FullOuterJoin on SQLite and MySQL.

## Deviations from plan implemented
- Plan called for a second `JoinPlan` constructor overload without OnCondition. Instead, the single constructor was made nullable — simpler approach.

## Gaps in original plan implemented
- `IEntityAccessor<T>` also needed CrossJoin/FullOuterJoin methods (plan only mentioned `IQueryBuilder`).
- Multiple `InterceptorKind` check sites beyond those listed in the plan needed updating (ChainAnalyzer join propagation, FileEmitter routing, CallSiteTranslator `IsClauseBearingKind`, UsageSiteDiscovery clause kind mapping).
- `ExecutionInfo.JoinKind` enum needed Cross/FullOuter values for consistency.

## Migration Steps
None — additive API change only.

## Performance Considerations
None — same source generation pattern as existing joins. No runtime overhead.

## Security Considerations
None.

## Breaking Changes
- Consumer-facing: None (additive only)
- Internal: `JoinPlan.OnCondition` changed from `SqlExpr` to `SqlExpr?` (internal sealed class)