### PR TITLE
Add RawSqlAsync to chain query analyzer diagnostic (QRY042) (#184)

### DIFF
--- a/src/Quarry.Analyzers.CodeFixes/CodeFixes/RawSqlToChainCodeFix.cs
+++ b/src/Quarry.Analyzers.CodeFixes/CodeFixes/RawSqlToChainCodeFix.cs
@@ -1,0 +1,74 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Quarry.Analyzers.CodeFixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class RawSqlToChainCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+        ImmutableArray.Create("QRY042");
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root == null) return;
+
+        var diagnostic = context.Diagnostics.First();
+
+        // The chain code is stored in diagnostic properties by the analyzer
+        if (!diagnostic.Properties.TryGetValue("ChainCode", out var chainCode) || string.IsNullOrEmpty(chainCode))
+            return;
+
+        var node = root.FindNode(diagnostic.Location.SourceSpan);
+        var invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+        if (invocation == null) return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Replace with chain query",
+                ct => ReplaceWithChainAsync(context.Document, invocation, chainCode!, ct),
+                equivalenceKey: "QRY042_RawSqlToChain"),
+            diagnostic);
+    }
+
+    private static async Task<Document> ReplaceWithChainAsync(
+        Document document,
+        InvocationExpressionSyntax invocation,
+        string chainCode,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root == null) return document;
+
+        // Determine the replacement scope.
+        // If .ToListAsync() is chained after, replace the entire expression including that call.
+        SyntaxNode nodeToReplace = invocation;
+
+        if (invocation.Parent is MemberAccessExpressionSyntax parentMemberAccess
+            && parentMemberAccess.Name.Identifier.Text == "ToListAsync"
+            && parentMemberAccess.Parent is InvocationExpressionSyntax toListInvocation)
+        {
+            nodeToReplace = toListInvocation;
+        }
+
+        // Parse the chain code into an expression
+        var replacement = SyntaxFactory.ParseExpression(chainCode);
+
+        // Preserve trivia from the original node
+        replacement = replacement.WithTriviaFrom(nodeToReplace);
+
+        var newRoot = root.ReplaceNode(nodeToReplace, replacement);
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/Quarry.Analyzers.Tests/CodeFixTests.cs
+++ b/src/Quarry.Analyzers.Tests/CodeFixTests.cs
@@ -91,4 +91,51 @@ public class CodeFixTests
         Assert.That(actions, Has.Count.EqualTo(1));
         Assert.That(actions[0].Title, Does.Contain("Any"));
     }
+
+    // ── RawSqlToChainCodeFix ──
+
+    [Test]
+    public void RawSqlToChainCodeFix_FixesCorrectDiagnosticId()
+    {
+        var fix = new RawSqlToChainCodeFix();
+        Assert.That(fix.FixableDiagnosticIds, Does.Contain("QRY042"));
+    }
+
+    [Test]
+    public void RawSqlToChainCodeFix_HasFixAllProvider()
+    {
+        var fix = new RawSqlToChainCodeFix();
+        Assert.That(fix.GetFixAllProvider(), Is.Not.Null);
+    }
+
+    [Test]
+    public async Task RawSqlToChainCodeFix_RegistersCodeFix()
+    {
+        var fix = new RawSqlToChainCodeFix();
+        var source = @"class C { void M() { db.RawSqlAsync<User>(""SELECT * FROM users""); } }";
+        var tree = CSharpSyntaxTree.ParseText(source);
+
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("TestProject", LanguageNames.CSharp);
+        project = project.AddMetadataReference(MetadataReference.CreateFromFile(typeof(object).Assembly.Location));
+        var document = project.AddDocument("Test.cs", SourceText.From(source));
+
+        var descriptor = Quarry.Analyzers.AnalyzerDiagnosticDescriptors.RawSqlConvertibleToChain;
+        var root = await tree.GetRootAsync();
+        var invocation = root.DescendantNodes()
+            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.InvocationExpressionSyntax>().First();
+
+        var properties = ImmutableDictionary<string, string?>.Empty
+            .Add("ChainCode", "db.Users()\n    .Select(u => u)\n    .ToAsyncEnumerable()");
+
+        var diagnostic = Diagnostic.Create(descriptor, invocation.GetLocation(), properties);
+
+        var actions = new List<CodeAction>();
+        var context = new CodeFixContext(document, diagnostic,
+            (action, _) => actions.Add(action), default);
+
+        await fix.RegisterCodeFixesAsync(context);
+        Assert.That(actions, Has.Count.EqualTo(1));
+        Assert.That(actions[0].Title, Is.EqualTo("Replace with chain query"));
+    }
 }

--- a/src/Quarry.Analyzers.Tests/RawSqlMigrationAnalyzerTests.cs
+++ b/src/Quarry.Analyzers.Tests/RawSqlMigrationAnalyzerTests.cs
@@ -98,12 +98,21 @@ public class OrderSchema : Schema
     public Col<string> Status { get; }
 }
 
+public class ProductSchema : Schema
+{
+    public static string Table => ""products"";
+    public Key<int> ProductId => Identity();
+    public Col<string> ProductName => Length(200);
+    public Col<decimal> Price => Precision(18, 2);
+}
+
 [QuarryContext(Dialect = SqlDialect.SQLite)]
 public partial class TestDbContext : QuarryContext
 {
     public TestDbContext(IDbConnection connection) : base(connection) { }
     public partial IEntityAccessor<User> Users();
     public partial IEntityAccessor<Order> Orders();
+    public partial IEntityAccessor<Product> Products();
 }
 
 public class User
@@ -120,6 +129,13 @@ public class Order
     public int UserId { get; set; }
     public decimal Total { get; set; }
     public string Status { get; set; }
+}
+
+public class Product
+{
+    public int ProductId { get; set; }
+    public string ProductName { get; set; }
+    public decimal Price { get; set; }
 }
 ";
 
@@ -597,5 +613,156 @@ public class TestService
         Assert.That(diagnostics, Has.Length.EqualTo(1));
         var chainCode = diagnostics[0].Properties["ChainCode"];
         Assert.That(chainCode, Does.Contain("u.UserId >= 1 && u.UserId <= 10"));
+    }
+
+    // ── Additional JOIN type tests ──
+
+    [Test]
+    public async Task QRY042_ChainCode_RightJoin()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(
+            ""SELECT u.UserName FROM users u RIGHT JOIN orders o ON u.UserId = o.UserId"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain(".RightJoin<Order>("));
+    }
+
+    [Test]
+    public async Task QRY042_ChainCode_CrossJoin()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(
+            ""SELECT u.UserName, p.ProductName FROM users u CROSS JOIN products p"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain(".CrossJoin<Product>("));
+    }
+
+    [Test]
+    public async Task QRY042_ChainCode_FullOuterJoin()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(
+            ""SELECT u.UserName FROM users u FULL OUTER JOIN orders o ON u.UserId = o.UserId"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain(".FullOuterJoin<Order>("));
+    }
+
+    // ── 3-table join test ──
+
+    [Test]
+    public async Task QRY042_ChainCode_ThreeTableJoin()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(
+            ""SELECT u.UserName, o.Total, p.ProductName FROM users u INNER JOIN orders o ON u.UserId = o.UserId INNER JOIN products p ON o.OrderId = p.ProductId"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain(".Join<Order>("));
+        Assert.That(chainCode, Does.Contain(".Join<Product>("));
+        Assert.That(chainCode, Does.Contain(".Select((u, o, p) => (u.UserName, o.Total, p.ProductName))"));
+    }
+
+    // ── Negation variant tests ──
+
+    [Test]
+    public async Task QRY042_ChainCode_IsNotNull()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users WHERE Email IS NOT NULL"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain("u.Email != null"));
+    }
+
+    [Test]
+    public async Task QRY042_ChainCode_NotIn()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users WHERE UserId NOT IN (@p0, @p1)"", 1, 2);
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain("!new[] { 1, 2 }.Contains(u.UserId)"));
+    }
+
+    [Test]
+    public async Task QRY042_ChainCode_NotBetween()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users WHERE UserId NOT BETWEEN @p0 AND @p1"", 1, 10);
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain("!(u.UserId >= 1 && u.UserId <= 10)"));
+    }
+
+    // ── Multi ORDER BY (ThenBy) test ──
+
+    [Test]
+    public async Task QRY042_ChainCode_MultipleOrderBy()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users ORDER BY UserName ASC, UserId DESC"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain(".OrderBy(u => u.UserName)"));
+        Assert.That(chainCode, Does.Contain(".ThenBy(u => u.UserId, Direction.Descending)"));
     }
 }

--- a/src/Quarry.Analyzers.Tests/RawSqlMigrationAnalyzerTests.cs
+++ b/src/Quarry.Analyzers.Tests/RawSqlMigrationAnalyzerTests.cs
@@ -197,4 +197,131 @@ public class TestService
         Assert.That(diagnostics[0].Properties.ContainsKey("Sql"), Is.True);
         Assert.That(diagnostics[0].Properties["Sql"], Is.EqualTo("SELECT * FROM users"));
     }
+
+    // ── Convertibility tests: should report ──
+
+    [Test]
+    public async Task QRY042_SelectWithWhereAndOrderBy_ReportsDiagnostic()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(
+            ""SELECT UserId, UserName FROM users WHERE IsActive = @p0 ORDER BY UserName"", true);
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+    }
+
+    [Test]
+    public async Task QRY042_SelectDistinct_ReportsDiagnostic()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT DISTINCT UserName FROM users"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+    }
+
+    [Test]
+    public async Task QRY042_SelectWithLimitOffset_ReportsDiagnostic()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users LIMIT 10 OFFSET 5"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+    }
+
+    // ── Convertibility tests: should NOT report ──
+
+    [Test]
+    public async Task QRY042_UnknownTable_NoDiagnostic()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM unknown_table"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Is.Empty);
+    }
+
+    [Test]
+    public async Task QRY042_UnknownColumn_NoDiagnostic()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT NonExistent FROM users"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Is.Empty);
+    }
+
+    [Test]
+    public async Task QRY042_CaseExpression_NoDiagnostic()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(
+            ""SELECT CASE WHEN IsActive = 1 THEN 'Yes' ELSE 'No' END FROM users"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Is.Empty);
+    }
+
+    [Test]
+    public async Task QRY042_InvalidSql_NoDiagnostic()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""not valid sql at all"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Is.Empty);
+    }
+
+    [Test]
+    public async Task QRY042_UnsupportedFunction_NoDiagnostic()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(
+            ""SELECT COALESCE(Email, 'none') FROM users"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Is.Empty);
+    }
 }

--- a/src/Quarry.Analyzers.Tests/RawSqlMigrationAnalyzerTests.cs
+++ b/src/Quarry.Analyzers.Tests/RawSqlMigrationAnalyzerTests.cs
@@ -1,0 +1,200 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Quarry.Analyzers;
+
+namespace Quarry.Analyzers.Tests;
+
+[TestFixture]
+public class RawSqlMigrationAnalyzerTests
+{
+    private static async Task<ImmutableArray<Diagnostic>> GetMigrationDiagnosticsAsync(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Linq.Enumerable).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Collections.Generic.List<>).Assembly.Location),
+        };
+
+        var runtimeDir = System.IO.Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var runtimeRef = System.IO.Path.Combine(runtimeDir, "System.Runtime.dll");
+        if (System.IO.File.Exists(runtimeRef))
+            references.Add(MetadataReference.CreateFromFile(runtimeRef));
+
+        // Add netstandard for analyzer assembly compatibility
+        var netstdRef = System.IO.Path.Combine(runtimeDir, "netstandard.dll");
+        if (System.IO.File.Exists(netstdRef))
+            references.Add(MetadataReference.CreateFromFile(netstdRef));
+
+        var quarryAssembly = typeof(Quarry.QuarryContext).Assembly.Location;
+        if (!string.IsNullOrEmpty(quarryAssembly))
+            references.Add(MetadataReference.CreateFromFile(quarryAssembly));
+
+        // Add System.Data.Common for DbConnection
+        var dataCommonAssembly = typeof(System.Data.Common.DbConnection).Assembly.Location;
+        if (!string.IsNullOrEmpty(dataCommonAssembly))
+            references.Add(MetadataReference.CreateFromFile(dataCommonAssembly));
+
+        // Add System.ComponentModel for IDbConnection
+        var componentModelAssembly = typeof(System.Data.IDbConnection).Assembly.Location;
+        if (!string.IsNullOrEmpty(componentModelAssembly))
+            references.Add(MetadataReference.CreateFromFile(componentModelAssembly));
+
+        // Add Threading for IAsyncEnumerable
+        var threadingRef = System.IO.Path.Combine(runtimeDir, "System.Threading.dll");
+        if (System.IO.File.Exists(threadingRef))
+            references.Add(MetadataReference.CreateFromFile(threadingRef));
+
+        // Add System.Runtime.InteropServices
+        var interopRef = System.IO.Path.Combine(runtimeDir, "System.Runtime.InteropServices.dll");
+        if (System.IO.File.Exists(interopRef))
+            references.Add(MetadataReference.CreateFromFile(interopRef));
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            syntaxTrees: new[] { syntaxTree },
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var analyzer = new RawSqlMigrationAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        var diagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+        return diagnostics
+            .Where(d => d.Id.StartsWith("QRY"))
+            .ToImmutableArray();
+    }
+
+    // ── Source templates ──
+
+    private const string ContextAndSchemaPrefix = @"
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Threading;
+using Quarry;
+
+public class UserSchema : Schema
+{
+    public static string Table => ""users"";
+    public Key<int> UserId => Identity();
+    public Col<string> UserName => Length(100);
+    public Col<string?> Email { get; }
+    public Col<bool> IsActive => Default(true);
+}
+
+[QuarryContext(Dialect = SqlDialect.SQLite)]
+public partial class TestDbContext : QuarryContext
+{
+    public TestDbContext(IDbConnection connection) : base(connection) { }
+    public partial IEntityAccessor<User> Users();
+}
+
+public class User
+{
+    public int UserId { get; set; }
+    public string UserName { get; set; }
+    public string? Email { get; set; }
+    public bool IsActive { get; set; }
+}
+";
+
+    // ── Detection tests ──
+
+    [Test]
+    public async Task QRY042_StringLiteralRawSql_ReportsDiagnostic()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        Assert.That(diagnostics[0].Id, Is.EqualTo("QRY042"));
+    }
+
+    [Test]
+    public async Task QRY042_VariableSqlArgument_NoDiagnostic()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        string sql = ""SELECT * FROM users"";
+        var results = db.RawSqlAsync<User>(sql);
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Is.Empty);
+    }
+
+    [Test]
+    public async Task QRY042_NonQuarryContextReceiver_NoDiagnostic()
+    {
+        // Calling RawSqlAsync on something that isn't a QuarryContext should not trigger
+        var source = @"
+using System;
+using System.Collections.Generic;
+
+public class FakeContext
+{
+    public IAsyncEnumerable<T> RawSqlAsync<T>(string sql, params object?[] parameters) => throw new NotSupportedException();
+}
+
+public class User { public int UserId { get; set; } }
+
+public class TestService
+{
+    public void Run(FakeContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Is.Empty);
+    }
+
+    [Test]
+    public async Task QRY042_WithParameters_ReportsDiagnostic()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users WHERE UserId = @p0"", 1);
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        Assert.That(diagnostics[0].Id, Is.EqualTo("QRY042"));
+    }
+
+    [Test]
+    public async Task QRY042_DiagnosticProperties_ContainSql()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        Assert.That(diagnostics[0].Properties.ContainsKey("Sql"), Is.True);
+        Assert.That(diagnostics[0].Properties["Sql"], Is.EqualTo("SELECT * FROM users"));
+    }
+}

--- a/src/Quarry.Analyzers.Tests/RawSqlMigrationAnalyzerTests.cs
+++ b/src/Quarry.Analyzers.Tests/RawSqlMigrationAnalyzerTests.cs
@@ -324,4 +324,128 @@ public class TestService
         var diagnostics = await GetMigrationDiagnosticsAsync(source);
         Assert.That(diagnostics, Is.Empty);
     }
+
+    // ── Chain code generation tests ──
+
+    [Test]
+    public async Task QRY042_ChainCode_SimpleSelectStar()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain(".Users()"));
+        Assert.That(chainCode, Does.Contain(".Select(u => u)"));
+        Assert.That(chainCode, Does.Contain(".ToAsyncEnumerable()"));
+    }
+
+    [Test]
+    public async Task QRY042_ChainCode_WhereWithParameter()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db, int userId)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users WHERE UserId = @p0"", userId);
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain(".Where(u => u.UserId == userId)"));
+    }
+
+    [Test]
+    public async Task QRY042_ChainCode_OrderByDescending()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users ORDER BY UserName DESC"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain(".OrderBy(u => u.UserName, Direction.Descending)"));
+    }
+
+    [Test]
+    public async Task QRY042_ChainCode_SelectSpecificColumns()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT UserId, UserName FROM users"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain(".Select(u => (u.UserId, u.UserName))"));
+    }
+
+    [Test]
+    public async Task QRY042_ChainCode_LimitAndOffset()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users LIMIT 10 OFFSET 5"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain(".Limit(10)"));
+        Assert.That(chainCode, Does.Contain(".Offset(5)"));
+    }
+
+    [Test]
+    public async Task QRY042_ChainCode_Distinct()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT DISTINCT UserName FROM users"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain(".Distinct()"));
+    }
+
+    [Test]
+    public async Task QRY042_ChainCode_CountAggregate()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT COUNT(*) FROM users"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain("Sql.Count()"));
+    }
 }

--- a/src/Quarry.Analyzers.Tests/RawSqlMigrationAnalyzerTests.cs
+++ b/src/Quarry.Analyzers.Tests/RawSqlMigrationAnalyzerTests.cs
@@ -89,11 +89,21 @@ public class UserSchema : Schema
     public Col<bool> IsActive => Default(true);
 }
 
+public class OrderSchema : Schema
+{
+    public static string Table => ""orders"";
+    public Key<int> OrderId => Identity();
+    public Ref<UserSchema, int> UserId => ForeignKey<UserSchema, int>();
+    public Col<decimal> Total => Precision(18, 2);
+    public Col<string> Status { get; }
+}
+
 [QuarryContext(Dialect = SqlDialect.SQLite)]
 public partial class TestDbContext : QuarryContext
 {
     public TestDbContext(IDbConnection connection) : base(connection) { }
     public partial IEntityAccessor<User> Users();
+    public partial IEntityAccessor<Order> Orders();
 }
 
 public class User
@@ -102,6 +112,14 @@ public class User
     public string UserName { get; set; }
     public string? Email { get; set; }
     public bool IsActive { get; set; }
+}
+
+public class Order
+{
+    public int OrderId { get; set; }
+    public int UserId { get; set; }
+    public decimal Total { get; set; }
+    public string Status { get; set; }
 }
 ";
 
@@ -447,5 +465,137 @@ public class TestService
         Assert.That(diagnostics, Has.Length.EqualTo(1));
         var chainCode = diagnostics[0].Properties["ChainCode"];
         Assert.That(chainCode, Does.Contain("Sql.Count()"));
+    }
+
+    // ── JOIN tests ──
+
+    [Test]
+    public async Task QRY042_ChainCode_InnerJoin()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(
+            ""SELECT u.UserName, o.Total FROM users u INNER JOIN orders o ON u.UserId = o.UserId"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain(".Join<Order>("));
+        Assert.That(chainCode, Does.Contain("u.UserId == o.UserId"));
+        Assert.That(chainCode, Does.Contain(".Select((u, o) => (u.UserName, o.Total))"));
+    }
+
+    [Test]
+    public async Task QRY042_ChainCode_LeftJoin()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(
+            ""SELECT u.UserName FROM users u LEFT JOIN orders o ON u.UserId = o.UserId"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain(".LeftJoin<Order>("));
+    }
+
+    // ── GROUP BY / HAVING tests ──
+
+    [Test]
+    public async Task QRY042_ChainCode_GroupByWithHaving()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(
+            ""SELECT UserName, COUNT(*) FROM users GROUP BY UserName HAVING COUNT(*) > 1"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain(".GroupBy(u => u.UserName)"));
+        Assert.That(chainCode, Does.Contain(".Having(u => Sql.Count() > 1)"));
+    }
+
+    // ── LIKE rejection test ──
+
+    [Test]
+    public async Task QRY042_LikeExpression_NoDiagnostic()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(
+            ""SELECT * FROM users WHERE UserName LIKE '%test%'"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Is.Empty);
+    }
+
+    // ── IN / IS NULL / BETWEEN expression tests ──
+
+    [Test]
+    public async Task QRY042_ChainCode_InExpression()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users WHERE UserId IN (@p0, @p1)"", 1, 2);
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain("new[] { 1, 2 }.Contains(u.UserId)"));
+    }
+
+    [Test]
+    public async Task QRY042_ChainCode_IsNullExpression()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users WHERE Email IS NULL"");
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain("u.Email == null"));
+    }
+
+    [Test]
+    public async Task QRY042_ChainCode_BetweenExpression()
+    {
+        var source = ContextAndSchemaPrefix + @"
+public class TestService
+{
+    public void Run(TestDbContext db)
+    {
+        var results = db.RawSqlAsync<User>(""SELECT * FROM users WHERE UserId BETWEEN @p0 AND @p1"", 1, 10);
+    }
+}";
+        var diagnostics = await GetMigrationDiagnosticsAsync(source);
+        Assert.That(diagnostics, Has.Length.EqualTo(1));
+        var chainCode = diagnostics[0].Properties["ChainCode"];
+        Assert.That(chainCode, Does.Contain("u.UserId >= 1 && u.UserId <= 10"));
     }
 }

--- a/src/Quarry.Analyzers/AnalyzerDiagnosticDescriptors.cs
+++ b/src/Quarry.Analyzers/AnalyzerDiagnosticDescriptors.cs
@@ -200,4 +200,17 @@ internal static class AnalyzerDiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "This query uses a feature that is suboptimal or unsupported for the target SQL dialect.");
+
+    // ── QRY0xx: Migration ──
+
+    private const string MigrationCategory = "QuarryMigration";
+
+    public static readonly DiagnosticDescriptor RawSqlConvertibleToChain = new(
+        id: "QRY042",
+        title: "RawSqlAsync convertible to chain query",
+        messageFormat: "This RawSqlAsync query can be expressed as a chain query",
+        category: MigrationCategory,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "The SQL in this RawSqlAsync call uses only constructs that Quarry chain queries support. Consider replacing it with a chain query for type safety and compile-time checking.");
 }

--- a/src/Quarry.Analyzers/Migration/SqlToChainConverter.cs
+++ b/src/Quarry.Analyzers/Migration/SqlToChainConverter.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Quarry.Generators.Models;
+using Quarry.Generators.Sql.Parser;
+
+namespace Quarry.Analyzers.Migration;
+
+/// <summary>
+/// Converts a parsed SQL SELECT statement to an equivalent Quarry chain query C# expression.
+/// </summary>
+internal sealed class SqlToChainConverter
+{
+    private static readonly HashSet<string> SupportedAggregates = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "COUNT", "SUM", "MIN", "MAX", "AVG"
+    };
+
+    private readonly ContextInfo _context;
+
+    /// <summary>Table name (case-insensitive) → (EntityInfo, EntityMapping).</summary>
+    private readonly Dictionary<string, (EntityInfo Entity, EntityMapping Mapping)> _tableToEntity;
+
+    public SqlToChainConverter(ContextInfo context)
+    {
+        _context = context;
+
+        _tableToEntity = new Dictionary<string, (EntityInfo, EntityMapping)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var mapping in context.EntityMappings)
+        {
+            var tableName = mapping.Entity.TableName;
+            if (!string.IsNullOrEmpty(tableName) && !_tableToEntity.ContainsKey(tableName))
+                _tableToEntity[tableName] = (mapping.Entity, mapping);
+        }
+    }
+
+    /// <summary>
+    /// Checks whether the given SQL statement can be fully converted to a chain query.
+    /// Returns null on success, or an error reason string on failure.
+    /// </summary>
+    public string? CheckConvertibility(SqlSelectStatement stmt)
+    {
+        // Must have a FROM clause
+        if (stmt.From == null)
+            return "No FROM clause";
+
+        // FROM table must resolve to a known entity
+        if (!_tableToEntity.ContainsKey(stmt.From.TableName))
+            return $"Unknown table '{stmt.From.TableName}'";
+
+        // Max 4 tables (1 primary + 3 joins) — chain query limit
+        if (stmt.Joins.Count > 3)
+            return $"Too many joins ({stmt.Joins.Count}); chain queries support up to 3";
+
+        // All joined tables must resolve
+        foreach (var join in stmt.Joins)
+        {
+            if (!_tableToEntity.ContainsKey(join.Table.TableName))
+                return $"Unknown table '{join.Table.TableName}'";
+        }
+
+        // Build alias-to-entity map for column resolution
+        var aliasMap = BuildAliasMap(stmt);
+
+        // Walk the AST to check all nodes are convertible
+        foreach (var col in stmt.Columns)
+        {
+            var err = CheckNode(col, aliasMap);
+            if (err != null) return err;
+        }
+
+        if (stmt.Where != null)
+        {
+            var err = CheckExpr(stmt.Where, aliasMap);
+            if (err != null) return err;
+        }
+
+        foreach (var join in stmt.Joins)
+        {
+            if (join.Condition != null)
+            {
+                var err = CheckExpr(join.Condition, aliasMap);
+                if (err != null) return err;
+            }
+        }
+
+        if (stmt.GroupBy != null)
+        {
+            foreach (var expr in stmt.GroupBy)
+            {
+                var err = CheckExpr(expr, aliasMap);
+                if (err != null) return err;
+            }
+        }
+
+        if (stmt.Having != null)
+        {
+            var err = CheckExpr(stmt.Having, aliasMap);
+            if (err != null) return err;
+        }
+
+        if (stmt.OrderBy != null)
+        {
+            foreach (var term in stmt.OrderBy)
+            {
+                var err = CheckExpr(term.Expression, aliasMap);
+                if (err != null) return err;
+            }
+        }
+
+        if (stmt.Limit != null)
+        {
+            var err = CheckExpr(stmt.Limit, aliasMap);
+            if (err != null) return err;
+        }
+
+        if (stmt.Offset != null)
+        {
+            var err = CheckExpr(stmt.Offset, aliasMap);
+            if (err != null) return err;
+        }
+
+        return null; // convertible
+    }
+
+    /// <summary>
+    /// Builds a mapping from table alias (or table name if no alias) to EntityInfo.
+    /// </summary>
+    internal Dictionary<string, EntityInfo> BuildAliasMap(SqlSelectStatement stmt)
+    {
+        var map = new Dictionary<string, EntityInfo>(StringComparer.OrdinalIgnoreCase);
+
+        if (stmt.From != null && _tableToEntity.TryGetValue(stmt.From.TableName, out var fromEntry))
+        {
+            var alias = stmt.From.Alias ?? stmt.From.TableName;
+            map[alias] = fromEntry.Entity;
+        }
+
+        foreach (var join in stmt.Joins)
+        {
+            if (_tableToEntity.TryGetValue(join.Table.TableName, out var joinEntry))
+            {
+                var alias = join.Table.Alias ?? join.Table.TableName;
+                map[alias] = joinEntry.Entity;
+            }
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Resolves a SQL column name to a C# property name for the given entity.
+    /// Returns null if not found.
+    /// </summary>
+    internal static string? ResolveColumnToProperty(EntityInfo entity, string columnName)
+    {
+        foreach (var col in entity.Columns)
+        {
+            if (string.Equals(col.ColumnName, columnName, StringComparison.OrdinalIgnoreCase))
+                return col.PropertyName;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Looks up the EntityMapping for a given table name.
+    /// </summary>
+    internal (EntityInfo Entity, EntityMapping Mapping)? ResolveTable(string tableName)
+    {
+        return _tableToEntity.TryGetValue(tableName, out var entry) ? entry : null;
+    }
+
+    private string? CheckNode(SqlNode node, Dictionary<string, EntityInfo> aliasMap)
+    {
+        switch (node)
+        {
+            case SqlSelectColumn selectCol:
+                return CheckExpr(selectCol.Expression, aliasMap);
+
+            case SqlStarColumn:
+                return null; // SELECT * is always convertible
+
+            default:
+                return $"Unsupported SELECT column node: {node.NodeKind}";
+        }
+    }
+
+    private string? CheckExpr(SqlExpr expr, Dictionary<string, EntityInfo> aliasMap)
+    {
+        switch (expr)
+        {
+            case SqlBinaryExpr binary:
+                return CheckExpr(binary.Left, aliasMap) ?? CheckExpr(binary.Right, aliasMap);
+
+            case SqlUnaryExpr unary:
+                return CheckExpr(unary.Operand, aliasMap);
+
+            case SqlColumnRef colRef:
+                return CheckColumnRef(colRef, aliasMap);
+
+            case SqlLiteral:
+            case SqlParameter:
+                return null;
+
+            case SqlFunctionCall func:
+                if (!SupportedAggregates.Contains(func.FunctionName))
+                    return $"Unsupported function '{func.FunctionName}'";
+                foreach (var arg in func.Arguments)
+                {
+                    var err = CheckExpr(arg, aliasMap);
+                    if (err != null) return err;
+                }
+                return null;
+
+            case SqlInExpr inExpr:
+                var inErr = CheckExpr(inExpr.Expression, aliasMap);
+                if (inErr != null) return inErr;
+                foreach (var val in inExpr.Values)
+                {
+                    var err = CheckExpr(val, aliasMap);
+                    if (err != null) return err;
+                }
+                return null;
+
+            case SqlBetweenExpr between:
+                return CheckExpr(between.Expression, aliasMap)
+                    ?? CheckExpr(between.Low, aliasMap)
+                    ?? CheckExpr(between.High, aliasMap);
+
+            case SqlIsNullExpr isNull:
+                return CheckExpr(isNull.Expression, aliasMap);
+
+            case SqlParenExpr paren:
+                return CheckExpr(paren.Inner, aliasMap);
+
+            // Unconvertible nodes
+            case SqlCaseExpr:
+                return "CASE expressions are not supported";
+
+            case SqlCastExpr:
+                return "CAST expressions are not supported";
+
+            case SqlExistsExpr:
+                return "EXISTS subqueries are not supported";
+
+            case SqlUnsupported unsupported:
+                return $"Unsupported SQL construct: {unsupported.RawText}";
+
+            default:
+                return $"Unrecognized expression node: {expr.NodeKind}";
+        }
+    }
+
+    private string? CheckColumnRef(SqlColumnRef colRef, Dictionary<string, EntityInfo> aliasMap)
+    {
+        if (colRef.TableAlias != null)
+        {
+            if (!aliasMap.TryGetValue(colRef.TableAlias, out var entity))
+                return $"Unknown table alias '{colRef.TableAlias}'";
+
+            if (ResolveColumnToProperty(entity, colRef.ColumnName) == null)
+                return $"Unknown column '{colRef.ColumnName}' on entity '{entity.EntityName}'";
+        }
+        else
+        {
+            // No table alias — try to resolve against all entities in scope
+            var found = false;
+            foreach (var kvp in aliasMap)
+            {
+                if (ResolveColumnToProperty(kvp.Value, colRef.ColumnName) != null)
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+                return $"Unknown column '{colRef.ColumnName}'";
+        }
+
+        return null;
+    }
+}

--- a/src/Quarry.Analyzers/Migration/SqlToChainConverter.cs
+++ b/src/Quarry.Analyzers/Migration/SqlToChainConverter.cs
@@ -525,24 +525,25 @@ internal sealed class SqlToChainConverter
         Dictionary<string, EntityInfo> aliasMap,
         Dictionary<string, string> aliasToParam)
     {
-        string paramName;
+        string paramName = aliasToParam.Values.FirstOrDefault() ?? "x";
         EntityInfo? entity = null;
 
         if (colRef.TableAlias != null)
         {
-            aliasToParam.TryGetValue(colRef.TableAlias, out paramName!);
+            if (aliasToParam.TryGetValue(colRef.TableAlias, out var resolved))
+                paramName = resolved;
             aliasMap.TryGetValue(colRef.TableAlias, out entity);
         }
         else
         {
             // Find the first entity that has this column
-            paramName = aliasToParam.Values.FirstOrDefault() ?? "x";
             foreach (var kvp in aliasMap)
             {
                 if (ResolveColumnToProperty(kvp.Value, colRef.ColumnName) != null)
                 {
                     entity = kvp.Value;
-                    aliasToParam.TryGetValue(kvp.Key, out paramName!);
+                    if (aliasToParam.TryGetValue(kvp.Key, out var resolvedParam))
+                        paramName = resolvedParam;
                     break;
                 }
             }
@@ -575,7 +576,10 @@ internal sealed class SqlToChainConverter
         switch (literal.LiteralKind)
         {
             case SqlLiteralKind.String:
-                return $"\"{literal.Value}\"";
+                var escaped = literal.Value
+                    .Replace("\\", "\\\\")
+                    .Replace("\"", "\\\"");
+                return $"\"{escaped}\"";
             case SqlLiteralKind.Number:
                 return literal.Value;
             case SqlLiteralKind.Boolean:
@@ -716,6 +720,8 @@ internal sealed class SqlToChainConverter
         switch (expr)
         {
             case SqlBinaryExpr binary:
+                if (binary.Operator == SqlBinaryOp.Like)
+                    return "LIKE expressions are not supported";
                 return CheckExpr(binary.Left, aliasMap) ?? CheckExpr(binary.Right, aliasMap);
 
             case SqlUnaryExpr unary:

--- a/src/Quarry.Analyzers/Migration/SqlToChainConverter.cs
+++ b/src/Quarry.Analyzers/Migration/SqlToChainConverter.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Quarry.Generators.Models;
 using Quarry.Generators.Sql.Parser;
 
@@ -171,6 +173,529 @@ internal sealed class SqlToChainConverter
         return _tableToEntity.TryGetValue(tableName, out var entry) ? entry : null;
     }
 
+    /// <summary>
+    /// Converts a SQL SELECT statement to a C# chain query expression string.
+    /// Call <see cref="CheckConvertibility"/> first to ensure the SQL is convertible.
+    /// </summary>
+    /// <param name="stmt">The parsed SQL statement.</param>
+    /// <param name="contextVarName">The variable name of the QuarryContext (e.g., "db").</param>
+    /// <param name="parameterArgs">The argument expressions from the RawSqlAsync call site (positional).</param>
+    /// <param name="useExecuteFetchAll">If true, ends with ExecuteFetchAllAsync() instead of ToAsyncEnumerable().</param>
+    public string Convert(SqlSelectStatement stmt, string contextVarName, IReadOnlyList<string> parameterArgs, bool useExecuteFetchAll)
+    {
+        var aliasMap = BuildAliasMap(stmt);
+
+        // Build ordered alias list: FROM table first, then JOINs in order
+        var orderedAliases = new List<string>();
+        if (stmt.From != null)
+            orderedAliases.Add(stmt.From.Alias ?? stmt.From.TableName);
+        foreach (var join in stmt.Joins)
+            orderedAliases.Add(join.Table.Alias ?? join.Table.TableName);
+
+        // Generate lambda parameter names (single letter based on entity name)
+        var lambdaParams = GenerateLambdaParams(stmt, aliasMap);
+
+        // Build alias → lambda param mapping
+        var aliasToParam = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < orderedAliases.Count && i < lambdaParams.Count; i++)
+            aliasToParam[orderedAliases[i]] = lambdaParams[i];
+
+        var sb = new StringBuilder();
+
+        // FROM → ctx.Accessor()
+        var fromEntry = _tableToEntity[stmt.From!.TableName];
+        sb.Append(contextVarName);
+        sb.Append('.');
+        sb.Append(fromEntry.Mapping.PropertyName);
+        sb.Append("()");
+
+        // WHERE (pre-join: only if no joins, or WHERE only references primary table)
+        if (stmt.Where != null && stmt.Joins.Count == 0)
+        {
+            sb.Append("\n    .Where(");
+            sb.Append(lambdaParams[0]);
+            sb.Append(" => ");
+            sb.Append(TranslateExpr(stmt.Where, aliasMap, aliasToParam, parameterArgs));
+            sb.Append(')');
+        }
+
+        // JOINs
+        for (var i = 0; i < stmt.Joins.Count; i++)
+        {
+            var join = stmt.Joins[i];
+            var joinEntry = _tableToEntity[join.Table.TableName];
+
+            sb.Append("\n    .");
+            sb.Append(JoinMethodName(join.JoinKind));
+            sb.Append('<');
+            sb.Append(joinEntry.Entity.EntityName);
+            sb.Append(">(");
+
+            if (join.JoinKind != SqlJoinKind.Cross)
+            {
+                // Lambda params: all entities up to and including this join
+                sb.Append('(');
+                for (var j = 0; j <= i + 1; j++)
+                {
+                    if (j > 0) sb.Append(", ");
+                    sb.Append(lambdaParams[j]);
+                }
+                sb.Append(") => ");
+                sb.Append(TranslateExpr(join.Condition!, aliasMap, aliasToParam, parameterArgs));
+            }
+
+            sb.Append(')');
+        }
+
+        // WHERE (post-join: if joins exist)
+        if (stmt.Where != null && stmt.Joins.Count > 0)
+        {
+            sb.Append("\n    .Where(");
+            AppendLambdaSignature(sb, lambdaParams, stmt.Joins.Count + 1);
+            sb.Append(" => ");
+            sb.Append(TranslateExpr(stmt.Where, aliasMap, aliasToParam, parameterArgs));
+            sb.Append(')');
+        }
+
+        // GROUP BY
+        if (stmt.GroupBy != null && stmt.GroupBy.Count > 0)
+        {
+            sb.Append("\n    .GroupBy(");
+            AppendLambdaSignature(sb, lambdaParams, stmt.Joins.Count + 1);
+            sb.Append(" => ");
+            if (stmt.GroupBy.Count == 1)
+            {
+                sb.Append(TranslateExpr(stmt.GroupBy[0], aliasMap, aliasToParam, parameterArgs));
+            }
+            else
+            {
+                sb.Append('(');
+                for (var i = 0; i < stmt.GroupBy.Count; i++)
+                {
+                    if (i > 0) sb.Append(", ");
+                    sb.Append(TranslateExpr(stmt.GroupBy[i], aliasMap, aliasToParam, parameterArgs));
+                }
+                sb.Append(')');
+            }
+            sb.Append(')');
+        }
+
+        // HAVING
+        if (stmt.Having != null)
+        {
+            sb.Append("\n    .Having(");
+            AppendLambdaSignature(sb, lambdaParams, stmt.Joins.Count + 1);
+            sb.Append(" => ");
+            sb.Append(TranslateExpr(stmt.Having, aliasMap, aliasToParam, parameterArgs));
+            sb.Append(')');
+        }
+
+        // ORDER BY
+        if (stmt.OrderBy != null && stmt.OrderBy.Count > 0)
+        {
+            for (var i = 0; i < stmt.OrderBy.Count; i++)
+            {
+                var term = stmt.OrderBy[i];
+                sb.Append("\n    .");
+                sb.Append(i == 0 ? "OrderBy" : "ThenBy");
+                sb.Append('(');
+                AppendLambdaSignature(sb, lambdaParams, stmt.Joins.Count + 1);
+                sb.Append(" => ");
+                sb.Append(TranslateExpr(term.Expression, aliasMap, aliasToParam, parameterArgs));
+                if (term.IsDescending)
+                    sb.Append(", Direction.Descending");
+                sb.Append(')');
+            }
+        }
+
+        // DISTINCT
+        if (stmt.IsDistinct)
+            sb.Append("\n    .Distinct()");
+
+        // SELECT
+        sb.Append("\n    .Select(");
+        AppendLambdaSignature(sb, lambdaParams, stmt.Joins.Count + 1);
+        sb.Append(" => ");
+        AppendSelectProjection(sb, stmt, aliasMap, aliasToParam, parameterArgs, lambdaParams);
+        sb.Append(')');
+
+        // LIMIT
+        if (stmt.Limit != null)
+        {
+            sb.Append("\n    .Limit(");
+            sb.Append(TranslateExpr(stmt.Limit, aliasMap, aliasToParam, parameterArgs));
+            sb.Append(')');
+        }
+
+        // OFFSET
+        if (stmt.Offset != null)
+        {
+            sb.Append("\n    .Offset(");
+            sb.Append(TranslateExpr(stmt.Offset, aliasMap, aliasToParam, parameterArgs));
+            sb.Append(')');
+        }
+
+        // Terminal
+        if (useExecuteFetchAll)
+            sb.Append("\n    .ExecuteFetchAllAsync()");
+        else
+            sb.Append("\n    .ToAsyncEnumerable()");
+
+        return sb.ToString();
+    }
+
+    private static List<string> GenerateLambdaParams(SqlSelectStatement stmt, Dictionary<string, EntityInfo> aliasMap)
+    {
+        var params_ = new List<string>();
+        var used = new HashSet<string>(StringComparer.Ordinal);
+
+        if (stmt.From != null)
+        {
+            var alias = stmt.From.Alias ?? stmt.From.TableName;
+            if (aliasMap.TryGetValue(alias, out var entity))
+            {
+                var p = PickParamName(entity.EntityName, used);
+                params_.Add(p);
+                used.Add(p);
+            }
+        }
+
+        foreach (var join in stmt.Joins)
+        {
+            var alias = join.Table.Alias ?? join.Table.TableName;
+            if (aliasMap.TryGetValue(alias, out var entity))
+            {
+                var p = PickParamName(entity.EntityName, used);
+                params_.Add(p);
+                used.Add(p);
+            }
+        }
+
+        return params_;
+    }
+
+    private static string PickParamName(string entityName, HashSet<string> used)
+    {
+        // Use first letter lowercase
+        var candidate = entityName.Substring(0, 1).ToLowerInvariant();
+        if (!used.Contains(candidate))
+            return candidate;
+
+        // Try two letters
+        if (entityName.Length > 1)
+        {
+            candidate = entityName.Substring(0, 2).ToLowerInvariant();
+            if (!used.Contains(candidate))
+                return candidate;
+        }
+
+        // Append number
+        for (var i = 2; ; i++)
+        {
+            var numbered = entityName.Substring(0, 1).ToLowerInvariant() + i;
+            if (!used.Contains(numbered))
+                return numbered;
+        }
+    }
+
+    private static void AppendLambdaSignature(StringBuilder sb, List<string> lambdaParams, int count)
+    {
+        if (count == 1)
+        {
+            sb.Append(lambdaParams[0]);
+        }
+        else
+        {
+            sb.Append('(');
+            for (var i = 0; i < count && i < lambdaParams.Count; i++)
+            {
+                if (i > 0) sb.Append(", ");
+                sb.Append(lambdaParams[i]);
+            }
+            sb.Append(')');
+        }
+    }
+
+    private void AppendSelectProjection(
+        StringBuilder sb,
+        SqlSelectStatement stmt,
+        Dictionary<string, EntityInfo> aliasMap,
+        Dictionary<string, string> aliasToParam,
+        IReadOnlyList<string> parameterArgs,
+        List<string> lambdaParams)
+    {
+        // Check for SELECT *
+        if (stmt.Columns.Count == 1 && stmt.Columns[0] is SqlStarColumn star && star.TableAlias == null)
+        {
+            sb.Append(lambdaParams[0]);
+            return;
+        }
+
+        // Check for table.*
+        if (stmt.Columns.Count == 1 && stmt.Columns[0] is SqlStarColumn tableStar && tableStar.TableAlias != null)
+        {
+            if (aliasToParam.TryGetValue(tableStar.TableAlias, out var param))
+                sb.Append(param);
+            else
+                sb.Append(lambdaParams[0]);
+            return;
+        }
+
+        // Multiple columns or expressions → tuple
+        if (stmt.Columns.Count == 1)
+        {
+            // Single expression (e.g., COUNT(*))
+            var col = stmt.Columns[0];
+            if (col is SqlSelectColumn sc)
+                sb.Append(TranslateExpr(sc.Expression, aliasMap, aliasToParam, parameterArgs));
+            else
+                sb.Append(lambdaParams[0]);
+            return;
+        }
+
+        sb.Append('(');
+        for (var i = 0; i < stmt.Columns.Count; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            var col = stmt.Columns[i];
+            if (col is SqlSelectColumn sc)
+                sb.Append(TranslateExpr(sc.Expression, aliasMap, aliasToParam, parameterArgs));
+            else if (col is SqlStarColumn s)
+            {
+                if (s.TableAlias != null && aliasToParam.TryGetValue(s.TableAlias, out var p))
+                    sb.Append(p);
+                else
+                    sb.Append(lambdaParams[0]);
+            }
+        }
+        sb.Append(')');
+    }
+
+    private string TranslateExpr(
+        SqlExpr expr,
+        Dictionary<string, EntityInfo> aliasMap,
+        Dictionary<string, string> aliasToParam,
+        IReadOnlyList<string> parameterArgs)
+    {
+        switch (expr)
+        {
+            case SqlColumnRef colRef:
+                return TranslateColumnRef(colRef, aliasMap, aliasToParam);
+
+            case SqlParameter param:
+                return TranslateParameter(param, parameterArgs);
+
+            case SqlLiteral literal:
+                return TranslateLiteral(literal);
+
+            case SqlBinaryExpr binary:
+                var left = TranslateExpr(binary.Left, aliasMap, aliasToParam, parameterArgs);
+                var right = TranslateExpr(binary.Right, aliasMap, aliasToParam, parameterArgs);
+                var op = TranslateBinaryOp(binary.Operator);
+                return $"{left} {op} {right}";
+
+            case SqlUnaryExpr unary:
+                var operand = TranslateExpr(unary.Operand, aliasMap, aliasToParam, parameterArgs);
+                return unary.Operator == SqlUnaryOp.Not ? $"!{operand}" : $"-{operand}";
+
+            case SqlParenExpr paren:
+                var inner = TranslateExpr(paren.Inner, aliasMap, aliasToParam, parameterArgs);
+                return $"({inner})";
+
+            case SqlIsNullExpr isNull:
+                var nullExpr = TranslateExpr(isNull.Expression, aliasMap, aliasToParam, parameterArgs);
+                return isNull.IsNegated ? $"{nullExpr} != null" : $"{nullExpr} == null";
+
+            case SqlInExpr inExpr:
+                return TranslateInExpr(inExpr, aliasMap, aliasToParam, parameterArgs);
+
+            case SqlBetweenExpr between:
+                return TranslateBetweenExpr(between, aliasMap, aliasToParam, parameterArgs);
+
+            case SqlFunctionCall func:
+                return TranslateFunctionCall(func, aliasMap, aliasToParam, parameterArgs);
+
+            default:
+                return "/* unsupported */";
+        }
+    }
+
+    private string TranslateColumnRef(
+        SqlColumnRef colRef,
+        Dictionary<string, EntityInfo> aliasMap,
+        Dictionary<string, string> aliasToParam)
+    {
+        string paramName;
+        EntityInfo? entity = null;
+
+        if (colRef.TableAlias != null)
+        {
+            aliasToParam.TryGetValue(colRef.TableAlias, out paramName!);
+            aliasMap.TryGetValue(colRef.TableAlias, out entity);
+        }
+        else
+        {
+            // Find the first entity that has this column
+            paramName = aliasToParam.Values.FirstOrDefault() ?? "x";
+            foreach (var kvp in aliasMap)
+            {
+                if (ResolveColumnToProperty(kvp.Value, colRef.ColumnName) != null)
+                {
+                    entity = kvp.Value;
+                    aliasToParam.TryGetValue(kvp.Key, out paramName!);
+                    break;
+                }
+            }
+        }
+
+        var propName = entity != null
+            ? ResolveColumnToProperty(entity, colRef.ColumnName) ?? colRef.ColumnName
+            : colRef.ColumnName;
+
+        return $"{paramName}.{propName}";
+    }
+
+    private static string TranslateParameter(SqlParameter param, IReadOnlyList<string> parameterArgs)
+    {
+        // Extract index from @p0, @p1, etc.
+        var raw = param.RawText;
+        if (raw.StartsWith("@p", StringComparison.OrdinalIgnoreCase) &&
+            int.TryParse(raw.Substring(2), out var index) &&
+            index >= 0 && index < parameterArgs.Count)
+        {
+            return parameterArgs[index];
+        }
+
+        // Fallback: return as-is
+        return raw;
+    }
+
+    private static string TranslateLiteral(SqlLiteral literal)
+    {
+        switch (literal.LiteralKind)
+        {
+            case SqlLiteralKind.String:
+                return $"\"{literal.Value}\"";
+            case SqlLiteralKind.Number:
+                return literal.Value;
+            case SqlLiteralKind.Boolean:
+                return literal.Value.Equals("true", StringComparison.OrdinalIgnoreCase) ? "true" : "false";
+            case SqlLiteralKind.Null:
+                return "null";
+            default:
+                return literal.Value;
+        }
+    }
+
+    private static string TranslateBinaryOp(SqlBinaryOp op)
+    {
+        switch (op)
+        {
+            case SqlBinaryOp.Equal: return "==";
+            case SqlBinaryOp.NotEqual: return "!=";
+            case SqlBinaryOp.LessThan: return "<";
+            case SqlBinaryOp.GreaterThan: return ">";
+            case SqlBinaryOp.LessThanOrEqual: return "<=";
+            case SqlBinaryOp.GreaterThanOrEqual: return ">=";
+            case SqlBinaryOp.And: return "&&";
+            case SqlBinaryOp.Or: return "||";
+            case SqlBinaryOp.Add: return "+";
+            case SqlBinaryOp.Subtract: return "-";
+            case SqlBinaryOp.Multiply: return "*";
+            case SqlBinaryOp.Divide: return "/";
+            case SqlBinaryOp.Modulo: return "%";
+            case SqlBinaryOp.Like: return "/* LIKE */";
+            default: return "/* unknown op */";
+        }
+    }
+
+    private string TranslateInExpr(
+        SqlInExpr inExpr,
+        Dictionary<string, EntityInfo> aliasMap,
+        Dictionary<string, string> aliasToParam,
+        IReadOnlyList<string> parameterArgs)
+    {
+        var target = TranslateExpr(inExpr.Expression, aliasMap, aliasToParam, parameterArgs);
+        var sb = new StringBuilder();
+
+        sb.Append("new[] { ");
+        for (var i = 0; i < inExpr.Values.Count; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append(TranslateExpr(inExpr.Values[i], aliasMap, aliasToParam, parameterArgs));
+        }
+        sb.Append(" }.Contains(");
+        sb.Append(target);
+        sb.Append(')');
+
+        if (inExpr.IsNegated)
+            return $"!{sb}";
+
+        return sb.ToString();
+    }
+
+    private string TranslateBetweenExpr(
+        SqlBetweenExpr between,
+        Dictionary<string, EntityInfo> aliasMap,
+        Dictionary<string, string> aliasToParam,
+        IReadOnlyList<string> parameterArgs)
+    {
+        var expr = TranslateExpr(between.Expression, aliasMap, aliasToParam, parameterArgs);
+        var low = TranslateExpr(between.Low, aliasMap, aliasToParam, parameterArgs);
+        var high = TranslateExpr(between.High, aliasMap, aliasToParam, parameterArgs);
+
+        var result = $"{expr} >= {low} && {expr} <= {high}";
+        return between.IsNegated ? $"!({result})" : result;
+    }
+
+    private string TranslateFunctionCall(
+        SqlFunctionCall func,
+        Dictionary<string, EntityInfo> aliasMap,
+        Dictionary<string, string> aliasToParam,
+        IReadOnlyList<string> parameterArgs)
+    {
+        var name = func.FunctionName.ToUpperInvariant();
+
+        switch (name)
+        {
+            case "COUNT":
+                if (func.Arguments.Count == 0)
+                    return "Sql.Count()";
+                // COUNT(*) — the star is parsed as SqlColumnRef(null, "*")
+                if (func.Arguments[0] is SqlColumnRef starRef && starRef.ColumnName == "*")
+                    return "Sql.Count()";
+                return $"Sql.Count({TranslateExpr(func.Arguments[0], aliasMap, aliasToParam, parameterArgs)})";
+
+            case "SUM":
+                return $"Sql.Sum({TranslateExpr(func.Arguments[0], aliasMap, aliasToParam, parameterArgs)})";
+
+            case "AVG":
+                return $"Sql.Avg({TranslateExpr(func.Arguments[0], aliasMap, aliasToParam, parameterArgs)})";
+
+            case "MIN":
+                return $"Sql.Min({TranslateExpr(func.Arguments[0], aliasMap, aliasToParam, parameterArgs)})";
+
+            case "MAX":
+                return $"Sql.Max({TranslateExpr(func.Arguments[0], aliasMap, aliasToParam, parameterArgs)})";
+
+            default:
+                return $"/* {func.FunctionName}(...) */";
+        }
+    }
+
+    private static string JoinMethodName(SqlJoinKind kind)
+    {
+        switch (kind)
+        {
+            case SqlJoinKind.Inner: return "Join";
+            case SqlJoinKind.Left: return "LeftJoin";
+            case SqlJoinKind.Right: return "RightJoin";
+            case SqlJoinKind.Cross: return "CrossJoin";
+            case SqlJoinKind.FullOuter: return "FullOuterJoin";
+            default: return "Join";
+        }
+    }
+
     private string? CheckNode(SqlNode node, Dictionary<string, EntityInfo> aliasMap)
     {
         switch (node)
@@ -254,6 +779,10 @@ internal sealed class SqlToChainConverter
 
     private string? CheckColumnRef(SqlColumnRef colRef, Dictionary<string, EntityInfo> aliasMap)
     {
+        // Star in expression context (e.g., COUNT(*))
+        if (colRef.ColumnName == "*")
+            return null;
+
         if (colRef.TableAlias != null)
         {
             if (!aliasMap.TryGetValue(colRef.TableAlias, out var entity))

--- a/src/Quarry.Analyzers/Migration/SqlToChainConverter.cs
+++ b/src/Quarry.Analyzers/Migration/SqlToChainConverter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Quarry.Generators.Models;
 using Quarry.Generators.Sql.Parser;
 
@@ -18,15 +17,11 @@ internal sealed class SqlToChainConverter
         "COUNT", "SUM", "MIN", "MAX", "AVG"
     };
 
-    private readonly ContextInfo _context;
-
     /// <summary>Table name (case-insensitive) → (EntityInfo, EntityMapping).</summary>
     private readonly Dictionary<string, (EntityInfo Entity, EntityMapping Mapping)> _tableToEntity;
 
     public SqlToChainConverter(ContextInfo context)
     {
-        _context = context;
-
         _tableToEntity = new Dictionary<string, (EntityInfo, EntityMapping)>(StringComparer.OrdinalIgnoreCase);
         foreach (var mapping in context.EntityMappings)
         {
@@ -671,15 +666,19 @@ internal sealed class SqlToChainConverter
                 return $"Sql.Count({TranslateExpr(func.Arguments[0], aliasMap, aliasToParam, parameterArgs)})";
 
             case "SUM":
+                if (func.Arguments.Count == 0) return "Sql.Sum(0)";
                 return $"Sql.Sum({TranslateExpr(func.Arguments[0], aliasMap, aliasToParam, parameterArgs)})";
 
             case "AVG":
+                if (func.Arguments.Count == 0) return "Sql.Avg(0)";
                 return $"Sql.Avg({TranslateExpr(func.Arguments[0], aliasMap, aliasToParam, parameterArgs)})";
 
             case "MIN":
+                if (func.Arguments.Count == 0) return "Sql.Min(0)";
                 return $"Sql.Min({TranslateExpr(func.Arguments[0], aliasMap, aliasToParam, parameterArgs)})";
 
             case "MAX":
+                if (func.Arguments.Count == 0) return "Sql.Max(0)";
                 return $"Sql.Max({TranslateExpr(func.Arguments[0], aliasMap, aliasToParam, parameterArgs)})";
 
             default:

--- a/src/Quarry.Analyzers/RawSqlMigrationAnalyzer.cs
+++ b/src/Quarry.Analyzers/RawSqlMigrationAnalyzer.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Quarry.Generators.Models;
+using Quarry.Generators.Parsing;
+
+namespace Quarry.Analyzers;
+
+/// <summary>
+/// Detects RawSqlAsync&lt;T&gt; calls with string literal SQL that can be expressed as chain queries.
+/// Emits QRY040 with the generated chain code stored in diagnostic properties for the code fix.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+internal sealed class RawSqlMigrationAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(AnalyzerDiagnosticDescriptors.RawSqlConvertibleToChain);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(
+            GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var contextCache = new ConcurrentDictionary<string, ContextInfo>(StringComparer.Ordinal);
+
+            // Pre-discover all contexts and their entities (same pattern as QuarryQueryAnalyzer)
+            foreach (var syntaxTree in compilationContext.Compilation.SyntaxTrees)
+            {
+#pragma warning disable RS1030
+                var semanticModel = compilationContext.Compilation.GetSemanticModel(syntaxTree);
+#pragma warning restore RS1030
+                var root = syntaxTree.GetRoot(compilationContext.CancellationToken);
+
+                foreach (var classDecl in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
+                {
+                    if (!ContextParser.HasQuarryContextAttribute(classDecl))
+                        continue;
+
+                    var contextInfo = ContextParser.ParseContext(classDecl, semanticModel, compilationContext.CancellationToken);
+                    if (contextInfo == null)
+                        continue;
+
+                    contextCache.TryAdd(contextInfo.ClassName, contextInfo);
+                }
+            }
+
+            compilationContext.RegisterSyntaxNodeAction(
+                nodeContext => AnalyzeInvocation(nodeContext, contextCache),
+                SyntaxKind.InvocationExpression);
+        });
+    }
+
+    private static void AnalyzeInvocation(
+        SyntaxNodeAnalysisContext nodeContext,
+        ConcurrentDictionary<string, ContextInfo> contextCache)
+    {
+        var invocation = (InvocationExpressionSyntax)nodeContext.Node;
+
+        // Must be a member access: something.RawSqlAsync<T>(...)
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return;
+
+        // Method name must be RawSqlAsync
+        if (memberAccess.Name is not GenericNameSyntax genericName
+            || genericName.Identifier.Text != "RawSqlAsync")
+            return;
+
+        // Must have at least one argument (the SQL string)
+        if (invocation.ArgumentList.Arguments.Count == 0)
+            return;
+
+        var firstArg = invocation.ArgumentList.Arguments[0].Expression;
+
+        // SQL must be a string literal
+        if (firstArg is not LiteralExpressionSyntax literal
+            || !literal.IsKind(SyntaxKind.StringLiteralExpression))
+            return;
+
+        // Verify the receiver is a QuarryContext via semantic model
+        var symbolInfo = nodeContext.SemanticModel.GetSymbolInfo(invocation, nodeContext.CancellationToken);
+        if (symbolInfo.Symbol is not IMethodSymbol methodSymbol)
+            return;
+
+        var containingType = methodSymbol.ContainingType;
+        if (!InheritsFromQuarryContext(containingType))
+            return;
+
+        // Resolve the context info
+        ContextInfo? contextInfo = null;
+        var receiverType = nodeContext.SemanticModel.GetTypeInfo(memberAccess.Expression, nodeContext.CancellationToken).Type;
+        if (receiverType != null)
+            contextCache.TryGetValue(receiverType.Name, out contextInfo);
+
+        // For Phase 1: emit diagnostic for any string-literal RawSqlAsync on a QuarryContext.
+        // Phase 2 will add convertibility checking before emitting.
+        var properties = ImmutableDictionary<string, string?>.Empty;
+
+        // Store the SQL text for later phases
+        properties = properties.Add("Sql", literal.Token.ValueText);
+
+        // Store the context class name if resolved
+        if (contextInfo != null)
+            properties = properties.Add("ContextClass", contextInfo.ClassName);
+
+        var diagnostic = Diagnostic.Create(
+            AnalyzerDiagnosticDescriptors.RawSqlConvertibleToChain,
+            invocation.GetLocation(),
+            properties);
+
+        nodeContext.ReportDiagnostic(diagnostic);
+    }
+
+    private static bool InheritsFromQuarryContext(INamedTypeSymbol? type)
+    {
+        while (type != null)
+        {
+            if (type.Name == "QuarryContext" &&
+                type.ContainingNamespace?.ToDisplayString() == "Quarry")
+                return true;
+
+            type = type.BaseType;
+        }
+
+        return false;
+    }
+}

--- a/src/Quarry.Analyzers/RawSqlMigrationAnalyzer.cs
+++ b/src/Quarry.Analyzers/RawSqlMigrationAnalyzer.cs
@@ -118,9 +118,24 @@ internal sealed class RawSqlMigrationAnalyzer : DiagnosticAnalyzer
         if (convertError != null)
             return;
 
+        // Extract the context variable name from the receiver expression
+        var contextVarName = memberAccess.Expression.ToString();
+
+        // Extract parameter arguments (skip the SQL string, skip CancellationToken if present)
+        var parameterArgs = ExtractParameterArgs(invocation, methodSymbol);
+
+        // Check if .ToListAsync() is chained after the RawSqlAsync call
+        var useExecuteFetchAll = IsFollowedByToListAsync(invocation);
+
+        // Generate the chain code
+        var chainCode = converter.Convert(
+            parseResult.Statement, contextVarName, parameterArgs, useExecuteFetchAll);
+
         var properties = ImmutableDictionary<string, string?>.Empty
             .Add("Sql", sql)
-            .Add("ContextClass", contextInfo.ClassName);
+            .Add("ContextClass", contextInfo.ClassName)
+            .Add("ChainCode", chainCode)
+            .Add("UseExecuteFetchAll", useExecuteFetchAll.ToString());
 
         var diagnostic = Diagnostic.Create(
             AnalyzerDiagnosticDescriptors.RawSqlConvertibleToChain,
@@ -128,6 +143,41 @@ internal sealed class RawSqlMigrationAnalyzer : DiagnosticAnalyzer
             properties);
 
         nodeContext.ReportDiagnostic(diagnostic);
+    }
+
+    private static List<string> ExtractParameterArgs(
+        InvocationExpressionSyntax invocation, IMethodSymbol methodSymbol)
+    {
+        var args = new List<string>();
+        var arguments = invocation.ArgumentList.Arguments;
+
+        // Skip first argument (SQL string). Remaining are parameters.
+        // If the method has a CancellationToken parameter, skip that too.
+        var hasCancellationToken = methodSymbol.Parameters.Any(p =>
+            p.Type.Name == "CancellationToken");
+
+        var startIndex = hasCancellationToken ? 2 : 1; // skip sql + optional ct
+
+        for (var i = startIndex; i < arguments.Count; i++)
+        {
+            args.Add(arguments[i].Expression.ToString());
+        }
+
+        return args;
+    }
+
+    private static bool IsFollowedByToListAsync(InvocationExpressionSyntax invocation)
+    {
+        // Check if the parent is a member access calling ToListAsync()
+        // Pattern: db.RawSqlAsync<T>("...").ToListAsync()
+        if (invocation.Parent is MemberAccessExpressionSyntax parentMemberAccess
+            && parentMemberAccess.Name.Identifier.Text == "ToListAsync"
+            && parentMemberAccess.Parent is InvocationExpressionSyntax)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     private static bool InheritsFromQuarryContext(INamedTypeSymbol? type)

--- a/src/Quarry.Analyzers/RawSqlMigrationAnalyzer.cs
+++ b/src/Quarry.Analyzers/RawSqlMigrationAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Quarry.Analyzers;
 
 /// <summary>
 /// Detects RawSqlAsync&lt;T&gt; calls with string literal SQL that can be expressed as chain queries.
-/// Emits QRY040 with the generated chain code stored in diagnostic properties for the code fix.
+/// Emits QRY042 with the generated chain code stored in diagnostic properties for the code fix.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 internal sealed class RawSqlMigrationAnalyzer : DiagnosticAnalyzer

--- a/src/Quarry.Analyzers/RawSqlMigrationAnalyzer.cs
+++ b/src/Quarry.Analyzers/RawSqlMigrationAnalyzer.cs
@@ -7,8 +7,10 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Quarry.Analyzers.Migration;
 using Quarry.Generators.Models;
 using Quarry.Generators.Parsing;
+using Quarry.Generators.Sql.Parser;
 
 namespace Quarry.Analyzers;
 
@@ -100,16 +102,25 @@ internal sealed class RawSqlMigrationAnalyzer : DiagnosticAnalyzer
         if (receiverType != null)
             contextCache.TryGetValue(receiverType.Name, out contextInfo);
 
-        // For Phase 1: emit diagnostic for any string-literal RawSqlAsync on a QuarryContext.
-        // Phase 2 will add convertibility checking before emitting.
-        var properties = ImmutableDictionary<string, string?>.Empty;
+        // Need context info with entities to check convertibility
+        if (contextInfo == null || contextInfo.EntityMappings.Count == 0)
+            return;
 
-        // Store the SQL text for later phases
-        properties = properties.Add("Sql", literal.Token.ValueText);
+        // Parse the SQL string
+        var sql = literal.Token.ValueText;
+        var parseResult = SqlParser.Parse(sql, contextInfo.Dialect);
+        if (!parseResult.Success || parseResult.Statement == null)
+            return;
 
-        // Store the context class name if resolved
-        if (contextInfo != null)
-            properties = properties.Add("ContextClass", contextInfo.ClassName);
+        // Check if the parsed SQL is convertible to a chain query
+        var converter = new SqlToChainConverter(contextInfo);
+        var convertError = converter.CheckConvertibility(parseResult.Statement);
+        if (convertError != null)
+            return;
+
+        var properties = ImmutableDictionary<string, string?>.Empty
+            .Add("Sql", sql)
+            .Add("ContextClass", contextInfo.ClassName);
 
         var diagnostic = Diagnostic.Create(
             AnalyzerDiagnosticDescriptors.RawSqlConvertibleToChain,


### PR DESCRIPTION
## Summary
- Closes #184
- New Roslyn analyzer (QRY042) detects `RawSqlAsync<T>` calls with string literal SQL convertible to Quarry chain queries
- Code fix provider replaces `RawSqlAsync<T>` invocations with generated chain query code
- Uses shared SQL parser from #182 to parse and validate SQL ASTs

## Reason for Change
No tooling existed to help users migrate from `RawSqlAsync` to chain queries. Users had to manually identify convertible queries and rewrite them.

## Impact
- New info-level diagnostic (QRY042) surfaces in codebases using `RawSqlAsync` with string literal SQL
- Suppressible via `.editorconfig` or pragma
- No breaking changes to existing APIs

## Plan items implemented as specified
- Separate `RawSqlMigrationAnalyzer` class (not integrated into `QuarryQueryAnalyzer`)
- Entity/context discovery via `ContextParser` (same pattern as existing analyzer)
- `SqlToChainConverter` with convertibility checking and code generation
- Table name → EntityInfo and column name → property name reverse resolution
- Parameter mapping from `@p0`/`@p1` to actual call site argument expressions
- Value tuple projection for specific columns, explicit `.Select(u => u)` for `SELECT *`
- Hybrid terminal: `ToAsyncEnumerable()` default, `ExecuteFetchAllAsync()` when `.ToListAsync()` detected
- `RawSqlToChainCodeFix` with `BatchFixer` support

## Deviations from plan implemented
- Diagnostic ID changed from QRY040 to QRY042 (QRY040-041 already used by generator)
- LIKE expressions blocked in convertibility check (plan specified translation, but blocked is safer as a first pass)

## Gaps in original plan implemented
- `COUNT(*)` star argument handling (parser represents `*` as `SqlColumnRef(null, "*")`)

## Migration Steps
None required.

## Performance Considerations
The analyzer runs at compile-time within Roslyn. SQL parsing is only performed for string-literal `RawSqlAsync` calls on `QuarryContext` subclasses. The convertibility check short-circuits on first unsupported node.

## Security Considerations
No runtime execution paths. Operates entirely within the Roslyn compilation pipeline.

## Breaking Changes
- Consumer-facing: None
- Internal: None