### PR TITLE
Add join-aware nullable projection analysis for outer joins (#191)

### DIFF
--- a/src/Quarry.Generator/CodeGen/TerminalEmitHelpers.cs
+++ b/src/Quarry.Generator/CodeGen/TerminalEmitHelpers.cs
@@ -571,7 +571,8 @@ internal static class TerminalEmitHelpers
                 var typeMappingArg = col.CustomTypeMapping != null ? $", typeMappingClass: \"{esc(col.CustomTypeMapping)}\"" : "";
                 var fkArgs = col.IsForeignKey ? $", isForeignKey: true, foreignKeyEntityName: \"{esc(col.ForeignKeyEntityName!)}\"" : "";
                 var enumArg = col.IsEnum ? ", isEnum: true" : "";
-                sb.AppendLine($"            new(\"{esc(col.PropertyName)}\", \"{esc(col.ColumnName)}\", \"{esc(col.ClrType)}\", {col.Ordinal}, isNullable: {(col.IsNullable ? "true" : "false")}{typeMappingArg}{fkArgs}{enumArg}),");
+                var joinNullArg = col.IsJoinNullable ? ", isJoinNullable: true" : "";
+                sb.AppendLine($"            new(\"{esc(col.PropertyName)}\", \"{esc(col.ColumnName)}\", \"{esc(col.ClrType)}\", {col.Ordinal}, isNullable: {(col.IsNullable ? "true" : "false")}{typeMappingArg}{fkArgs}{enumArg}{joinNullArg}),");
             }
             sb.AppendLine("        };");
         }

--- a/src/Quarry.Generator/Models/ProjectionInfo.cs
+++ b/src/Quarry.Generator/Models/ProjectionInfo.cs
@@ -297,7 +297,7 @@ internal sealed class ProjectedColumn : IEquatable<ProjectedColumn>
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(PropertyName, ColumnName, ClrType, Ordinal, IsNullable);
+        return HashCode.Combine(PropertyName, ColumnName, ClrType, Ordinal, IsNullable, IsJoinNullable);
     }
 }
 

--- a/src/Quarry.Generator/Models/ProjectionInfo.cs
+++ b/src/Quarry.Generator/Models/ProjectionInfo.cs
@@ -136,7 +136,8 @@ internal sealed class ProjectedColumn : IEquatable<ProjectedColumn>
         bool isForeignKey = false,
         string? foreignKeyEntityName = null,
         bool isEnum = false,
-        IReadOnlyList<string>? navigationHops = null)
+        IReadOnlyList<string>? navigationHops = null,
+        bool isJoinNullable = false)
     {
         PropertyName = propertyName;
         ColumnName = columnName;
@@ -155,6 +156,7 @@ internal sealed class ProjectedColumn : IEquatable<ProjectedColumn>
         ForeignKeyEntityName = foreignKeyEntityName;
         IsEnum = isEnum;
         NavigationHops = navigationHops;
+        IsJoinNullable = isJoinNullable;
     }
 
     /// <summary>
@@ -178,9 +180,24 @@ internal sealed class ProjectedColumn : IEquatable<ProjectedColumn>
     public string FullClrType { get; }
 
     /// <summary>
-    /// Gets whether this column is nullable.
+    /// Gets whether this column is nullable (based on schema metadata).
     /// </summary>
     public bool IsNullable { get; }
+
+    /// <summary>
+    /// Gets whether this column is effectively nullable due to being on the nullable side
+    /// of an outer join (LEFT, RIGHT, or FULL OUTER). When true, reader code must emit
+    /// IsDBNull checks even though the schema declares the column as NOT NULL.
+    /// This is separate from <see cref="IsNullable"/> to preserve the user's declared
+    /// result type for interceptor signature matching.
+    /// </summary>
+    public bool IsJoinNullable { get; }
+
+    /// <summary>
+    /// Gets whether this column requires a null check in reader code generation.
+    /// True when the column is schema-nullable or join-nullable.
+    /// </summary>
+    public bool EffectivelyNullable => IsNullable || IsJoinNullable;
 
     /// <summary>
     /// Gets the ordinal position in the result set (0-based).
@@ -261,6 +278,7 @@ internal sealed class ProjectedColumn : IEquatable<ProjectedColumn>
             && ClrType == other.ClrType
             && FullClrType == other.FullClrType
             && IsNullable == other.IsNullable
+            && IsJoinNullable == other.IsJoinNullable
             && Ordinal == other.Ordinal
             && Alias == other.Alias
             && SqlExpression == other.SqlExpression

--- a/src/Quarry.Generator/Parsing/ChainAnalyzer.cs
+++ b/src/Quarry.Generator/Parsing/ChainAnalyzer.cs
@@ -641,7 +641,7 @@ internal static class ChainAnalyzer
                         registry, isTraced);
                 }
                 projection = BuildProjection(raw.ProjectionInfo, executionSite, registry,
-                    site.Bound.Dialect, implicitJoinInfos, diagnostics);
+                    site.Bound.Dialect, implicitJoinInfos, joinPlans, diagnostics);
             }
         }
 
@@ -766,7 +766,8 @@ internal static class ChainAnalyzer
                         tableAlias: "t0",
                         isForeignKey: col.IsForeignKey,
                         foreignKeyEntityName: col.ForeignKeyEntityName,
-                        isEnum: col.IsEnum));
+                        isEnum: col.IsEnum,
+                        isJoinNullable: col.IsJoinNullable));
                 }
                 else
                 {
@@ -1148,6 +1149,7 @@ internal static class ChainAnalyzer
         EntityRegistry registry,
         SqlDialect dialect,
         List<ImplicitJoinInfo> implicitJoins,
+        IReadOnlyList<JoinPlan>? joinPlans = null,
         List<DiagnosticInfo>? diagnostics = null)
     {
         // Build column lookups for enrichment
@@ -1182,6 +1184,30 @@ internal static class ChainAnalyzer
             entityColumnLookup = new Dictionary<string, ColumnInfo>(StringComparer.Ordinal);
             foreach (var ec in entityRef.Columns)
                 entityColumnLookup[ec.PropertyName] = ec;
+        }
+
+        // Determine whether a table alias is on the nullable side of an outer join.
+        // Cascading: a RIGHT/FULL OUTER join at position i makes all tables 0..i nullable.
+        bool IsJoinNullable(string? tableAlias)
+        {
+            if (tableAlias == null || joinPlans == null || joinPlans.Count == 0)
+                return false;
+            int k = int.Parse(tableAlias.Substring(1)); // "t0" -> 0, "t1" -> 1, etc.
+            // Right side of its own join: join[k-1] is Left or FullOuter
+            if (k >= 1 && k - 1 < joinPlans.Count)
+            {
+                var kind = joinPlans[k - 1].Kind;
+                if (kind == JoinClauseKind.Left || kind == JoinClauseKind.FullOuter)
+                    return true;
+            }
+            // Left side of a later Right or FullOuter join
+            for (int i = Math.Max(k, 0); i < joinPlans.Count; i++)
+            {
+                var kind = joinPlans[i].Kind;
+                if (kind == JoinClauseKind.Right || kind == JoinClauseKind.FullOuter)
+                    return true;
+            }
+            return false;
         }
 
         var columns = new List<ProjectedColumn>();
@@ -1277,11 +1303,37 @@ internal static class ChainAnalyzer
                             tableAlias: col.TableAlias,
                             isForeignKey: entityCol.Kind == ColumnKind.ForeignKey,
                             foreignKeyEntityName: entityCol.ReferencedEntityName,
-                            isEnum: entityCol.IsEnum));
+                            isEnum: entityCol.IsEnum,
+                            isJoinNullable: IsJoinNullable(col.TableAlias)));
                         continue;
                     }
                 }
-                columns.Add(col);
+                // Apply join-nullable override for unenriched columns
+                if (!col.IsJoinNullable && IsJoinNullable(col.TableAlias))
+                {
+                    columns.Add(new ProjectedColumn(
+                        propertyName: col.PropertyName,
+                        columnName: col.ColumnName,
+                        clrType: col.ClrType,
+                        fullClrType: col.FullClrType,
+                        isNullable: col.IsNullable,
+                        ordinal: col.Ordinal,
+                        alias: col.Alias,
+                        sqlExpression: col.SqlExpression,
+                        isAggregateFunction: col.IsAggregateFunction,
+                        customTypeMapping: col.CustomTypeMapping,
+                        isValueType: col.IsValueType,
+                        readerMethodName: col.ReaderMethodName,
+                        tableAlias: col.TableAlias,
+                        isForeignKey: col.IsForeignKey,
+                        foreignKeyEntityName: col.ForeignKeyEntityName,
+                        isEnum: col.IsEnum,
+                        isJoinNullable: true));
+                }
+                else
+                {
+                    columns.Add(col);
+                }
             }
         }
 
@@ -1297,6 +1349,7 @@ internal static class ChainAnalyzer
                 if (entry != null)
                 {
                     var ordinal = 0;
+                    var entityJoinNullable = IsJoinNullable(projInfo.JoinedEntityAlias);
                     foreach (var col in EntityRef.FromEntityInfo(entry.Entity).Columns)
                     {
                         columns.Add(new ProjectedColumn(
@@ -1312,7 +1365,8 @@ internal static class ChainAnalyzer
                             customTypeMapping: col.CustomTypeMappingClass,
                             isForeignKey: col.Kind == ColumnKind.ForeignKey,
                             foreignKeyEntityName: col.ReferencedEntityName,
-                            isEnum: col.IsEnum));
+                            isEnum: col.IsEnum,
+                            isJoinNullable: entityJoinNullable));
                     }
                 }
             }

--- a/src/Quarry.Generator/Parsing/ChainAnalyzer.cs
+++ b/src/Quarry.Generator/Parsing/ChainAnalyzer.cs
@@ -1328,6 +1328,7 @@ internal static class ChainAnalyzer
                         isForeignKey: col.IsForeignKey,
                         foreignKeyEntityName: col.ForeignKeyEntityName,
                         isEnum: col.IsEnum,
+                        navigationHops: col.NavigationHops,
                         isJoinNullable: true));
                 }
                 else

--- a/src/Quarry.Generator/Projection/ReaderCodeGenerator.cs
+++ b/src/Quarry.Generator/Projection/ReaderCodeGenerator.cs
@@ -196,6 +196,11 @@ internal static class ReaderCodeGenerator
         var ordinal = column.Ordinal;
         var readerMethod = column.ReaderMethodName;
         var rawRead = $"r.{readerMethod}({ordinal})";
+        // Use EffectivelyNullable to include join-forced nullability for reader null checks
+        var needsNullCheck = column.EffectivelyNullable;
+        // Join-only nullable: null check needed but return type must stay non-nullable
+        // (the user declared a non-nullable type, but the join can produce NULL at runtime)
+        var joinOnlyNullable = column.IsJoinNullable && !column.IsNullable;
 
         // Handle FK columns — wrap raw key value in new Ref<TEntity, TKey>(...)
         if (column.IsForeignKey && column.ForeignKeyEntityName != null)
@@ -203,9 +208,10 @@ internal static class ReaderCodeGenerator
             var refType = $"EntityRef<{column.ForeignKeyEntityName}, {column.ClrType}>";
 
             // Handle nullable types - need null check
-            if (column.IsNullable)
+            if (needsNullCheck)
             {
-                return $"r.IsDBNull({ordinal}) ? default({refType}?) : new {refType}({rawRead})";
+                var defaultExpr = joinOnlyNullable ? $"default({refType})" : $"default({refType}?)";
+                return $"r.IsDBNull({ordinal}) ? {defaultExpr} : new {refType}({rawRead})";
             }
 
             return $"new {refType}({rawRead})";
@@ -214,9 +220,10 @@ internal static class ReaderCodeGenerator
         // Handle enum columns — cast integral value to enum type
         if (column.IsEnum)
         {
-            if (column.IsNullable)
+            if (needsNullCheck)
             {
-                return $"r.IsDBNull({ordinal}) ? default({column.FullClrType}?) : ({column.FullClrType}){rawRead}";
+                var defaultExpr = joinOnlyNullable ? $"default({column.FullClrType})" : $"default({column.FullClrType}?)";
+                return $"r.IsDBNull({ordinal}) ? {defaultExpr} : ({column.FullClrType}){rawRead}";
             }
 
             return $"({column.FullClrType}){rawRead}";
@@ -226,9 +233,10 @@ internal static class ReaderCodeGenerator
         // (e.g., (uint)r.GetInt32(0) for unsigned, (sbyte)r.GetByte(0) for signed byte)
         if (TypeClassification.NeedsSignCast(column.ClrType))
         {
-            if (column.IsNullable)
+            if (needsNullCheck)
             {
-                return $"r.IsDBNull({ordinal}) ? default({column.ClrType}?) : ({column.ClrType}){rawRead}";
+                var defaultExpr = joinOnlyNullable ? $"default({column.ClrType})" : $"default({column.ClrType}?)";
+                return $"r.IsDBNull({ordinal}) ? {defaultExpr} : ({column.ClrType}){rawRead}";
             }
 
             return $"({column.ClrType}){rawRead}";
@@ -238,10 +246,13 @@ internal static class ReaderCodeGenerator
         if (column.CustomTypeMapping != null)
         {
             var fieldName = InterceptorCodeGenerator.GetMappingFieldName(column.CustomTypeMapping);
-            if (column.IsNullable)
+            if (needsNullCheck)
             {
                 var nullableType = column.IsValueType ? $"{column.ClrType}?" : column.ClrType;
-                return $"r.IsDBNull({ordinal}) ? default({nullableType}) : {fieldName}.FromDb(r.{readerMethod}({ordinal}))";
+                var defaultExpr = joinOnlyNullable
+                    ? (column.IsValueType ? $"default({column.ClrType})" : "default!")
+                    : $"default({nullableType})";
+                return $"r.IsDBNull({ordinal}) ? {defaultExpr} : {fieldName}.FromDb(r.{readerMethod}({ordinal}))";
             }
             return $"{fieldName}.FromDb(r.{readerMethod}({ordinal}))";
         }
@@ -250,27 +261,33 @@ internal static class ReaderCodeGenerator
         if (readerMethod == "GetValue")
         {
             var castType = column.FullClrType ?? column.ClrType;
-            if (column.IsNullable)
+            if (needsNullCheck)
             {
                 var nullableType = column.IsValueType ? $"{castType}?" : castType;
-                return $"r.IsDBNull({ordinal}) ? default({nullableType}) : ({castType})r.GetValue({ordinal})";
+                var defaultExpr = joinOnlyNullable
+                    ? (column.IsValueType ? $"default({castType})" : "default!")
+                    : $"default({nullableType})";
+                return $"r.IsDBNull({ordinal}) ? {defaultExpr} : ({castType})r.GetValue({ordinal})";
             }
             return $"({castType})r.GetValue({ordinal})";
         }
 
         // Handle nullable types - need null check
-        if (column.IsNullable)
+        if (needsNullCheck)
         {
-            // For value types: default(DateTime?) returns null, not DateTime.MinValue
-            // For reference types: use null (idiomatic and type-inference friendly in initializers)
             if (column.IsValueType)
             {
-                var nullableType = $"{column.ClrType}?";
-                return $"r.IsDBNull({ordinal}) ? default({nullableType}) : r.{readerMethod}({ordinal})";
+                // Join-only: return non-nullable default (e.g., 0 for int) to match declared type
+                // Schema-nullable: return nullable default (e.g., default(int?) = null)
+                var defaultExpr = joinOnlyNullable ? "default" : $"default({column.ClrType}?)";
+                return $"r.IsDBNull({ordinal}) ? {defaultExpr} : r.{readerMethod}({ordinal})";
             }
             else
             {
-                return $"r.IsDBNull({ordinal}) ? null : r.{readerMethod}({ordinal})";
+                // Join-only: use default! to suppress nullability warning (type stays non-nullable)
+                // Schema-nullable: use null (type is already nullable)
+                var defaultExpr = joinOnlyNullable ? "default!" : "null";
+                return $"r.IsDBNull({ordinal}) ? {defaultExpr} : r.{readerMethod}({ordinal})";
             }
         }
 

--- a/src/Quarry.Generator/QuarryGenerator.cs
+++ b/src/Quarry.Generator/QuarryGenerator.cs
@@ -830,7 +830,8 @@ public sealed class QuarryGenerator : IIncrementalGenerator
                     tableAlias: col.TableAlias,
                     isForeignKey: col.IsForeignKey,
                     foreignKeyEntityName: col.ForeignKeyEntityName,
-                    isEnum: col.IsEnum));
+                    isEnum: col.IsEnum,
+                    isJoinNullable: col.IsJoinNullable));
             }
             else
             {

--- a/src/Quarry.Tests/Integration/JoinNullableIntegrationTests.cs
+++ b/src/Quarry.Tests/Integration/JoinNullableIntegrationTests.cs
@@ -1,4 +1,7 @@
 using Quarry.Tests.Samples;
+using Pg = Quarry.Tests.Samples.Pg;
+using My = Quarry.Tests.Samples.My;
+using Ss = Quarry.Tests.Samples.Ss;
 
 namespace Quarry.Tests.Integration;
 
@@ -101,5 +104,109 @@ internal class JoinNullableIntegrationTests
         var defaultOrder = results.Single(r => r.OrderId == 0);
         Assert.That(defaultOrder.Total, Is.EqualTo(0m));
         Assert.That(defaultOrder.Status, Is.Null);
+    }
+
+    [Test]
+    public async Task LeftJoin_IntColumn_NullHandled()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, _, _, _) = t;
+
+        // Order.OrderId is an int (NOT NULL in schema)
+        var query = Lite.Users()
+            .LeftJoin<Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.OrderId))
+            .Prepare();
+
+        var results = await query.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(4));
+
+        // Matched rows have real values
+        var aliceRow = results.First(r => r.UserName == "Alice");
+        Assert.That(aliceRow.OrderId, Is.GreaterThan(0));
+
+        // Unmatched row: int defaults to 0
+        var charlieRow = results.Single(r => r.UserName == "Charlie");
+        Assert.That(charlieRow.OrderId, Is.EqualTo(0), "Join-nullable int should default to 0 when NULL");
+    }
+
+    [Test]
+    public async Task LeftJoin_EnumColumn_NullHandled()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, _, _, _) = t;
+
+        // Order.Priority is an enum (OrderPriority) — NOT NULL in schema
+        var query = Lite.Users()
+            .LeftJoin<Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Priority))
+            .Prepare();
+
+        var results = await query.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(4));
+
+        // Unmatched row: enum defaults to default(OrderPriority) = 0
+        var charlieRow = results.Single(r => r.UserName == "Charlie");
+        Assert.That(charlieRow.Priority, Is.EqualTo(default(OrderPriority)), "Join-nullable enum should default when NULL");
+    }
+
+    [Test]
+    public async Task RightJoin_SqlVerification_LeftSideMarkedJoinNullable()
+    {
+        // SQLite doesn't support RIGHT JOIN for execution, but we can verify
+        // the SQL generation and projection analysis across all dialects
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var lt = Lite.Users().RightJoin<Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var pg = Pg.Users().RightJoin<Pg.Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var my = My.Users().RightJoin<My.Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var ss = Ss.Users().RightJoin<Ss.Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Total)).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" RIGHT JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
+            pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" RIGHT JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
+            mysql:  "SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` RIGHT JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId`",
+            ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] RIGHT JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId]");
+
+        // Verify projection: left side (UserName) should be join-nullable, right side (Total) should not
+        var diag = lt.ToDiagnostics();
+        Assert.That(diag.ProjectionColumns![0].IsJoinNullable, Is.True, "LEFT side of RIGHT JOIN should be join-nullable");
+        Assert.That(diag.ProjectionColumns[1].IsJoinNullable, Is.False, "RIGHT side of RIGHT JOIN should not be join-nullable");
+    }
+
+    [Test]
+    public async Task FullOuterJoin_SqlVerification_BothSidesMarkedJoinNullable()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        var lt = Lite.Users().FullOuterJoin<Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var pg = Pg.Users().FullOuterJoin<Pg.Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var my = My.Users().FullOuterJoin<My.Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Total)).Prepare();
+        var ss = Ss.Users().FullOuterJoin<Ss.Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Total)).Prepare();
+
+        QueryTestHarness.AssertDialects(
+            lt.ToDiagnostics(), pg.ToDiagnostics(),
+            my.ToDiagnostics(), ss.ToDiagnostics(),
+            sqlite: "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" FULL OUTER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
+            pg:     "SELECT \"t0\".\"UserName\", \"t1\".\"Total\" FROM \"users\" AS \"t0\" FULL OUTER JOIN \"orders\" AS \"t1\" ON \"t0\".\"UserId\" = \"t1\".\"UserId\"",
+            mysql:  "SELECT `t0`.`UserName`, `t1`.`Total` FROM `users` AS `t0` FULL OUTER JOIN `orders` AS `t1` ON `t0`.`UserId` = `t1`.`UserId`",
+            ss:     "SELECT [t0].[UserName], [t1].[Total] FROM [users] AS [t0] FULL OUTER JOIN [orders] AS [t1] ON [t0].[UserId] = [t1].[UserId]");
+
+        // Verify projection: both sides should be join-nullable
+        var diag = lt.ToDiagnostics();
+        Assert.That(diag.ProjectionColumns![0].IsJoinNullable, Is.True, "LEFT side of FULL OUTER JOIN should be join-nullable");
+        Assert.That(diag.ProjectionColumns[1].IsJoinNullable, Is.True, "RIGHT side of FULL OUTER JOIN should be join-nullable");
     }
 }

--- a/src/Quarry.Tests/Integration/JoinNullableIntegrationTests.cs
+++ b/src/Quarry.Tests/Integration/JoinNullableIntegrationTests.cs
@@ -1,0 +1,105 @@
+using Quarry.Tests.Samples;
+
+namespace Quarry.Tests.Integration;
+
+/// <summary>
+/// Integration tests verifying that the generated reader correctly handles NULL values
+/// from outer join columns at runtime. Before the join-nullable fix, reading a NOT NULL
+/// column from the unmatched side of an outer join would crash with an InvalidCast.
+/// </summary>
+[TestFixture]
+internal class JoinNullableIntegrationTests
+{
+    [Test]
+    public async Task LeftJoin_TupleProjection_RightSideNullHandled()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, _, _, _) = t;
+
+        // Users LEFT JOIN Orders: Charlie has 0 orders → right side columns are NULL
+        var query = Lite.Users()
+            .LeftJoin<Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Total))
+            .Prepare();
+
+        var results = await query.ExecuteFetchAllAsync();
+
+        // 4 rows: Alice (2 orders) + Bob (1 order) + Charlie (0 orders = NULL right side)
+        Assert.That(results, Has.Count.EqualTo(4));
+
+        // Matched rows have real values
+        var aliceRows = results.Where(r => r.UserName == "Alice").ToList();
+        Assert.That(aliceRows, Has.Count.EqualTo(2));
+        Assert.That(aliceRows.Select(r => r.Total).OrderBy(v => v), Is.EquivalentTo(new[] { 75.50m, 250.00m }));
+
+        // Unmatched row (Charlie): Total is default(decimal) = 0 because the column is
+        // NOT NULL in schema but NULL at runtime due to LEFT JOIN
+        var charlieRow = results.Single(r => r.UserName == "Charlie");
+        Assert.That(charlieRow.Total, Is.EqualTo(0m), "Join-nullable decimal should default to 0 when NULL");
+    }
+
+    [Test]
+    public async Task LeftJoin_TupleProjection_MultipleRightColumns()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, _, _, _) = t;
+
+        // Select multiple right-side columns: Status (string, NOT NULL) and Total (decimal, NOT NULL)
+        var query = Lite.Users()
+            .LeftJoin<Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Status, o.Total))
+            .Prepare();
+
+        var results = await query.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(4));
+
+        // Unmatched row: both right-side columns are NULL → defaults
+        var charlieRow = results.Single(r => r.UserName == "Charlie");
+        Assert.That(charlieRow.Status, Is.Null, "Join-nullable string should be null when NULL");
+        Assert.That(charlieRow.Total, Is.EqualTo(0m), "Join-nullable decimal should default to 0 when NULL");
+    }
+
+    [Test]
+    public async Task LeftJoin_TupleProjection_WithWhereOnLeftTable()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, _, _, _) = t;
+
+        // Filter to only inactive user (Charlie) who has no orders
+        var query = Lite.Users()
+            .LeftJoin<Order>((u, o) => u.UserId == o.UserId.Id)
+            .Where((u, o) => !u.IsActive)
+            .Select((u, o) => (u.UserName, o.Total))
+            .Prepare();
+
+        var results = await query.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].UserName, Is.EqualTo("Charlie"));
+        Assert.That(results[0].Total, Is.EqualTo(0m), "Charlie has no orders, Total should be default(decimal)");
+    }
+
+    [Test]
+    public async Task LeftJoin_EntityProjection_RightSideNullHandled()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, _, _, _) = t;
+
+        // Project entire right-side entity
+        var query = Lite.Users()
+            .LeftJoin<Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => o)
+            .Prepare();
+
+        var results = await query.ExecuteFetchAllAsync();
+        Assert.That(results, Has.Count.EqualTo(4));
+
+        // Matched rows have real values
+        var matched = results.Where(r => r.OrderId != 0).ToList();
+        Assert.That(matched, Has.Count.EqualTo(3));
+
+        // Unmatched row: entity has all default values
+        var defaultOrder = results.Single(r => r.OrderId == 0);
+        Assert.That(defaultOrder.Total, Is.EqualTo(0m));
+        Assert.That(defaultOrder.Status, Is.Null);
+    }
+}

--- a/src/Quarry.Tests/ManifestOutput/quarry-manifest.mysql.md
+++ b/src/Quarry.Tests/ManifestOutput/quarry-manifest.mysql.md
@@ -2041,7 +2041,7 @@ SELECT `UserId`, `UserName`, `Email`, `IsActive`, `CreatedAt`, `LastLogin` FROM 
 
 | Metric | Count |
 |--------|------:|
-| Total discovered | 265 |
+| Total discovered | 267 |
 | Skipped (errors) | 0 |
-| Consolidated (deduped) | 44 |
+| Consolidated (deduped) | 46 |
 | Rendered | 221 |

--- a/src/Quarry.Tests/ManifestOutput/quarry-manifest.postgresql.md
+++ b/src/Quarry.Tests/ManifestOutput/quarry-manifest.postgresql.md
@@ -2054,7 +2054,7 @@ SELECT "UserId", "UserName", "Email", "IsActive", "CreatedAt", "LastLogin" FROM 
 
 | Metric | Count |
 |--------|------:|
-| Total discovered | 266 |
+| Total discovered | 268 |
 | Skipped (errors) | 0 |
-| Consolidated (deduped) | 44 |
+| Consolidated (deduped) | 46 |
 | Rendered | 222 |

--- a/src/Quarry.Tests/ManifestOutput/quarry-manifest.sqlite.md
+++ b/src/Quarry.Tests/ManifestOutput/quarry-manifest.sqlite.md
@@ -1091,6 +1091,14 @@ SELECT "t0"."UserName", "t1"."Status", "t2"."ProductName", "t2"."Quantity" FROM 
 
 ---
 
+### Users().Join(...).LeftJoin(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "t0"."UserName", "t1"."Total", "t2"."ProductName" FROM "users" AS "t0" INNER JOIN "orders" AS "t1" ON "t0"."UserId" = "t1"."UserId" LEFT JOIN "order_items" AS "t2" ON "t1"."OrderId" = "t2"."OrderId"
+```
+
+---
+
 ### Users().Join(...).Select(...).OrderBy(...).Prepare().ToDiagnostics()
 
 ```sql
@@ -1248,6 +1256,54 @@ SELECT "t0"."UserName", "t1"."Total" FROM "users" AS "t0" INNER JOIN "orders" AS
 
 ---
 
+### Users().LeftJoin(...).RightJoin(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "t0"."UserName", "t1"."Total", "t2"."ProductName" FROM "users" AS "t0" LEFT JOIN "orders" AS "t1" ON "t0"."UserId" = "t1"."UserId" RIGHT JOIN "order_items" AS "t2" ON "t1"."OrderId" = "t2"."OrderId"
+```
+
+---
+
+### Users().LeftJoin(...).Select(...).Prepare().ExecuteFetchAllAsync()
+
+```sql
+SELECT "t0"."UserName", "t1"."OrderId" FROM "users" AS "t0" LEFT JOIN "orders" AS "t1" ON "t0"."UserId" = "t1"."UserId"
+```
+
+---
+
+### Users().LeftJoin(...).Select(...).Prepare().ExecuteFetchAllAsync()
+
+```sql
+SELECT "t0"."UserName", "t1"."Priority" FROM "users" AS "t0" LEFT JOIN "orders" AS "t1" ON "t0"."UserId" = "t1"."UserId"
+```
+
+---
+
+### Users().LeftJoin(...).Select(...).Prepare().ExecuteFetchAllAsync()
+
+```sql
+SELECT "t0"."UserName", "t1"."Status", "t1"."Total" FROM "users" AS "t0" LEFT JOIN "orders" AS "t1" ON "t0"."UserId" = "t1"."UserId"
+```
+
+---
+
+### Users().LeftJoin(...).Select(...).Prepare().ExecuteFetchAllAsync()
+
+```sql
+SELECT "t0"."UserName", "t1"."Total" FROM "users" AS "t0" LEFT JOIN "orders" AS "t1" ON "t0"."UserId" = "t1"."UserId"
+```
+
+---
+
+### Users().LeftJoin(...).Select(...).Prepare().ExecuteFetchAllAsync()
+
+```sql
+SELECT "t1"."OrderId", "t1"."UserId", "t1"."Total", "t1"."Status", "t1"."Priority", "t1"."OrderDate", "t1"."Notes" FROM "users" AS "t0" LEFT JOIN "orders" AS "t1" ON "t0"."UserId" = "t1"."UserId"
+```
+
+---
+
 ### Users().LeftJoin(...).Select(...).Prepare().ToDiagnostics()
 
 ```sql
@@ -1259,7 +1315,31 @@ SELECT "t0"."UserName" FROM "users" AS "t0" LEFT JOIN "orders" AS "t1" ON "t0"."
 ### Users().LeftJoin(...).Select(...).Prepare().ToDiagnostics()
 
 ```sql
+SELECT "t0"."UserName", "t1"."Notes" FROM "users" AS "t0" LEFT JOIN "orders" AS "t1" ON "t0"."UserId" = "t1"."UserId"
+```
+
+---
+
+### Users().LeftJoin(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
+SELECT "t0"."UserName", "t1"."Total" FROM "users" AS "t0" LEFT JOIN "orders" AS "t1" ON "t0"."UserId" = "t1"."UserId"
+```
+
+---
+
+### Users().LeftJoin(...).Select(...).Prepare().ToDiagnostics()
+
+```sql
 SELECT "t1"."OrderId", "t1"."UserId", "t1"."Total", "t1"."Status", "t1"."Priority", "t1"."OrderDate", "t1"."Notes" FROM "users" AS "t0" LEFT JOIN "orders" AS "t1" ON "t0"."UserId" = "t1"."UserId"
+```
+
+---
+
+### Users().LeftJoin(...).Where(...).Select(...).Prepare().ExecuteFetchAllAsync()
+
+```sql
+SELECT "t0"."UserName", "t1"."Total" FROM "users" AS "t0" LEFT JOIN "orders" AS "t1" ON "t0"."UserId" = "t1"."UserId" WHERE NOT ("t0"."IsActive")
 ```
 
 ---
@@ -3190,7 +3270,7 @@ SELECT "WidgetId", "WidgetName", "Secret" FROM "widgets" WHERE "Secret" = @p0
 
 | Metric | Count |
 |--------|------:|
-| Total discovered | 482 |
+| Total discovered | 498 |
 | Skipped (errors) | 0 |
-| Consolidated (deduped) | 148 |
-| Rendered | 334 |
+| Consolidated (deduped) | 154 |
+| Rendered | 344 |

--- a/src/Quarry.Tests/ManifestOutput/quarry-manifest.sqlserver.md
+++ b/src/Quarry.Tests/ManifestOutput/quarry-manifest.sqlserver.md
@@ -2041,7 +2041,7 @@ SELECT [UserName], [Email] FROM [users] WHERE ([Email] IS NOT NULL) AND ([IsActi
 
 | Metric | Count |
 |--------|------:|
-| Total discovered | 265 |
+| Total discovered | 267 |
 | Skipped (errors) | 0 |
-| Consolidated (deduped) | 44 |
+| Consolidated (deduped) | 46 |
 | Rendered | 221 |

--- a/src/Quarry.Tests/SqlOutput/JoinNullableProjectionTests.cs
+++ b/src/Quarry.Tests/SqlOutput/JoinNullableProjectionTests.cs
@@ -1,0 +1,183 @@
+using Quarry.Tests.Samples;
+using Pg = Quarry.Tests.Samples.Pg;
+using My = Quarry.Tests.Samples.My;
+using Ss = Quarry.Tests.Samples.Ss;
+
+namespace Quarry.Tests.SqlOutput;
+
+/// <summary>
+/// Verifies that ProjectedColumn.IsJoinNullable is set correctly based on join type.
+/// Outer joins force columns on the nullable side to be join-nullable, even when
+/// the schema declares them NOT NULL.
+/// </summary>
+[TestFixture]
+internal class JoinNullableProjectionTests
+{
+    #region Inner Join (no join-nullable)
+
+    [Test]
+    public async Task InnerJoin_NoColumnsJoinNullable()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, _, _, _) = t;
+
+        var diag = Lite.Users().Join<Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Total)).Prepare().ToDiagnostics();
+
+        // INNER JOIN: neither side is join-nullable
+        Assert.That(diag.ProjectionColumns, Has.Count.EqualTo(2));
+        Assert.That(diag.ProjectionColumns![0].PropertyName, Is.EqualTo("UserName"));
+        Assert.That(diag.ProjectionColumns[0].IsJoinNullable, Is.False);
+        Assert.That(diag.ProjectionColumns[1].PropertyName, Is.EqualTo("Total"));
+        Assert.That(diag.ProjectionColumns[1].IsJoinNullable, Is.False);
+    }
+
+    #endregion
+
+    #region Cross Join (no join-nullable)
+
+    [Test]
+    public async Task CrossJoin_NoColumnsJoinNullable()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, _, _, _) = t;
+
+        var diag = Lite.Users().CrossJoin<Order>()
+            .Select((u, o) => (u.UserName, o.Total)).Prepare().ToDiagnostics();
+
+        // CROSS JOIN: neither side is join-nullable
+        Assert.That(diag.ProjectionColumns, Has.Count.EqualTo(2));
+        Assert.That(diag.ProjectionColumns![0].IsJoinNullable, Is.False);
+        Assert.That(diag.ProjectionColumns[1].IsJoinNullable, Is.False);
+    }
+
+    #endregion
+
+    #region Left Join
+
+    [Test]
+    public async Task LeftJoin_RightSideColumnsJoinNullable()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, _, _, _) = t;
+
+        var diag = Lite.Users().LeftJoin<Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Total)).Prepare().ToDiagnostics();
+
+        // LEFT JOIN: left side (t0 = Users) not join-nullable, right side (t1 = Orders) is join-nullable
+        Assert.That(diag.ProjectionColumns, Has.Count.EqualTo(2));
+        Assert.That(diag.ProjectionColumns![0].PropertyName, Is.EqualTo("UserName"));
+        Assert.That(diag.ProjectionColumns[0].IsJoinNullable, Is.False, "Left side of LEFT JOIN should not be join-nullable");
+        Assert.That(diag.ProjectionColumns[1].PropertyName, Is.EqualTo("Total"));
+        Assert.That(diag.ProjectionColumns[1].IsJoinNullable, Is.True, "Right side of LEFT JOIN should be join-nullable");
+    }
+
+    [Test]
+    public async Task LeftJoin_SchemaAlreadyNullable_StaysNullable()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, _, _, _) = t;
+
+        // Order.Notes is already nullable in schema
+        var diag = Lite.Users().LeftJoin<Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Notes)).Prepare().ToDiagnostics();
+
+        Assert.That(diag.ProjectionColumns, Has.Count.EqualTo(2));
+        Assert.That(diag.ProjectionColumns![1].PropertyName, Is.EqualTo("Notes"));
+        Assert.That(diag.ProjectionColumns[1].IsNullable, Is.True, "Schema nullable stays nullable");
+        Assert.That(diag.ProjectionColumns[1].IsJoinNullable, Is.True, "Right side of LEFT JOIN is also join-nullable");
+    }
+
+    #endregion
+
+    #region Right Join
+
+    [Test]
+    public async Task RightJoin_LeftSideColumnsJoinNullable()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, _, _, _) = t;
+
+        var diag = Lite.Users().RightJoin<Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Total)).Prepare().ToDiagnostics();
+
+        // RIGHT JOIN: left side (t0 = Users) is join-nullable, right side (t1 = Orders) not join-nullable
+        Assert.That(diag.ProjectionColumns, Has.Count.EqualTo(2));
+        Assert.That(diag.ProjectionColumns![0].PropertyName, Is.EqualTo("UserName"));
+        Assert.That(diag.ProjectionColumns[0].IsJoinNullable, Is.True, "Left side of RIGHT JOIN should be join-nullable");
+        Assert.That(diag.ProjectionColumns[1].PropertyName, Is.EqualTo("Total"));
+        Assert.That(diag.ProjectionColumns[1].IsJoinNullable, Is.False, "Right side of RIGHT JOIN should not be join-nullable");
+    }
+
+    #endregion
+
+    #region Full Outer Join
+
+    [Test]
+    public async Task FullOuterJoin_BothSidesJoinNullable()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, _, _, _) = t;
+
+        var diag = Lite.Users().FullOuterJoin<Order>((u, o) => u.UserId == o.UserId.Id)
+            .Select((u, o) => (u.UserName, o.Total)).Prepare().ToDiagnostics();
+
+        // FULL OUTER JOIN: both sides are join-nullable
+        Assert.That(diag.ProjectionColumns, Has.Count.EqualTo(2));
+        Assert.That(diag.ProjectionColumns![0].PropertyName, Is.EqualTo("UserName"));
+        Assert.That(diag.ProjectionColumns[0].IsJoinNullable, Is.True, "Left side of FULL OUTER JOIN should be join-nullable");
+        Assert.That(diag.ProjectionColumns[1].PropertyName, Is.EqualTo("Total"));
+        Assert.That(diag.ProjectionColumns[1].IsJoinNullable, Is.True, "Right side of FULL OUTER JOIN should be join-nullable");
+    }
+
+    #endregion
+
+    #region Cascading Nullability
+
+    [Test]
+    public async Task LeftJoin_ThenRightJoin_CascadesNullability()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, _, _, _) = t;
+
+        // t0 LEFT JOIN t1 RIGHT JOIN t2
+        // t0: join-nullable (left side of RIGHT JOIN at index 1)
+        // t1: join-nullable (right side of LEFT JOIN at index 0, AND left side of RIGHT JOIN at index 1)
+        // t2: not join-nullable (right side of RIGHT JOIN)
+        var diag = Lite.Users()
+            .LeftJoin<Order>((u, o) => u.UserId == o.UserId.Id)
+            .RightJoin<OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id)
+            .Select((u, o, oi) => (u.UserName, o.Total, oi.ProductName)).Prepare().ToDiagnostics();
+
+        Assert.That(diag.ProjectionColumns, Has.Count.EqualTo(3));
+        Assert.That(diag.ProjectionColumns![0].PropertyName, Is.EqualTo("UserName"));
+        Assert.That(diag.ProjectionColumns[0].IsJoinNullable, Is.True, "t0 should be join-nullable due to cascading RIGHT JOIN");
+        Assert.That(diag.ProjectionColumns[1].PropertyName, Is.EqualTo("Total"));
+        Assert.That(diag.ProjectionColumns[1].IsJoinNullable, Is.True, "t1 should be join-nullable (LEFT + cascading RIGHT)");
+        Assert.That(diag.ProjectionColumns[2].PropertyName, Is.EqualTo("ProductName"));
+        Assert.That(diag.ProjectionColumns[2].IsJoinNullable, Is.False, "t2 (RIGHT JOIN right side) should not be join-nullable");
+    }
+
+    [Test]
+    public async Task InnerJoin_ThenLeftJoin_OnlyLastJoinedTableNullable()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, _, _, _) = t;
+
+        // t0 INNER JOIN t1 LEFT JOIN t2
+        // t0: not join-nullable (inner join, no later RIGHT/FULL)
+        // t1: not join-nullable (right side of inner join, no later RIGHT/FULL)
+        // t2: join-nullable (right side of LEFT JOIN)
+        var diag = Lite.Users()
+            .Join<Order>((u, o) => u.UserId == o.UserId.Id)
+            .LeftJoin<OrderItem>((u, o, oi) => o.OrderId == oi.OrderId.Id)
+            .Select((u, o, oi) => (u.UserName, o.Total, oi.ProductName)).Prepare().ToDiagnostics();
+
+        Assert.That(diag.ProjectionColumns, Has.Count.EqualTo(3));
+        Assert.That(diag.ProjectionColumns![0].IsJoinNullable, Is.False, "t0 should not be join-nullable");
+        Assert.That(diag.ProjectionColumns[1].IsJoinNullable, Is.False, "t1 should not be join-nullable");
+        Assert.That(diag.ProjectionColumns[2].IsJoinNullable, Is.True, "t2 should be join-nullable (RIGHT side of LEFT JOIN)");
+    }
+
+    #endregion
+}

--- a/src/Quarry.Tests/SqlOutput/JoinNullableProjectionTests.cs
+++ b/src/Quarry.Tests/SqlOutput/JoinNullableProjectionTests.cs
@@ -1,7 +1,4 @@
 using Quarry.Tests.Samples;
-using Pg = Quarry.Tests.Samples.Pg;
-using My = Quarry.Tests.Samples.My;
-using Ss = Quarry.Tests.Samples.Ss;
 
 namespace Quarry.Tests.SqlOutput;
 

--- a/src/Quarry/Query/QueryDiagnostics.cs
+++ b/src/Quarry/Query/QueryDiagnostics.cs
@@ -260,7 +260,8 @@ public sealed class ProjectionColumnDiagnostic
 {
     public ProjectionColumnDiagnostic(string propertyName, string columnName, string clrType, int ordinal,
         bool isNullable = false, string? typeMappingClass = null,
-        bool isForeignKey = false, string? foreignKeyEntityName = null, bool isEnum = false)
+        bool isForeignKey = false, string? foreignKeyEntityName = null, bool isEnum = false,
+        bool isJoinNullable = false)
     {
         PropertyName = propertyName;
         ColumnName = columnName;
@@ -271,6 +272,7 @@ public sealed class ProjectionColumnDiagnostic
         IsForeignKey = isForeignKey;
         ForeignKeyEntityName = foreignKeyEntityName;
         IsEnum = isEnum;
+        IsJoinNullable = isJoinNullable;
     }
 
     public string PropertyName { get; }
@@ -282,6 +284,12 @@ public sealed class ProjectionColumnDiagnostic
     public bool IsForeignKey { get; }
     public string? ForeignKeyEntityName { get; }
     public bool IsEnum { get; }
+
+    /// <summary>
+    /// Whether this column is on the nullable side of an outer join (LEFT, RIGHT, FULL OUTER).
+    /// When true, the column can be NULL at runtime even if the schema declares it NOT NULL.
+    /// </summary>
+    public bool IsJoinNullable { get; }
 }
 
 /// <summary>Describes a JOIN operation in the query chain.</summary>


### PR DESCRIPTION
## Summary
- Closes #191

## Reason for Change
Projection analysis did not adjust column nullability based on join type. Columns from joined entities retained their schema-level nullability regardless of which side of an outer join they appeared on. NOT NULL columns from the right side of a LEFT JOIN were projected as non-nullable but could be NULL at runtime, causing `InvalidCastException` in generated reader code.

## Impact
Generated reader code now emits `IsDBNull` checks for columns on the nullable side of outer joins (LEFT, RIGHT, FULL OUTER). The user's declared tuple/result types are unchanged — interceptor signatures remain compatible. At runtime, unmatched join rows return safe default values (0 for value types, null for reference types) instead of crashing.

## Plan items implemented as specified
- Cascading nullable algorithm: tK is join-nullable if `join[K-1].Kind` is Left/FullOuter OR any `join[i >= K].Kind` is Right/FullOuter
- `List<JoinPlan>` passed directly to `BuildProjection` as new parameter
- Runtime fallback path (`MakeRuntimeBuildChain`) skipped — no join plan data available
- Analyzer-level tests covering all 5 join types + cascading scenarios
- Integration tests verifying runtime NULL handling

## Deviations from plan implemented
- Introduced separate `IsJoinNullable` property on `ProjectedColumn` instead of modifying `IsNullable` directly. This was necessary because changing `IsNullable` affected the tuple result type name used in interceptor signatures, causing CS9144 signature mismatches. `IsJoinNullable` controls reader null checks via `EffectivelyNullable` while preserving the user's declared types.

## Gaps in original plan implemented
- Added `EffectivelyNullable` computed property (`IsNullable || IsJoinNullable`) for clean reader code integration
- Exposed `IsJoinNullable` on `ProjectionColumnDiagnostic` for test observability
- Updated SQL manifests with new test query patterns

## Migration Steps
None — backwards compatible. New `isJoinNullable` parameter defaults to `false`.

## Performance Considerations
Negligible. The `IsJoinNullable()` local function iterates the join plan list (typically 1-5 entries) once per projected column. The `IsDBNull` check adds one comparison per column per row, only for outer-joined columns.

## Security Considerations
None — changes are in compile-time analyzer/codegen code operating on metadata.

## Breaking Changes
- Consumer-facing: None. Tuple result types unchanged. `ProjectionColumnDiagnostic.IsJoinNullable` added with default `false`.
- Internal: `BuildProjection` has new optional `joinPlans` parameter (default `null`).
