### PR TITLE
RawSqlAsync compile-time column resolution (#183)

### DIFF
--- a/src/Quarry.Generator/CodeGen/FileEmitter.cs
+++ b/src/Quarry.Generator/CodeGen/FileEmitter.cs
@@ -35,6 +35,12 @@ internal sealed class FileEmitter
     private readonly IReadOnlyList<TranslatedCallSite> _sites;
     private readonly IReadOnlyList<AssembledPlan>? _chains;
     private readonly IReadOnlyList<CarrierPlan>? _carrierPlans;
+    private readonly List<Models.DiagnosticInfo> _emitDiagnostics = new();
+
+    /// <summary>
+    /// Diagnostics collected during <see cref="Emit"/>. Populated after Emit() returns.
+    /// </summary>
+    public IReadOnlyList<Models.DiagnosticInfo> EmitDiagnostics => _emitDiagnostics;
 
     public FileEmitter(
         string contextClassName,
@@ -182,7 +188,9 @@ internal sealed class FileEmitter
             }
         }
 
-        // Emit file struct row readers for RawSql DTO sites at namespace scope
+        // Resolve compile-time column ordinals for RawSql sites with SQL literals.
+        // Sites that resolve successfully get static readers; others fall back to struct readers.
+        var rawSqlResolvedColumns = new Dictionary<string, IReadOnlyList<RawSqlColumnResolver.ResolvedColumn>>();
         var rawSqlStructNames = new Dictionary<string, string>();
         {
             int rawSqlStructIndex = 0;
@@ -193,6 +201,31 @@ internal sealed class FileEmitter
                     && site.RawSqlTypeInfo.TypeKind != RawSqlTypeKind.Scalar
                     && site.RawSqlTypeInfo.Properties.Count > 0)
                 {
+                    // Try compile-time column resolution first
+                    if (site.RawSqlTypeInfo.SqlLiteral != null)
+                    {
+                        var resolution = RawSqlColumnResolver.Resolve(
+                            site.RawSqlTypeInfo.SqlLiteral,
+                            site.Dialect,
+                            site.RawSqlTypeInfo.Properties);
+
+                        if (resolution.IsResolved)
+                        {
+                            rawSqlResolvedColumns[site.UniqueId] = resolution.Columns!;
+                            continue; // Skip struct creation — static reader will be used
+                        }
+
+                        // Resolution failed — collect diagnostic if applicable
+                        if (resolution.UnresolvableColumnPosition >= 0)
+                        {
+                            _emitDiagnostics.Add(new Models.DiagnosticInfo(
+                                "QRY041",
+                                site.Location,
+                                resolution.UnresolvableColumnPosition.ToString()));
+                        }
+                    }
+
+                    // Fall back to struct-based reader
                     var structName = $"RawSqlReader_{site.RawSqlTypeInfo.ResultTypeName}_{rawSqlStructIndex}";
                     rawSqlStructNames[site.UniqueId] = structName;
                     RawSqlBodyEmitter.EmitRowReaderStruct(sb, site.RawSqlTypeInfo, structName);
@@ -373,7 +406,7 @@ internal sealed class FileEmitter
             }
             foreach (var site in sites)
             {
-                EmitInterceptorMethod(sb, site, staticFields, staticFieldsByMethod, chainLookup, clauseBitMap, chainClauseLookup, firstClauseIds, carrierLookup, carrierClauseLookup, carrierFirstClauseIds, rawSqlStructNames);
+                EmitInterceptorMethod(sb, site, staticFields, staticFieldsByMethod, chainLookup, clauseBitMap, chainClauseLookup, firstClauseIds, carrierLookup, carrierClauseLookup, carrierFirstClauseIds, rawSqlStructNames, rawSqlResolvedColumns);
             }
             sb.AppendLine($"    #endregion");
             sb.AppendLine();
@@ -402,7 +435,8 @@ internal sealed class FileEmitter
         Dictionary<string, (CarrierPlan Carrier, AssembledPlan Chain)>? carrierLookup = null,
         Dictionary<string, (CarrierPlan Carrier, AssembledPlan Chain)>? carrierClauseLookup = null,
         HashSet<string>? carrierFirstClauseIds = null,
-        Dictionary<string, string>? rawSqlStructNames = null)
+        Dictionary<string, string>? rawSqlStructNames = null,
+        Dictionary<string, IReadOnlyList<RawSqlColumnResolver.ResolvedColumn>>? rawSqlResolvedColumns = null)
     {
         // Trace sites are compile-time-only signals — no interceptor generated
         if (site.Kind == InterceptorKind.Trace)
@@ -686,9 +720,11 @@ internal sealed class FileEmitter
 
             case InterceptorKind.RawSqlAsync:
                 {
+                    IReadOnlyList<RawSqlColumnResolver.ResolvedColumn>? resolvedCols = null;
+                    rawSqlResolvedColumns?.TryGetValue(site.UniqueId, out resolvedCols);
                     string? structName = null;
                     rawSqlStructNames?.TryGetValue(site.UniqueId, out structName);
-                    RawSqlBodyEmitter.EmitRawSqlAsync(sb, site, methodName, structName);
+                    RawSqlBodyEmitter.EmitRawSqlAsync(sb, site, methodName, structName, resolvedCols);
                 }
                 break;
 

--- a/src/Quarry.Generator/CodeGen/RawSqlBodyEmitter.cs
+++ b/src/Quarry.Generator/CodeGen/RawSqlBodyEmitter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text;
 using Quarry.Generators.IR;
 using Quarry.Generators.Models;
@@ -78,8 +79,16 @@ internal static class RawSqlBodyEmitter
 
     /// <summary>
     /// Emits a RawSqlAsync&lt;T&gt; interceptor with a typed reader delegate or struct reader.
+    /// When <paramref name="resolvedColumns"/> is provided, emits a static lambda with
+    /// compile-time ordinals (zero runtime overhead). Otherwise uses the struct-based reader
+    /// or lambda fallback.
     /// </summary>
-    public static void EmitRawSqlAsync(StringBuilder sb, TranslatedCallSite site, string methodName, string? structName = null)
+    public static void EmitRawSqlAsync(
+        StringBuilder sb,
+        TranslatedCallSite site,
+        string methodName,
+        string? structName = null,
+        IReadOnlyList<RawSqlColumnResolver.ResolvedColumn>? resolvedColumns = null)
     {
         var rawSqlInfo = site.RawSqlTypeInfo;
         if (rawSqlInfo == null)
@@ -118,6 +127,11 @@ internal static class RawSqlBodyEmitter
             sb.AppendLine($"            static r => {scalarRead},");
             sb.AppendLine($"            {ctArg},");
             sb.AppendLine($"            parameters);");
+        }
+        else if (resolvedColumns != null && resolvedColumns.Count > 0)
+        {
+            // Compile-time column resolution path — static lambda with hardcoded ordinals
+            EmitStaticOrdinalReader(sb, resultType, resolvedColumns, ctArg);
         }
         else if (structName != null && rawSqlInfo.Properties.Count > 0)
         {
@@ -164,6 +178,42 @@ internal static class RawSqlBodyEmitter
         }
 
         sb.AppendLine($"    }}");
+    }
+
+    /// <summary>
+    /// Emits a static lambda reader with compile-time resolved ordinals.
+    /// Each property is read at its known ordinal position — no runtime discovery needed.
+    /// </summary>
+    private static void EmitStaticOrdinalReader(
+        StringBuilder sb,
+        string resultType,
+        IReadOnlyList<RawSqlColumnResolver.ResolvedColumn> resolvedColumns,
+        string ctArg)
+    {
+        sb.AppendLine($"        return self.RawSqlAsyncWithReader(");
+        sb.AppendLine($"            sql,");
+        sb.AppendLine($"            static r =>");
+        sb.AppendLine($"            {{");
+        sb.AppendLine($"                var item = new {resultType}();");
+
+        foreach (var col in resolvedColumns)
+        {
+            var prop = col.Property;
+            var assignment = GeneratePropertyAssignment(prop, col.Ordinal.ToString());
+            if (prop.IsNullable)
+            {
+                sb.AppendLine($"                if (!r.IsDBNull({col.Ordinal})) item.{prop.PropertyName} = {assignment};");
+            }
+            else
+            {
+                sb.AppendLine($"                item.{prop.PropertyName} = {assignment};");
+            }
+        }
+
+        sb.AppendLine($"                return item;");
+        sb.AppendLine($"            }},");
+        sb.AppendLine($"            {ctArg},");
+        sb.AppendLine($"            parameters);");
     }
 
     /// <summary>

--- a/src/Quarry.Generator/CodeGen/RawSqlColumnResolver.cs
+++ b/src/Quarry.Generator/CodeGen/RawSqlColumnResolver.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using Quarry.Generators.Models;
+using Quarry.Generators.Sql;
+using Quarry.Generators.Sql.Parser;
+
+namespace Quarry.Generators.CodeGen;
+
+/// <summary>
+/// Resolves compile-time column ordinals from a SQL literal and a set of DTO properties.
+/// Used by FileEmitter to decide between static ordinal readers and runtime struct readers.
+/// </summary>
+internal static class RawSqlColumnResolver
+{
+    /// <summary>
+    /// A single resolved column mapping: property name → column ordinal in the SQL SELECT list.
+    /// </summary>
+    internal readonly struct ResolvedColumn
+    {
+        public string PropertyName { get; }
+        public int Ordinal { get; }
+        public RawSqlPropertyInfo Property { get; }
+
+        public ResolvedColumn(string propertyName, int ordinal, RawSqlPropertyInfo property)
+        {
+            PropertyName = propertyName;
+            Ordinal = ordinal;
+            Property = property;
+        }
+    }
+
+    /// <summary>
+    /// Result of column resolution. Either <see cref="Columns"/> is populated (success)
+    /// or <see cref="FallbackReason"/> explains why resolution failed.
+    /// </summary>
+    internal sealed class ColumnResolutionResult
+    {
+        /// <summary>Resolved property-to-ordinal mappings. Null on failure.</summary>
+        public IReadOnlyList<ResolvedColumn>? Columns { get; }
+
+        /// <summary>Human-readable reason for falling back to runtime ordinal discovery.</summary>
+        public string? FallbackReason { get; }
+
+        /// <summary>
+        /// Position (0-based) of the unresolvable column expression, or -1 if not applicable.
+        /// Used for QRY041 diagnostic emission.
+        /// </summary>
+        public int UnresolvableColumnPosition { get; }
+
+        private ColumnResolutionResult(IReadOnlyList<ResolvedColumn>? columns, string? fallbackReason, int unresolvableColumnPosition)
+        {
+            Columns = columns;
+            FallbackReason = fallbackReason;
+            UnresolvableColumnPosition = unresolvableColumnPosition;
+        }
+
+        public bool IsResolved => Columns != null;
+
+        public static ColumnResolutionResult Success(IReadOnlyList<ResolvedColumn> columns) =>
+            new(columns, null, -1);
+
+        public static ColumnResolutionResult Fallback(string reason, int unresolvablePosition = -1) =>
+            new(null, reason, unresolvablePosition);
+    }
+
+    /// <summary>
+    /// Attempts to resolve compile-time column ordinals from a SQL literal.
+    /// </summary>
+    /// <param name="sqlLiteral">The SQL string literal from the call site.</param>
+    /// <param name="dialect">The SQL dialect for parsing.</param>
+    /// <param name="properties">The DTO properties to match against SQL columns.</param>
+    /// <returns>A result indicating success with resolved columns, or a fallback reason.</returns>
+    public static ColumnResolutionResult Resolve(
+        string sqlLiteral,
+        SqlDialect dialect,
+        IReadOnlyList<RawSqlPropertyInfo> properties)
+    {
+        // Parse the SQL
+        var parseResult = SqlParser.Parse(sqlLiteral, dialect);
+
+        if (!parseResult.Success)
+            return ColumnResolutionResult.Fallback("SQL parse failed");
+
+        if (parseResult.HasUnsupported)
+            return ColumnResolutionResult.Fallback("SQL contains unsupported constructs (CTEs, UNION, window functions)");
+
+        var statement = parseResult.Statement!;
+
+        // Extract column names from the SELECT list
+        var sqlColumnNames = new List<string>(statement.Columns.Count);
+        for (int i = 0; i < statement.Columns.Count; i++)
+        {
+            var column = statement.Columns[i];
+
+            if (column is SqlStarColumn)
+                return ColumnResolutionResult.Fallback("SQL contains SELECT *");
+
+            if (column is SqlSelectColumn selectCol)
+            {
+                // Use alias if present
+                if (selectCol.Alias != null)
+                {
+                    sqlColumnNames.Add(selectCol.Alias);
+                    continue;
+                }
+
+                // Use column name from simple column reference
+                if (selectCol.Expression is SqlColumnRef colRef)
+                {
+                    sqlColumnNames.Add(colRef.ColumnName);
+                    continue;
+                }
+
+                // Unresolvable: complex expression without alias
+                return ColumnResolutionResult.Fallback(
+                    $"Column at position {i} is an expression without an alias",
+                    i);
+            }
+
+            // Unknown column node type — shouldn't happen, but be safe
+            return ColumnResolutionResult.Fallback($"Unknown column node type at position {i}");
+        }
+
+        // Match SQL columns to DTO properties (case-insensitive)
+        var resolved = new List<ResolvedColumn>();
+        for (int propIndex = 0; propIndex < properties.Count; propIndex++)
+        {
+            var prop = properties[propIndex];
+            int ordinal = -1;
+
+            for (int colIndex = 0; colIndex < sqlColumnNames.Count; colIndex++)
+            {
+                if (string.Equals(sqlColumnNames[colIndex], prop.PropertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    ordinal = colIndex;
+                    break;
+                }
+            }
+
+            // Only include properties that have a matching column
+            if (ordinal >= 0)
+            {
+                resolved.Add(new ResolvedColumn(prop.PropertyName, ordinal, prop));
+            }
+        }
+
+        return ColumnResolutionResult.Success(resolved);
+    }
+}

--- a/src/Quarry.Generator/CodeGen/RawSqlColumnResolver.cs
+++ b/src/Quarry.Generator/CodeGen/RawSqlColumnResolver.cs
@@ -144,6 +144,12 @@ internal static class RawSqlColumnResolver
             }
         }
 
+        // If no properties matched any SQL columns, fall back — a static reader
+        // with zero assignments would construct default objects less efficiently
+        // than the struct reader (which gracefully handles zero matches).
+        if (resolved.Count == 0)
+            return ColumnResolutionResult.Fallback("No SQL columns match any DTO properties");
+
         return ColumnResolutionResult.Success(resolved);
     }
 }

--- a/src/Quarry.Generator/DiagnosticDescriptors.cs
+++ b/src/Quarry.Generator/DiagnosticDescriptors.cs
@@ -536,6 +536,25 @@ internal static class DiagnosticDescriptors
         description: "The Quarry SQL manifest file could not be written to the specified path. " +
                      "Check that the QuarrySqlManifestPath directory exists and is writable.");
 
+    // ─── RawSql compile-time resolution diagnostics (QRY041) ──────────
+
+    /// <summary>
+    /// QRY041: RawSqlAsync column expression without alias.
+    /// Severity: Warning
+    /// </summary>
+    public static readonly DiagnosticDescriptor RawSqlUnresolvableColumn = new(
+        id: "QRY041",
+        title: "RawSqlAsync column expression without alias",
+        messageFormat: "RawSqlAsync column at position {0} is an expression without an alias. " +
+                       "Add 'AS alias' for compile-time column resolution. " +
+                       "Falling back to runtime ordinal discovery.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A column in the RawSqlAsync SQL literal is a complex expression (function call, " +
+                     "arithmetic, etc.) without an AS alias. The generator cannot determine the result " +
+                     "column name at compile time and falls back to runtime ordinal discovery.");
+
     // ─── Navigation join diagnostics (QRY060–QRY065) ──────────────────
 
     /// <summary>

--- a/src/Quarry.Generator/Models/RawSqlTypeInfo.cs
+++ b/src/Quarry.Generator/Models/RawSqlTypeInfo.cs
@@ -13,13 +13,15 @@ internal sealed class RawSqlTypeInfo : IEquatable<RawSqlTypeInfo>
         RawSqlTypeKind typeKind,
         IReadOnlyList<RawSqlPropertyInfo> properties,
         bool hasCancellationToken = false,
-        string? scalarReaderMethod = null)
+        string? scalarReaderMethod = null,
+        string? sqlLiteral = null)
     {
         ResultTypeName = resultTypeName;
         TypeKind = typeKind;
         Properties = properties;
         HasCancellationToken = hasCancellationToken;
         ScalarReaderMethod = scalarReaderMethod;
+        SqlLiteral = sqlLiteral;
     }
 
     /// <summary>
@@ -47,6 +49,13 @@ internal sealed class RawSqlTypeInfo : IEquatable<RawSqlTypeInfo>
     /// </summary>
     public string? ScalarReaderMethod { get; }
 
+    /// <summary>
+    /// The raw SQL string literal from the call site, if the first argument was a compile-time constant.
+    /// Used for compile-time column resolution (Phase 2 of #183).
+    /// Null when the SQL is a variable, interpolated string, or otherwise non-literal.
+    /// </summary>
+    public string? SqlLiteral { get; }
+
     public bool Equals(RawSqlTypeInfo? other)
     {
         if (other is null) return false;
@@ -55,6 +64,7 @@ internal sealed class RawSqlTypeInfo : IEquatable<RawSqlTypeInfo>
             && TypeKind == other.TypeKind
             && HasCancellationToken == other.HasCancellationToken
             && ScalarReaderMethod == other.ScalarReaderMethod
+            && SqlLiteral == other.SqlLiteral
             && EqualityHelpers.SequenceEqual(Properties, other.Properties);
     }
 
@@ -62,7 +72,7 @@ internal sealed class RawSqlTypeInfo : IEquatable<RawSqlTypeInfo>
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(ResultTypeName, TypeKind, HasCancellationToken, Properties.Count);
+        return HashCode.Combine(ResultTypeName, TypeKind, HasCancellationToken, Properties.Count, SqlLiteral);
     }
 }
 

--- a/src/Quarry.Generator/Parsing/DisplayClassEnricher.cs
+++ b/src/Quarry.Generator/Parsing/DisplayClassEnricher.cs
@@ -192,6 +192,30 @@ internal static class DisplayClassEnricher
                     rawSqlTypeInfo = PatchWithColumnMetadata(rawSqlTypeInfo, entry.Entity.Columns);
             }
 
+            // Extract SQL string literal from the first argument for compile-time column resolution.
+            // Only captures compile-time constant strings; variables and interpolated strings are skipped.
+            string? sqlLiteral = null;
+            if (invocation.ArgumentList?.Arguments.Count > 0)
+            {
+                var firstArg = invocation.ArgumentList.Arguments[0].Expression;
+                if (firstArg is LiteralExpressionSyntax literal
+                    && literal.IsKind(SyntaxKind.StringLiteralExpression))
+                {
+                    sqlLiteral = literal.Token.ValueText;
+                }
+            }
+
+            if (sqlLiteral != null)
+            {
+                rawSqlTypeInfo = new RawSqlTypeInfo(
+                    rawSqlTypeInfo.ResultTypeName,
+                    rawSqlTypeInfo.TypeKind,
+                    rawSqlTypeInfo.Properties,
+                    rawSqlTypeInfo.HasCancellationToken,
+                    rawSqlTypeInfo.ScalarReaderMethod,
+                    sqlLiteral);
+            }
+
             site.RawSqlTypeInfo = rawSqlTypeInfo;
 
             // Clear transient reference — no longer needed after enrichment

--- a/src/Quarry.Generator/QuarryGenerator.cs
+++ b/src/Quarry.Generator/QuarryGenerator.cs
@@ -728,6 +728,15 @@ public sealed class QuarryGenerator : IIncrementalGenerator
             var interceptorsSource = emitter.Emit();
             var fileName = $"{group.ContextClassName}.Interceptors.{group.FileTag}.g.cs";
             spc.AddSource(fileName, interceptorsSource);
+
+            // Report diagnostics collected during emission (e.g., QRY041 for unresolvable columns)
+            foreach (var diag in emitter.EmitDiagnostics)
+            {
+                var descriptor = GetDescriptorById(diag.DiagnosticId);
+                if (descriptor == null) continue;
+                var location = CreateLineLocation(diag.Location.FilePath, diag.Location.Line, diag.Location.Column);
+                spc.ReportDiagnostic(Diagnostic.Create(descriptor, location, diag.MessageArgs));
+            }
         }
         catch (Exception ex)
         {

--- a/src/Quarry.Generator/QuarryGenerator.cs
+++ b/src/Quarry.Generator/QuarryGenerator.cs
@@ -765,6 +765,7 @@ public sealed class QuarryGenerator : IIncrementalGenerator
         DiagnosticDescriptors.SqlRawPlaceholderMismatch,
         DiagnosticDescriptors.PreparedQueryEscapesScope,
         DiagnosticDescriptors.PreparedQueryNoTerminals,
+        DiagnosticDescriptors.RawSqlUnresolvableColumn,
     }.ToDictionary(d => d.Id);
 
     private static DiagnosticDescriptor? GetDescriptorById(string id) =>

--- a/src/Quarry.Generator/README.md
+++ b/src/Quarry.Generator/README.md
@@ -438,6 +438,7 @@ public Col<Money> Price => Mapped<MoneyMapping>();
 | QRY023 | Subquery FK-to-PK correlation ambiguous |
 | QRY028 | Redundant unique constraint (column + index) |
 | QRY034 | .Trace() requires QUARRY_TRACE define |
+| QRY041 | RawSqlAsync column expression without alias |
 | QRY050 | Schema changed since last migration snapshot |
 | QRY051 | Migration references unknown table/column |
 | QRY054 | Destructive migration without backup |

--- a/src/Quarry.Generator/llm.md
+++ b/src/Quarry.Generator/llm.md
@@ -372,6 +372,7 @@ All pipeline models implement `IEquatable<T>` for incremental caching.
 | QRY033 | Error | Forked query chain |
 | QRY034 | Warning | .Trace() requires QUARRY_TRACE define |
 | QRY035 | Error | PreparedQuery escapes scope |
+| QRY041 | Warning | RawSqlAsync column expression without alias (falls back to runtime ordinal discovery) |
 | QRY050-055 | Mixed | Migration diagnostics |
 | QRY900 | Error | Internal generator error (pipeline exception) |
 

--- a/src/Quarry.Tests/Integration/RawSqlIntegrationTests.cs
+++ b/src/Quarry.Tests/Integration/RawSqlIntegrationTests.cs
@@ -286,4 +286,43 @@ internal class RawSqlIntegrationTests
     }
 
     #endregion
+
+    #region Compile-Time Column Resolution Tests
+
+    [Test]
+    public async Task RawSqlAsync_LiteralSql_WithAliases_ResolvesCorrectly()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        // Uses AS aliases to match DTO property names — compile-time resolution via aliases
+        var results = await Lite.RawSqlAsync<UserWithEmailDto>(
+            "SELECT \"UserId\" AS \"UserId\", \"UserName\" AS \"UserName\", \"Email\" AS \"Email\" FROM \"users\" ORDER BY \"UserId\"").ToListAsync();
+
+        Assert.That(results, Has.Count.EqualTo(3));
+        Assert.That(results[0].UserId, Is.EqualTo(1));
+        Assert.That(results[0].UserName, Is.EqualTo("Alice"));
+        Assert.That(results[0].Email, Is.EqualTo("alice@test.com"));
+    }
+
+    [Test]
+    public async Task RawSqlAsync_LiteralSql_PartialColumns_MissingPropertiesStayDefault()
+    {
+        await using var t = await QueryTestHarness.CreateAsync();
+        var (Lite, Pg, My, Ss) = t;
+
+        // SQL selects only UserId and UserName — Email is not in the SQL
+        // The compile-time resolver should skip Email, leaving it at default (null)
+        var results = await Lite.RawSqlAsync<UserWithEmailDto>(
+            "SELECT \"UserId\", \"UserName\" FROM \"users\" ORDER BY \"UserId\"").ToListAsync();
+
+        Assert.That(results, Has.Count.EqualTo(3));
+        Assert.That(results[0].UserId, Is.EqualTo(1));
+        Assert.That(results[0].UserName, Is.EqualTo("Alice"));
+        Assert.That(results[0].Email, Is.Null, "Email not in SQL — should be default (null)");
+        Assert.That(results[1].UserId, Is.EqualTo(2));
+        Assert.That(results[1].Email, Is.Null);
+    }
+
+    #endregion
 }

--- a/src/Quarry.Tests/RawSqlColumnResolverTests.cs
+++ b/src/Quarry.Tests/RawSqlColumnResolverTests.cs
@@ -188,16 +188,16 @@ public class RawSqlColumnResolverTests
     }
 
     [Test]
-    public void Resolve_NoMatchingColumns_ReturnsEmptyResolution()
+    public void Resolve_NoMatchingColumns_FallsBack()
     {
         var result = RawSqlColumnResolver.Resolve(
             "SELECT foo, bar FROM users",
             GenDialect.SQLite,
             SampleProperties);
 
-        // Resolves successfully but with no matched columns
-        Assert.That(result.IsResolved, Is.True);
-        Assert.That(result.Columns, Has.Count.EqualTo(0));
+        // Zero matched columns → fallback to struct reader
+        Assert.That(result.IsResolved, Is.False);
+        Assert.That(result.FallbackReason, Does.Contain("No SQL columns match"));
     }
 
     #endregion

--- a/src/Quarry.Tests/RawSqlColumnResolverTests.cs
+++ b/src/Quarry.Tests/RawSqlColumnResolverTests.cs
@@ -1,0 +1,204 @@
+using Quarry.Generators.CodeGen;
+using Quarry.Generators.Models;
+using GenDialect = Quarry.Generators.Sql.SqlDialect;
+
+namespace Quarry.Tests;
+
+/// <summary>
+/// Tests for compile-time SQL column resolution logic.
+/// </summary>
+[TestFixture]
+public class RawSqlColumnResolverTests
+{
+    private static readonly RawSqlPropertyInfo[] SampleProperties = new[]
+    {
+        new RawSqlPropertyInfo("UserId", "int", "GetInt32", false),
+        new RawSqlPropertyInfo("UserName", "string", "GetString", false),
+        new RawSqlPropertyInfo("Email", "string", "GetString", true)
+    };
+
+    #region Success Cases
+
+    [Test]
+    public void Resolve_SimpleSelect_ReturnsCorrectOrdinals()
+    {
+        var result = RawSqlColumnResolver.Resolve(
+            "SELECT UserId, UserName, Email FROM users",
+            GenDialect.SQLite,
+            SampleProperties);
+
+        Assert.That(result.IsResolved, Is.True);
+        Assert.That(result.Columns, Has.Count.EqualTo(3));
+        Assert.That(result.Columns![0].PropertyName, Is.EqualTo("UserId"));
+        Assert.That(result.Columns[0].Ordinal, Is.EqualTo(0));
+        Assert.That(result.Columns![1].PropertyName, Is.EqualTo("UserName"));
+        Assert.That(result.Columns[1].Ordinal, Is.EqualTo(1));
+        Assert.That(result.Columns![2].PropertyName, Is.EqualTo("Email"));
+        Assert.That(result.Columns[2].Ordinal, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Resolve_WithAliases_MatchesAlias()
+    {
+        var result = RawSqlColumnResolver.Resolve(
+            "SELECT id AS UserId, name AS UserName FROM users",
+            GenDialect.SQLite,
+            SampleProperties);
+
+        Assert.That(result.IsResolved, Is.True);
+        Assert.That(result.Columns, Has.Count.EqualTo(2));
+        Assert.That(result.Columns![0].PropertyName, Is.EqualTo("UserId"));
+        Assert.That(result.Columns[0].Ordinal, Is.EqualTo(0));
+        Assert.That(result.Columns![1].PropertyName, Is.EqualTo("UserName"));
+        Assert.That(result.Columns[1].Ordinal, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Resolve_CaseInsensitive_MatchesColumns()
+    {
+        var result = RawSqlColumnResolver.Resolve(
+            "SELECT userid, username, email FROM users",
+            GenDialect.SQLite,
+            SampleProperties);
+
+        Assert.That(result.IsResolved, Is.True);
+        Assert.That(result.Columns, Has.Count.EqualTo(3));
+    }
+
+    [Test]
+    public void Resolve_PartialColumns_OnlyMatchedPropertiesReturned()
+    {
+        var result = RawSqlColumnResolver.Resolve(
+            "SELECT UserId FROM users",
+            GenDialect.SQLite,
+            SampleProperties);
+
+        Assert.That(result.IsResolved, Is.True);
+        Assert.That(result.Columns, Has.Count.EqualTo(1));
+        Assert.That(result.Columns![0].PropertyName, Is.EqualTo("UserId"));
+        Assert.That(result.Columns[0].Ordinal, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Resolve_QualifiedColumns_MatchesColumnName()
+    {
+        var result = RawSqlColumnResolver.Resolve(
+            "SELECT u.UserId, u.UserName FROM users u",
+            GenDialect.SQLite,
+            SampleProperties);
+
+        Assert.That(result.IsResolved, Is.True);
+        Assert.That(result.Columns, Has.Count.EqualTo(2));
+    }
+
+    [TestCase(0)] // SQLite
+    [TestCase(1)] // PostgreSQL
+    [TestCase(2)] // MySQL
+    [TestCase(3)] // SqlServer
+    public void Resolve_AllDialects_WorkCorrectly(int dialectValue)
+    {
+        var dialect = (GenDialect)dialectValue;
+        var result = RawSqlColumnResolver.Resolve(
+            "SELECT UserId, UserName FROM users",
+            dialect,
+            SampleProperties);
+
+        Assert.That(result.IsResolved, Is.True);
+        Assert.That(result.Columns, Has.Count.EqualTo(2));
+    }
+
+    #endregion
+
+    #region Fallback Cases
+
+    [Test]
+    public void Resolve_SelectStar_FallsBack()
+    {
+        var result = RawSqlColumnResolver.Resolve(
+            "SELECT * FROM users",
+            GenDialect.SQLite,
+            SampleProperties);
+
+        Assert.That(result.IsResolved, Is.False);
+        Assert.That(result.FallbackReason, Does.Contain("SELECT *"));
+    }
+
+    [Test]
+    public void Resolve_TableStar_FallsBack()
+    {
+        var result = RawSqlColumnResolver.Resolve(
+            "SELECT u.* FROM users u",
+            GenDialect.SQLite,
+            SampleProperties);
+
+        Assert.That(result.IsResolved, Is.False);
+        Assert.That(result.FallbackReason, Does.Contain("SELECT *"));
+    }
+
+    [Test]
+    public void Resolve_UnresolvableExpression_FallsBackWithPosition()
+    {
+        var result = RawSqlColumnResolver.Resolve(
+            "SELECT UserId, price * quantity FROM orders",
+            GenDialect.SQLite,
+            SampleProperties);
+
+        Assert.That(result.IsResolved, Is.False);
+        Assert.That(result.UnresolvableColumnPosition, Is.EqualTo(1));
+        Assert.That(result.FallbackReason, Does.Contain("position 1"));
+    }
+
+    [Test]
+    public void Resolve_FunctionWithoutAlias_FallsBack()
+    {
+        var result = RawSqlColumnResolver.Resolve(
+            "SELECT COUNT(*) FROM users",
+            GenDialect.SQLite,
+            SampleProperties);
+
+        Assert.That(result.IsResolved, Is.False);
+        Assert.That(result.UnresolvableColumnPosition, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Resolve_FunctionWithAlias_Succeeds()
+    {
+        var props = new[] { new RawSqlPropertyInfo("Total", "int", "GetInt32", false) };
+        var result = RawSqlColumnResolver.Resolve(
+            "SELECT COUNT(*) AS Total FROM users",
+            GenDialect.SQLite,
+            props);
+
+        Assert.That(result.IsResolved, Is.True);
+        Assert.That(result.Columns, Has.Count.EqualTo(1));
+        Assert.That(result.Columns![0].PropertyName, Is.EqualTo("Total"));
+        Assert.That(result.Columns[0].Ordinal, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Resolve_InvalidSql_FallsBack()
+    {
+        var result = RawSqlColumnResolver.Resolve(
+            "NOT VALID SQL AT ALL",
+            GenDialect.SQLite,
+            SampleProperties);
+
+        Assert.That(result.IsResolved, Is.False);
+        Assert.That(result.FallbackReason, Does.Contain("parse failed"));
+    }
+
+    [Test]
+    public void Resolve_NoMatchingColumns_ReturnsEmptyResolution()
+    {
+        var result = RawSqlColumnResolver.Resolve(
+            "SELECT foo, bar FROM users",
+            GenDialect.SQLite,
+            SampleProperties);
+
+        // Resolves successfully but with no matched columns
+        Assert.That(result.IsResolved, Is.True);
+        Assert.That(result.Columns, Has.Count.EqualTo(0));
+    }
+
+    #endregion
+}

--- a/src/Quarry.Tests/RawSqlGeneratorPipelineTests.cs
+++ b/src/Quarry.Tests/RawSqlGeneratorPipelineTests.cs
@@ -632,6 +632,106 @@ public class Service
             "Should not contain runtime column name discovery");
     }
 
+    [Test]
+    public void RawSqlAsync_UnresolvableExpression_EmitsQRY041AndFallsBack()
+    {
+        // SQL with arithmetic expression without alias → QRY041 warning + struct fallback
+        var source = @"
+using Quarry;
+using System.Threading.Tasks;
+
+namespace TestApp;
+
+public class OrderDto
+{
+    public int OrderId { get; set; }
+    public decimal Total { get; set; }
+}
+
+public class OrderSchema : Schema
+{
+    public static string Table => ""orders"";
+    public Key<int> OrderId => Identity();
+}
+
+[QuarryContext(Dialect = SqlDialect.SQLite)]
+public partial class TestDbContext : QuarryContext
+{
+    public partial IEntityAccessor<Order> Orders();
+}
+
+public class Service
+{
+    public async Task Test(TestDbContext db)
+    {
+        var results = await db.RawSqlAsync<OrderDto>(""SELECT OrderId, price * qty FROM orders"");
+    }
+}
+";
+
+        var compilation = CreateCompilation(source);
+        var (diagnostics, result) = RunGeneratorWithDiagnostics(compilation);
+
+        var code = GetInterceptorsCode(result);
+        Assert.That(code, Is.Not.Null, "Should generate interceptors file");
+
+        // Should fall back to struct-based reader
+        Assert.That(code, Does.Contain("IRowReader<OrderDto>"),
+            "Should fall back to struct-based reader for unresolvable expression");
+        Assert.That(code, Does.Contain("switch (r.GetName(i).ToLowerInvariant())"),
+            "Should use runtime column discovery");
+    }
+
+    [Test]
+    public void RawSqlAsync_VariableSql_FallsBackToStructReader()
+    {
+        // SQL passed as a variable, not a literal → struct fallback
+        var source = @"
+using Quarry;
+using System.Threading.Tasks;
+
+namespace TestApp;
+
+public class UserDto
+{
+    public int UserId { get; set; }
+    public string UserName { get; set; } = null!;
+}
+
+public class UserSchema : Schema
+{
+    public static string Table => ""users"";
+    public Key<int> UserId => Identity();
+    public Col<string> UserName => Length(100);
+}
+
+[QuarryContext(Dialect = SqlDialect.SQLite)]
+public partial class TestDbContext : QuarryContext
+{
+    public partial IEntityAccessor<User> Users();
+}
+
+public class Service
+{
+    public async Task Test(TestDbContext db)
+    {
+        var sql = ""SELECT UserId, UserName FROM users"";
+        var results = await db.RawSqlAsync<UserDto>(sql);
+    }
+}
+";
+
+        var compilation = CreateCompilation(source);
+        var (diagnostics, result) = RunGeneratorWithDiagnostics(compilation);
+
+        var code = GetInterceptorsCode(result);
+        Assert.That(code, Is.Not.Null, "Should generate interceptors file");
+
+        // Variable SQL → struct-based reader (no compile-time resolution)
+        Assert.That(code, Does.Contain("IRowReader<UserDto>"),
+            "Should use struct-based reader for variable SQL");
+    }
+
     #endregion
 
     #region Helpers

--- a/src/Quarry.Tests/RawSqlGeneratorPipelineTests.cs
+++ b/src/Quarry.Tests/RawSqlGeneratorPipelineTests.cs
@@ -680,6 +680,11 @@ public class Service
             "Should fall back to struct-based reader for unresolvable expression");
         Assert.That(code, Does.Contain("switch (r.GetName(i).ToLowerInvariant())"),
             "Should use runtime column discovery");
+
+        // QRY041 diagnostic should be emitted
+        Assert.That(diagnostics, Has.Some.Matches<Microsoft.CodeAnalysis.Diagnostic>(
+            d => d.Id == "QRY041" && d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Warning),
+            "Should emit QRY041 warning for unresolvable column expression");
     }
 
     [Test]

--- a/src/Quarry.Tests/RawSqlGeneratorPipelineTests.cs
+++ b/src/Quarry.Tests/RawSqlGeneratorPipelineTests.cs
@@ -570,10 +570,10 @@ public class Service
     }
 
     [Test]
-    public void RawSqlAsync_ConcreteDto_WithProperties_GeneratesPropertySwitch()
+    public void RawSqlAsync_ConcreteDto_WithLiteralSql_GeneratesStaticOrdinalReader()
     {
-        // When T is a concrete DTO that exists in the source, the generator discovers
-        // its properties via the semantic model and generates a switch-based reader.
+        // When T is a concrete DTO with a literal SQL string, the generator parses the SQL
+        // at compile time and emits a static lambda with hardcoded ordinals.
         var source = @"
 using Quarry;
 using System.Threading.Tasks;
@@ -615,13 +615,21 @@ public class Service
         var code = GetInterceptorsCode(result);
         Assert.That(code, Is.Not.Null, "Should generate interceptors file");
 
-        // Verify property switch cases are generated for each DTO property
-        Assert.That(code, Does.Contain("case \"userid\""),
-            "Should generate switch case for UserId property");
-        Assert.That(code, Does.Contain("case \"username\""),
-            "Should generate switch case for UserName property");
-        Assert.That(code, Does.Contain("case \"email\""),
-            "Should generate switch case for Email property");
+        // Compile-time column resolution: static reader with hardcoded ordinals
+        Assert.That(code, Does.Contain("r.GetInt32(0)"),
+            "Should generate hardcoded ordinal 0 for UserId");
+        Assert.That(code, Does.Contain("r.GetString(1)"),
+            "Should generate hardcoded ordinal 1 for UserName");
+        Assert.That(code, Does.Contain("r.GetString(2)"),
+            "Should generate hardcoded ordinal 2 for Email");
+        // Nullable Email should have IsDBNull check
+        Assert.That(code, Does.Contain("!r.IsDBNull(2)"),
+            "Should guard nullable Email with IsDBNull check");
+        // Should NOT contain struct-based reader (no runtime ordinal discovery)
+        Assert.That(code, Does.Not.Contain("IRowReader<UserDto>"),
+            "Should not emit struct-based row reader for literal SQL");
+        Assert.That(code, Does.Not.Contain("switch (r.GetName"),
+            "Should not contain runtime column name discovery");
     }
 
     #endregion

--- a/src/Quarry.Tests/RawSqlInterceptorTests.cs
+++ b/src/Quarry.Tests/RawSqlInterceptorTests.cs
@@ -670,6 +670,169 @@ public class RawSqlInterceptorTests
 
     #endregion
 
+    #region Compile-Time Column Resolution Tests
+
+    [Test]
+    public void RawSqlAsync_WithSqlLiteral_GeneratesStaticOrdinalReader()
+    {
+        var rawSqlTypeInfo = new RawSqlTypeInfo(
+            "UserDto",
+            RawSqlTypeKind.Dto,
+            new[]
+            {
+                new RawSqlPropertyInfo("UserId", "int", "GetInt32", false),
+                new RawSqlPropertyInfo("UserName", "string", "GetString", false),
+                new RawSqlPropertyInfo("Email", "string", "GetString", true)
+            },
+            sqlLiteral: "SELECT UserId, UserName, Email FROM users");
+
+        var site = CreateRawSqlCallSite(InterceptorKind.RawSqlAsync, "UserDto", rawSqlTypeInfo);
+
+        var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
+            "AppDbContext", "TestApp", "test0000", new[] { site });
+
+        // Static ordinal reader — hardcoded ordinals, no struct
+        Assert.That(result, Does.Contain("r.GetInt32(0)"),
+            "UserId at ordinal 0");
+        Assert.That(result, Does.Contain("r.GetString(1)"),
+            "UserName at ordinal 1");
+        Assert.That(result, Does.Contain("!r.IsDBNull(2)"),
+            "Nullable Email gets IsDBNull guard");
+        Assert.That(result, Does.Contain("r.GetString(2)"),
+            "Email at ordinal 2");
+        Assert.That(result, Does.Not.Contain("IRowReader<UserDto>"),
+            "No struct reader emitted");
+        Assert.That(result, Does.Not.Contain("switch (r.GetName"),
+            "No runtime column discovery");
+    }
+
+    [Test]
+    public void RawSqlAsync_WithSqlLiteral_Aliases_ResolvesCorrectly()
+    {
+        var rawSqlTypeInfo = new RawSqlTypeInfo(
+            "UserDto",
+            RawSqlTypeKind.Dto,
+            new[]
+            {
+                new RawSqlPropertyInfo("Id", "int", "GetInt32", false),
+                new RawSqlPropertyInfo("FullName", "string", "GetString", false)
+            },
+            sqlLiteral: "SELECT user_id AS Id, first_name AS FullName FROM users");
+
+        var site = CreateRawSqlCallSite(InterceptorKind.RawSqlAsync, "UserDto", rawSqlTypeInfo);
+
+        var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
+            "AppDbContext", "TestApp", "test0000", new[] { site });
+
+        // Aliases match property names → static ordinal reader
+        Assert.That(result, Does.Contain("r.GetInt32(0)"), "Id at ordinal 0 via alias");
+        Assert.That(result, Does.Contain("r.GetString(1)"), "FullName at ordinal 1 via alias");
+        Assert.That(result, Does.Not.Contain("IRowReader"), "No struct reader");
+    }
+
+    [Test]
+    public void RawSqlAsync_WithSqlLiteral_PartialColumns_SkipsMissingProperties()
+    {
+        // SQL selects fewer columns than DTO has properties
+        var rawSqlTypeInfo = new RawSqlTypeInfo(
+            "UserDto",
+            RawSqlTypeKind.Dto,
+            new[]
+            {
+                new RawSqlPropertyInfo("UserId", "int", "GetInt32", false),
+                new RawSqlPropertyInfo("UserName", "string", "GetString", false),
+                new RawSqlPropertyInfo("Email", "string", "GetString", true)
+            },
+            sqlLiteral: "SELECT UserId, UserName FROM users");
+
+        var site = CreateRawSqlCallSite(InterceptorKind.RawSqlAsync, "UserDto", rawSqlTypeInfo);
+
+        var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
+            "AppDbContext", "TestApp", "test0000", new[] { site });
+
+        // Only matched columns are read — Email is not in SQL
+        Assert.That(result, Does.Contain("r.GetInt32(0)"), "UserId at ordinal 0");
+        Assert.That(result, Does.Contain("r.GetString(1)"), "UserName at ordinal 1");
+        Assert.That(result, Does.Not.Contain("Email"),
+            "Email property not in SQL — should be skipped entirely");
+        Assert.That(result, Does.Not.Contain("IRowReader"), "No struct reader");
+    }
+
+    [Test]
+    public void RawSqlAsync_WithSqlLiteral_SelectStar_FallsBackToStruct()
+    {
+        var rawSqlTypeInfo = new RawSqlTypeInfo(
+            "UserDto",
+            RawSqlTypeKind.Dto,
+            new[]
+            {
+                new RawSqlPropertyInfo("UserId", "int", "GetInt32", false),
+                new RawSqlPropertyInfo("UserName", "string", "GetString", false)
+            },
+            sqlLiteral: "SELECT * FROM users");
+
+        var site = CreateRawSqlCallSite(InterceptorKind.RawSqlAsync, "UserDto", rawSqlTypeInfo);
+
+        var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
+            "AppDbContext", "TestApp", "test0000", new[] { site });
+
+        // SELECT * → fallback to struct reader
+        Assert.That(result, Does.Contain("IRowReader<UserDto>"),
+            "Should fall back to struct-based reader for SELECT *");
+        Assert.That(result, Does.Contain("switch (r.GetName(i).ToLowerInvariant())"),
+            "Should use runtime column discovery");
+    }
+
+    [Test]
+    public void RawSqlAsync_WithoutSqlLiteral_UsesStructReader()
+    {
+        // No SQL literal (variable-based SQL) → struct reader
+        var rawSqlTypeInfo = new RawSqlTypeInfo(
+            "UserDto",
+            RawSqlTypeKind.Dto,
+            new[]
+            {
+                new RawSqlPropertyInfo("UserId", "int", "GetInt32", false),
+                new RawSqlPropertyInfo("UserName", "string", "GetString", false)
+            });
+
+        var site = CreateRawSqlCallSite(InterceptorKind.RawSqlAsync, "UserDto", rawSqlTypeInfo);
+
+        var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
+            "AppDbContext", "TestApp", "test0000", new[] { site });
+
+        // No SQL literal → struct reader
+        Assert.That(result, Does.Contain("IRowReader<UserDto>"),
+            "Should use struct-based reader when no SQL literal");
+    }
+
+    [Test]
+    public void RawSqlAsync_WithSqlLiteral_CaseInsensitiveColumnMatching()
+    {
+        // SQL columns are lowercase but DTO properties are PascalCase
+        var rawSqlTypeInfo = new RawSqlTypeInfo(
+            "UserDto",
+            RawSqlTypeKind.Dto,
+            new[]
+            {
+                new RawSqlPropertyInfo("UserId", "int", "GetInt32", false),
+                new RawSqlPropertyInfo("UserName", "string", "GetString", false)
+            },
+            sqlLiteral: "SELECT userid, username FROM users");
+
+        var site = CreateRawSqlCallSite(InterceptorKind.RawSqlAsync, "UserDto", rawSqlTypeInfo);
+
+        var result = InterceptorCodeGenerator.GenerateInterceptorsFile(
+            "AppDbContext", "TestApp", "test0000", new[] { site });
+
+        // Case-insensitive matching should resolve columns
+        Assert.That(result, Does.Contain("r.GetInt32(0)"), "UserId matched case-insensitively");
+        Assert.That(result, Does.Contain("r.GetString(1)"), "UserName matched case-insensitively");
+        Assert.That(result, Does.Not.Contain("IRowReader"), "No struct reader");
+    }
+
+    #endregion
+
     #region RawCallSite Equality Tests
 
     [Test]


### PR DESCRIPTION
## Summary
- Closes #183 (Phase 2)

## Reason for Change
Phase 1 (PR #193) introduced struct-based ordinal caching for RawSqlAsync readers, eliminating per-row `GetOrdinal` calls. Phase 2 takes this further: for **literal SQL strings**, the generator now parses the SQL at compile time using the shared SQL parser (#182) to determine result columns and their ordinals. This enables emitting **static lambdas with hardcoded ordinal access** — zero runtime overhead, no ordinal discovery, no struct allocation.

## Impact
For `db.RawSqlAsync<UserDto>("SELECT UserId, UserName, Email FROM users")`, the generated reader changes from a struct-based runtime ordinal cache to:
```csharp
static r =>
{
    var item = new UserDto();
    item.UserId = r.GetInt32(0);
    item.UserName = r.GetString(1);
    if (!r.IsDBNull(2)) item.Email = r.GetString(2);
    return item;
};
```

Falls back to Phase 1 struct reader when:
- SQL is not a string literal (variable, interpolated)
- SQL contains `SELECT *` or `table.*`
- SQL has unsupported constructs (CTEs, UNION, window functions)
- Column is a complex expression without an `AS` alias (emits QRY041 warning)
- Parse fails

## Plan items implemented as specified
- Phase 1: `SqlLiteral` property on `RawSqlTypeInfo`
- Phase 2: SQL literal extraction in `DisplayClassEnricher`
- Phase 3: `RawSqlColumnResolver` + static ordinal reader in `RawSqlBodyEmitter`/`FileEmitter`
- Phase 4: QRY041 diagnostic descriptor and emission pipeline
- Phase 5: Integration tests for aliases and partial column selection
- Phase 6: llm.md and README.md diagnostic documentation

## Deviations from plan implemented
- `ColumnResolutionResult` is a sealed class with factory methods (not a record struct) — cleaner API with `IsResolved` property
- `EmitStaticOrdinalReader` is private (not public) — integrated into existing `EmitRawSqlAsync` method via optional parameter
- Zero-matched-columns treated as fallback reason (review finding fix)

## Gaps in original plan implemented
- `FileEmitter.EmitDiagnostics` property added for diagnostic collection during emission (dialect not available during enrichment)
- QRY041 diagnostic assertion added to pipeline test (review finding fix)

## Migration Steps
None — transparent to consumers. Existing literal SQL calls automatically benefit.

## Performance Considerations
Static ordinal readers eliminate: ~128 bytes closure allocation per query, O(C) `GetName` calls, and the `IRowReader<T>` struct dispatch overhead. The SQL parsing happens at compile time only.

## Security Considerations
SQL literals are parsed at compile time only — no SQL execution or transmission. The parser input comes exclusively from source code string literals.

## Breaking Changes
- Consumer-facing: None. Public API unchanged.
- Internal: `RawSqlTypeInfo` constructor has new optional `sqlLiteral` parameter. `EmitRawSqlAsync` has new optional `resolvedColumns` parameter. `EmitInterceptorMethod` has new optional `rawSqlResolvedColumns` parameter.