### PR TITLE
perf: collapse carrier list path to one state machine, dialect-aware CommandBehavior

### DIFF
--- a/src/Quarry.Generator/CodeGen/CarrierEmitter.cs
+++ b/src/Quarry.Generator/CodeGen/CarrierEmitter.cs
@@ -607,13 +607,22 @@ internal static class CarrierEmitter
     /// <summary>
     /// Emits DbCommand creation and binds parameters with mask-gated conditional support.
     /// </summary>
+    /// <remarks>
+    /// The CommandTimeout assignment is guarded by a compare-and-set that skips the property
+    /// setter when the value already matches the driver's default — saving a setter call
+    /// (and any provider-side validation) on the hot path.
+    /// </remarks>
     private static void EmitCarrierCommandBinding(
-        StringBuilder sb, AssembledPlan chain, CarrierPlan carrier,
-        string timeoutExpr)
+        StringBuilder sb, AssembledPlan chain, CarrierPlan carrier)
     {
+        var timeoutExpr = HasCarrierField(carrier, FieldRole.Timeout)
+            ? "__c.Timeout ?? __ctx.DefaultTimeout"
+            : "__ctx.DefaultTimeout";
+
         sb.AppendLine("        var __cmd = __ctx.Connection.CreateCommand();");
         sb.AppendLine("        __cmd.CommandText = sql;");
-        sb.AppendLine($"        __cmd.CommandTimeout = (int)({timeoutExpr}).TotalSeconds;");
+        sb.AppendLine($"        var __timeoutSec = (int)({timeoutExpr}).TotalSeconds;");
+        sb.AppendLine("        if (__cmd.CommandTimeout != __timeoutSec) __cmd.CommandTimeout = __timeoutSec;");
 
         var dialectLiteral = GetDialectLiteral(chain.Dialect);
         var paramCount = chain.ChainParameters.Count;
@@ -753,15 +762,21 @@ internal static class CarrierEmitter
         // Parameter logging
         EmitInlineParameterLogging(sb, chain, carrier);
 
-        // Command binding
-        var timeoutExpr = HasCarrierField(carrier, FieldRole.Timeout)
-            ? "__c.Timeout ?? __ctx.DefaultTimeout"
-            : "__ctx.DefaultTimeout";
-        EmitCarrierCommandBinding(sb, chain, carrier, timeoutExpr);
+        // Command binding (CommandTimeout is set inside the executor)
+        EmitCarrierCommandBinding(sb, chain, carrier);
 
-        // Executor call
+        // Executor call. Reader-shaped terminals receive a per-query CommandBehavior literal
+        // chosen by CommandBehaviorSelector — non-row terminals (NonQuery / Scalar) do not.
         var readerArg = readerExpression != null ? $", {readerExpression}" : "";
-        sb.AppendLine($"        return QueryExecutor.{executorMethod}(__opId, __ctx, __cmd{readerArg}, cancellationToken);");
+        if (readerExpression != null)
+        {
+            var behaviorExpr = CommandBehaviorSelector.Select(chain.Dialect, chain.ProjectionInfo?.Columns);
+            sb.AppendLine($"        return QueryExecutor.{executorMethod}(__opId, __ctx, __cmd{readerArg}, {behaviorExpr}, cancellationToken);");
+        }
+        else
+        {
+            sb.AppendLine($"        return QueryExecutor.{executorMethod}(__opId, __ctx, __cmd, cancellationToken);");
+        }
     }
 
     /// <summary>
@@ -901,13 +916,16 @@ internal static class CarrierEmitter
         sb.AppendLine("        if (__logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)");
         sb.AppendLine("            QueryLog.SqlGenerated(__opId, sql);");
 
-        // Command creation + inline parameter binding from entity properties
+        // Command creation + inline parameter binding from entity properties.
+        // CommandTimeout uses a guarded compare-and-set to skip the property setter when
+        // the value already matches.
         var timeoutExpr = HasCarrierField(carrier, FieldRole.Timeout)
             ? "__c.Timeout ?? __ctx.DefaultTimeout"
             : "__ctx.DefaultTimeout";
         sb.AppendLine("        var __cmd = __ctx.Connection.CreateCommand();");
         sb.AppendLine("        __cmd.CommandText = sql;");
-        sb.AppendLine($"        __cmd.CommandTimeout = (int)({timeoutExpr}).TotalSeconds;");
+        sb.AppendLine($"        var __timeoutSec = (int)({timeoutExpr}).TotalSeconds;");
+        sb.AppendLine("        if (__cmd.CommandTimeout != __timeoutSec) __cmd.CommandTimeout = __timeoutSec;");
 
         // Bind entity properties as parameters using InsertInfo
         var insertInfo = chain.InsertInfo;

--- a/src/Quarry.Generator/CodeGen/CommandBehaviorSelector.cs
+++ b/src/Quarry.Generator/CodeGen/CommandBehaviorSelector.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using Quarry.Generators.Models;
+using Quarry.Generators.Sql;
+
+namespace Quarry.Generators.CodeGen;
+
+/// <summary>
+/// Picks the <c>CommandBehavior</c> literal that the generated interceptor passes to the
+/// executor. Decision is per-query and per-dialect: <c>SequentialAccess</c> is added only
+/// when the projection contains a streaming-shaped column (<c>byte[]</c>, <see cref="System.IO.Stream"/>),
+/// and never for SQLite (Microsoft.Data.Sqlite always reads lazily — the flag is pure overhead).
+/// For small fixed-width row workloads (the 99% case) buffered mode is equal-or-faster on
+/// every provider, so the default omits <c>SequentialAccess</c>.
+/// </summary>
+internal static class CommandBehaviorSelector
+{
+    private const string SingleResultOnly = "System.Data.CommandBehavior.SingleResult";
+    private const string SingleResultSequential = "System.Data.CommandBehavior.SingleResult | System.Data.CommandBehavior.SequentialAccess";
+
+    /// <summary>
+    /// Returns the fully-qualified C# expression for the <c>CommandBehavior</c> argument
+    /// to pass to a carrier executor method.
+    /// </summary>
+    /// <param name="dialect">The target SQL dialect for this call site.</param>
+    /// <param name="columns">Projected columns produced by the analyzer. May be empty for non-projection terminals.</param>
+    public static string Select(SqlDialect dialect, IReadOnlyList<ProjectedColumn>? columns)
+    {
+        if (dialect == SqlDialect.SQLite)
+            return SingleResultOnly;
+
+        if (columns == null || columns.Count == 0)
+            return SingleResultOnly;
+
+        for (int i = 0; i < columns.Count; i++)
+        {
+            if (IsLargeColumnType(columns[i].FullClrType))
+                return SingleResultSequential;
+        }
+
+        return SingleResultOnly;
+    }
+
+    private static bool IsLargeColumnType(string fullClrType)
+    {
+        // byte[] / Byte[] / global::System.Byte[] all end in []
+        if (fullClrType.EndsWith("byte[]", System.StringComparison.Ordinal) ||
+            fullClrType.EndsWith("Byte[]", System.StringComparison.Ordinal))
+            return true;
+
+        // Any type whose name ends in "Stream" — Stream, MemoryStream, FileStream, etc.
+        // The projected column FullClrType is the result-type member, which for streaming
+        // payloads is virtually always a Stream-derived type.
+        if (fullClrType.EndsWith("Stream", System.StringComparison.Ordinal))
+            return true;
+
+        return false;
+    }
+}

--- a/src/Quarry.Generator/CodeGen/TerminalBodyEmitter.cs
+++ b/src/Quarry.Generator/CodeGen/TerminalBodyEmitter.cs
@@ -559,13 +559,15 @@ internal static class TerminalBodyEmitter
         sb.AppendLine("        if (__logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)");
         sb.AppendLine("            QueryLog.SqlGenerated(__opId, sql);");
 
-        // Command creation and parameter binding
+        // Command creation and parameter binding. CommandTimeout uses a guarded
+        // compare-and-set so the setter is skipped when the value already matches.
         var timeoutExpr = carrier.Fields.Any(f => f.Role == FieldRole.Timeout)
             ? "__c.Timeout ?? __ctx.DefaultTimeout"
             : "__ctx.DefaultTimeout";
         sb.AppendLine("        var __cmd = __ctx.Connection.CreateCommand();");
         sb.AppendLine("        __cmd.CommandText = sql;");
-        sb.AppendLine($"        __cmd.CommandTimeout = (int)({timeoutExpr}).TotalSeconds;");
+        sb.AppendLine($"        var __timeoutSec = (int)({timeoutExpr}).TotalSeconds;");
+        sb.AppendLine("        if (__cmd.CommandTimeout != __timeoutSec) __cmd.CommandTimeout = __timeoutSec;");
 
         // Bind parameters from entities
         var convertBool = InterceptorCodeGenerator.RequiresBoolToIntConversion(chain.Dialect);

--- a/src/Quarry/Context/QuarryContext.cs
+++ b/src/Quarry/Context/QuarryContext.cs
@@ -386,7 +386,7 @@ public abstract class QuarryContext : IAsyncDisposable, IDisposable
             command.Parameters.Add(param);
         }
 
-        return QueryExecutor.ToCarrierAsyncEnumerableWithCommandAsync(opId, this, command, reader, cancellationToken);
+        return QueryExecutor.ToCarrierAsyncEnumerableWithCommandAsync(opId, this, command, reader, CommandBehavior.SingleResult, cancellationToken);
     }
 
     /// <summary>
@@ -421,7 +421,7 @@ public abstract class QuarryContext : IAsyncDisposable, IDisposable
             command.Parameters.Add(param);
         }
 
-        return QueryExecutor.ToCarrierAsyncEnumerableWithCommandAsync<T, TReader>(opId, this, command, cancellationToken);
+        return QueryExecutor.ToCarrierAsyncEnumerableWithCommandAsync<T, TReader>(opId, this, command, CommandBehavior.SingleResult, cancellationToken);
     }
 
     /// <summary>

--- a/src/Quarry/Internal/QueryExecutor.cs
+++ b/src/Quarry/Internal/QueryExecutor.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Quarry.Logging;
 
@@ -15,18 +16,35 @@ namespace Quarry.Internal;
 public static class QueryExecutor
 {
     /// <summary>
-    /// Executes a carrier-optimized query with a pre-built command and returns all results as a list.
-    /// Delegates to <see cref="ToCarrierAsyncEnumerableWithCommandAsync{TResult}"/> for the actual execution.
+    /// Executes a carrier-optimized query with a pre-built command and materializes all results into a list.
     /// </summary>
     public static async Task<List<TResult>> ExecuteCarrierWithCommandAsync<TResult>(
         long opId, QuarryContext ctx,
-        DbCommand command, Func<DbDataReader, TResult> reader, CancellationToken ct)
+        DbCommand command, Func<DbDataReader, TResult> reader,
+        CommandBehavior behavior, CancellationToken ct)
     {
+        await using var _cmd = command;
+
+        if (ctx.Connection.State != ConnectionState.Open)
+            await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
+
+        var startTimestamp = Stopwatch.GetTimestamp();
+        await using var dbReader = await command.ExecuteReaderAsync(behavior, ct).ConfigureAwait(false);
+
         var results = new List<TResult>();
-        await foreach (var item in ToCarrierAsyncEnumerableWithCommandAsync(opId, ctx, command, reader, ct).ConfigureAwait(false))
+        try
         {
-            results.Add(item);
+            while (await dbReader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                results.Add(reader(dbReader));
+            }
         }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            ReportReaderFailure(opId, command, ex);
+        }
+
+        FinalizeQuery(opId, ctx, startTimestamp, results.Count, command.CommandText);
         return results;
     }
 
@@ -35,34 +53,28 @@ public static class QueryExecutor
     /// </summary>
     public static async Task<TResult> ExecuteCarrierFirstWithCommandAsync<TResult>(
         long opId, QuarryContext ctx,
-        DbCommand command, Func<DbDataReader, TResult> reader, CancellationToken ct)
+        DbCommand command, Func<DbDataReader, TResult> reader,
+        CommandBehavior behavior, CancellationToken ct)
     {
         await using var _cmd = command;
-        await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
+
+        if (ctx.Connection.State != ConnectionState.Open)
+            await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
 
         var startTimestamp = Stopwatch.GetTimestamp();
-        await using var dbReader = await command.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess | CommandBehavior.SingleRow, ct).ConfigureAwait(false);
+        await using var dbReader = await command.ExecuteReaderAsync(behavior | CommandBehavior.SingleRow, ct).ConfigureAwait(false);
 
         try
         {
             if (await dbReader.ReadAsync(ct).ConfigureAwait(false))
             {
-                var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-                if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
-                    QueryLog.FetchCompleted(opId, 1, elapsedMs);
-
-                CheckSlowQuery(opId, ctx, elapsedMs, command.CommandText);
-
+                FinalizeQuery(opId, ctx, startTimestamp, 1, command.CommandText);
                 return reader(dbReader);
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Error, QueryLog.CategoryName) == true)
-                QueryLog.QueryFailed(opId, ex);
-
-            throw new QuarryQueryException($"Error reading query results: {ex.Message}", command.CommandText, ex);
+            ReportReaderFailure(opId, command, ex);
         }
 
         throw new InvalidOperationException("Sequence contains no elements.");
@@ -73,43 +85,32 @@ public static class QueryExecutor
     /// </summary>
     public static async Task<TResult?> ExecuteCarrierFirstOrDefaultWithCommandAsync<TResult>(
         long opId, QuarryContext ctx,
-        DbCommand command, Func<DbDataReader, TResult> reader, CancellationToken ct)
+        DbCommand command, Func<DbDataReader, TResult> reader,
+        CommandBehavior behavior, CancellationToken ct)
     {
         await using var _cmd = command;
-        await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
+
+        if (ctx.Connection.State != ConnectionState.Open)
+            await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
 
         var startTimestamp = Stopwatch.GetTimestamp();
-        await using var dbReader = await command.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess | CommandBehavior.SingleRow, ct).ConfigureAwait(false);
+        await using var dbReader = await command.ExecuteReaderAsync(behavior | CommandBehavior.SingleRow, ct).ConfigureAwait(false);
 
         try
         {
             if (await dbReader.ReadAsync(ct).ConfigureAwait(false))
             {
-                var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-                if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
-                    QueryLog.FetchCompleted(opId, 1, elapsedMs);
-
-                CheckSlowQuery(opId, ctx, elapsedMs, command.CommandText);
-
-                return reader(dbReader);
+                var result = reader(dbReader);
+                FinalizeQuery(opId, ctx, startTimestamp, 1, command.CommandText);
+                return result;
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Error, QueryLog.CategoryName) == true)
-                QueryLog.QueryFailed(opId, ex);
-
-            throw new QuarryQueryException($"Error reading query results: {ex.Message}", command.CommandText, ex);
+            ReportReaderFailure(opId, command, ex);
         }
 
-        var elapsed = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-        if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
-            QueryLog.FetchCompleted(opId, 0, elapsed);
-
-        CheckSlowQuery(opId, ctx, elapsed, command.CommandText);
-
+        FinalizeQuery(opId, ctx, startTimestamp, 0, command.CommandText);
         return default;
     }
 
@@ -118,13 +119,16 @@ public static class QueryExecutor
     /// </summary>
     public static async Task<TResult> ExecuteCarrierSingleWithCommandAsync<TResult>(
         long opId, QuarryContext ctx,
-        DbCommand command, Func<DbDataReader, TResult> reader, CancellationToken ct)
+        DbCommand command, Func<DbDataReader, TResult> reader,
+        CommandBehavior behavior, CancellationToken ct)
     {
         await using var _cmd = command;
-        await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
+
+        if (ctx.Connection.State != ConnectionState.Open)
+            await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
 
         var startTimestamp = Stopwatch.GetTimestamp();
-        await using var dbReader = await command.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess, ct).ConfigureAwait(false);
+        await using var dbReader = await command.ExecuteReaderAsync(behavior, ct).ConfigureAwait(false);
 
         try
         {
@@ -136,13 +140,7 @@ public static class QueryExecutor
             if (await dbReader.ReadAsync(ct).ConfigureAwait(false))
                 throw new InvalidOperationException("Sequence contains more than one element.");
 
-            var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
-                QueryLog.FetchCompleted(opId, 1, elapsedMs);
-
-            CheckSlowQuery(opId, ctx, elapsedMs, command.CommandText);
-
+            FinalizeQuery(opId, ctx, startTimestamp, 1, command.CommandText);
             return result;
         }
         catch (InvalidOperationException)
@@ -151,10 +149,8 @@ public static class QueryExecutor
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Error, QueryLog.CategoryName) == true)
-                QueryLog.QueryFailed(opId, ex);
-
-            throw new QuarryQueryException($"Error reading query results: {ex.Message}", command.CommandText, ex);
+            ReportReaderFailure(opId, command, ex);
+            throw; // unreachable — ReportReaderFailure always throws
         }
     }
 
@@ -164,25 +160,22 @@ public static class QueryExecutor
     /// </summary>
     public static async Task<TResult?> ExecuteCarrierSingleOrDefaultWithCommandAsync<TResult>(
         long opId, QuarryContext ctx,
-        DbCommand command, Func<DbDataReader, TResult> reader, CancellationToken ct)
+        DbCommand command, Func<DbDataReader, TResult> reader,
+        CommandBehavior behavior, CancellationToken ct)
     {
         await using var _cmd = command;
-        await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
+
+        if (ctx.Connection.State != ConnectionState.Open)
+            await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
 
         var startTimestamp = Stopwatch.GetTimestamp();
-        await using var dbReader = await command.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess, ct).ConfigureAwait(false);
+        await using var dbReader = await command.ExecuteReaderAsync(behavior, ct).ConfigureAwait(false);
 
         try
         {
             if (!await dbReader.ReadAsync(ct).ConfigureAwait(false))
             {
-                var elapsedMs0 = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-                if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
-                    QueryLog.FetchCompleted(opId, 0, elapsedMs0);
-
-                CheckSlowQuery(opId, ctx, elapsedMs0, command.CommandText);
-
+                FinalizeQuery(opId, ctx, startTimestamp, 0, command.CommandText);
                 return default;
             }
 
@@ -191,13 +184,7 @@ public static class QueryExecutor
             if (await dbReader.ReadAsync(ct).ConfigureAwait(false))
                 throw new InvalidOperationException("Sequence contains more than one element.");
 
-            var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
-                QueryLog.FetchCompleted(opId, 1, elapsedMs);
-
-            CheckSlowQuery(opId, ctx, elapsedMs, command.CommandText);
-
+            FinalizeQuery(opId, ctx, startTimestamp, 1, command.CommandText);
             return result;
         }
         catch (InvalidOperationException)
@@ -206,10 +193,8 @@ public static class QueryExecutor
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Error, QueryLog.CategoryName) == true)
-                QueryLog.QueryFailed(opId, ex);
-
-            throw new QuarryQueryException($"Error reading query results: {ex.Message}", command.CommandText, ex);
+            ReportReaderFailure(opId, command, ex);
+            throw; // unreachable
         }
     }
 
@@ -221,9 +206,12 @@ public static class QueryExecutor
         DbCommand command, CancellationToken ct)
     {
         await using var _cmd = command;
-        await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
 
-        var instrumented = LogsmithOutput.Logger != null || ctx.SlowQueryThreshold.HasValue;
+        if (ctx.Connection.State != ConnectionState.Open)
+            await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
+
+        var logger = LogsmithOutput.Logger;
+        var instrumented = logger != null || ctx.SlowQueryThreshold.HasValue;
         var startTimestamp = instrumented ? Stopwatch.GetTimestamp() : 0;
 
         try
@@ -238,7 +226,7 @@ public static class QueryExecutor
 
             if (result is null or DBNull)
             {
-                if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
+                if (logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
                     QueryLog.ScalarResult(opId, "null");
 
                 if (default(TScalar) is null)
@@ -247,7 +235,7 @@ public static class QueryExecutor
                 throw new InvalidOperationException("Query returned null but expected a non-nullable value.");
             }
 
-            if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
+            if (logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
                 QueryLog.ScalarResult(opId, result.ToString() ?? "null");
 
             return ScalarConverter.Convert<TScalar>(result);
@@ -258,7 +246,7 @@ public static class QueryExecutor
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Error, QueryLog.CategoryName) == true)
+            if (logger?.IsEnabled(LogLevel.Error, QueryLog.CategoryName) == true)
                 QueryLog.QueryFailed(opId, ex);
 
             throw new QuarryQueryException($"Error executing scalar query: {ex.Message}", command.CommandText, ex);
@@ -273,25 +261,22 @@ public static class QueryExecutor
         DbCommand command, CancellationToken ct)
     {
         await using var _cmd = command;
-        await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
+
+        if (ctx.Connection.State != ConnectionState.Open)
+            await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
 
         var startTimestamp = Stopwatch.GetTimestamp();
 
         try
         {
             var rowCount = await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
-            var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
-                QueryLog.FetchCompleted(opId, rowCount, elapsedMs);
-
-            CheckSlowQuery(opId, ctx, elapsedMs, command.CommandText);
-
+            FinalizeQuery(opId, ctx, startTimestamp, rowCount, command.CommandText);
             return rowCount;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Error, QueryLog.CategoryName) == true)
+            var logger = LogsmithOutput.Logger;
+            if (logger?.IsEnabled(LogLevel.Error, QueryLog.CategoryName) == true)
                 QueryLog.QueryFailed(opId, ex);
 
             throw new QuarryQueryException($"Error executing query: {ex.Message}", command.CommandText, ex);
@@ -304,13 +289,16 @@ public static class QueryExecutor
     public static async IAsyncEnumerable<TResult> ToCarrierAsyncEnumerableWithCommandAsync<TResult>(
         long opId, QuarryContext ctx,
         DbCommand command, Func<DbDataReader, TResult> reader,
+        CommandBehavior behavior,
         [EnumeratorCancellation] CancellationToken ct)
     {
         await using var _cmd = command;
-        await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
+
+        if (ctx.Connection.State != ConnectionState.Open)
+            await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
 
         var startTimestamp = Stopwatch.GetTimestamp();
-        await using var dbReader = await command.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess, ct).ConfigureAwait(false);
+        await using var dbReader = await command.ExecuteReaderAsync(behavior, ct).ConfigureAwait(false);
 
         int rowCount = 0;
         while (await dbReader.ReadAsync(ct).ConfigureAwait(false))
@@ -322,22 +310,15 @@ public static class QueryExecutor
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Error, QueryLog.CategoryName) == true)
-                    QueryLog.QueryFailed(opId, ex);
-
-                throw new QuarryQueryException($"Error reading query results: {ex.Message}", command.CommandText, ex);
+                ReportReaderFailure(opId, command, ex);
+                throw; // unreachable
             }
 
             rowCount++;
             yield return result;
         }
 
-        var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-        if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
-            QueryLog.FetchCompleted(opId, rowCount, elapsedMs);
-
-        CheckSlowQuery(opId, ctx, elapsedMs, command.CommandText);
+        FinalizeQuery(opId, ctx, startTimestamp, rowCount, command.CommandText);
     }
 
     /// <summary>
@@ -347,14 +328,17 @@ public static class QueryExecutor
     public static async IAsyncEnumerable<TResult> ToCarrierAsyncEnumerableWithCommandAsync<TResult, TReader>(
         long opId, QuarryContext ctx,
         DbCommand command,
+        CommandBehavior behavior,
         [EnumeratorCancellation] CancellationToken ct)
         where TReader : struct, IRowReader<TResult>
     {
         await using var _cmd = command;
-        await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
+
+        if (ctx.Connection.State != ConnectionState.Open)
+            await ctx.EnsureConnectionOpenAsync(ct).ConfigureAwait(false);
 
         var startTimestamp = Stopwatch.GetTimestamp();
-        await using var dbReader = await command.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess, ct).ConfigureAwait(false);
+        await using var dbReader = await command.ExecuteReaderAsync(behavior, ct).ConfigureAwait(false);
 
         var reader = new TReader();
         reader.Resolve(dbReader);
@@ -369,22 +353,42 @@ public static class QueryExecutor
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Error, QueryLog.CategoryName) == true)
-                    QueryLog.QueryFailed(opId, ex);
-
-                throw new QuarryQueryException($"Error reading query results: {ex.Message}", command.CommandText, ex);
+                ReportReaderFailure(opId, command, ex);
+                throw; // unreachable
             }
 
             rowCount++;
             yield return result;
         }
 
+        FinalizeQuery(opId, ctx, startTimestamp, rowCount, command.CommandText);
+    }
+
+    /// <summary>
+    /// Logs fetch completion at Debug and runs the slow-query check, in one place.
+    /// </summary>
+    private static void FinalizeQuery(long opId, QuarryContext ctx, long startTimestamp, int rowCount, string sql)
+    {
         var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
 
-        if (LogsmithOutput.Logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
+        var logger = LogsmithOutput.Logger;
+        if (logger?.IsEnabled(LogLevel.Debug, QueryLog.CategoryName) == true)
             QueryLog.FetchCompleted(opId, rowCount, elapsedMs);
 
-        CheckSlowQuery(opId, ctx, elapsedMs, command.CommandText);
+        CheckSlowQuery(opId, ctx, elapsedMs, sql);
+    }
+
+    /// <summary>
+    /// Centralizes the wrap-as-QuarryQueryException pattern used by every reader path.
+    /// </summary>
+    [DoesNotReturn]
+    private static void ReportReaderFailure(long opId, DbCommand command, Exception ex)
+    {
+        var logger = LogsmithOutput.Logger;
+        if (logger?.IsEnabled(LogLevel.Error, QueryLog.CategoryName) == true)
+            QueryLog.QueryFailed(opId, ex);
+
+        throw new QuarryQueryException($"Error reading query results: {ex.Message}", command.CommandText, ex);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Closes #
- Collapse the carrier list terminal to a single async state machine and move `CommandBehavior` selection into the generator so SQLite — and small-row projections generally — stop paying for `SequentialAccess`.
- **Quarry `WindowRunningSum`: 351.6 µs → 217.0 µs (−38%)**, now within 5 µs of hand-written Raw and ~55 µs of Dapper, on identical allocations (15.67 KB vs 15.95 KB for Dapper).

## Reason for Change
`WindowRunningSumBenchmarks` was showing Quarry at 1.61× the hand-written Raw baseline despite identical SQL, identical allocation profile (15.95 KB), and a zero-allocation carrier chain. Investigation traced the gap to three places that each cost a measurable slice on 100-row queries against in-memory SQLite:

1. **Two stacked async state machines in the list path.** `ExecuteCarrierWithCommandAsync` was wrapping `ToCarrierAsyncEnumerableWithCommandAsync` and iterating with `await foreach`, so every row paid `MoveNextAsync` / `ValueTask` dispatch on top of the outer `Task<List<T>>` state machine. Dapper's list path is a single async method with a flat `while (Read) list.Add(materialize)` loop.
2. **Unconditional `CommandBehavior.SingleResult | CommandBehavior.SequentialAccess`** passed to `ExecuteReaderAsync`. Microsoft.Data.Sqlite always reads columns lazily, so `SequentialAccess` buys nothing on SQLite and just adds per-column state tracking. For other providers it only helps when there's actually a streaming-shaped column (BLOB / TEXT). For typical small-row projections, buffered mode is equal-or-faster on every provider.
3. **Unconditional `CommandTimeout` setter call** on every execution, even when the value already matched the driver default, plus an `EnsureConnectionOpenAsync` `await` frame in the common already-open path.

## Impact
| Method | Before | After | Δ |
|---|---:|---:|---:|
| Dapper_RunningSum | 217.8 µs | 161.8 µs | (re-baselined) |
| Raw_RunningSum | 300.9 µs | 211.9 µs | −89.0 µs |
| **Quarry_RunningSum** | **351.6 µs** | **217.0 µs** | **−134.6 µs (−38%)** |
| SqlKata_RunningSum | 345.0 µs | 247.3 µs | −97.7 µs |
| EfCore_RunningSum | 369.8 µs | 256.2 µs | −113.6 µs |

Quarry now runs at 1.03× Raw (was 1.17× Raw), on 15.67 KB allocated (down from 15.95 KB). All 3,240 tests still pass (Quarry.Tests 2,936 + Migration 201 + Analyzers 103). Raw's ~90 µs drop is almost entirely the removed `SequentialAccess` flag — a side-benefit available to any caller who picks the new `CommandBehavior` default.

## Plan items implemented as specified
1. **Collapse carrier list path to one state machine.** `ExecuteCarrierWithCommandAsync` in `src/Quarry/Internal/QueryExecutor.cs` no longer delegates to `ToCarrierAsyncEnumerableWithCommandAsync` — it opens the reader, loops `ReadAsync` → `reader(dbReader)` → `list.Add` directly, and returns. The `async IAsyncEnumerable` path is preserved unchanged for `await foreach` consumers. Single state machine per list query instead of two.
2. **Generator-driven, per-query `CommandBehavior`.** New `src/Quarry.Generator/CodeGen/CommandBehaviorSelector.cs` picks the literal based on both dialect and projection:
   - `SqlDialect.SQLite` → always `CommandBehavior.SingleResult` (no `SequentialAccess`).
   - Other dialects → add `SequentialAccess` only when the projection contains a `byte[]` or `Stream`-derived column; otherwise `SingleResult` only.
   `CarrierEmitter.EmitCarrierExecutionTerminal` threads the chosen literal through to reader-shaped executor calls. Non-row terminals (`ExecuteCarrierNonQueryWithCommandAsync`, `ExecuteCarrierScalarWithCommandAsync`) do not take the new argument.
3. **Skip `CommandTimeout` assignment when already default.** Both `CarrierEmitter.EmitCarrierCommandBinding` and `TerminalBodyEmitter.EmitBatchInsertCarrierTerminal` now emit a guarded compare-and-set: `var __timeoutSec = (int)(timeoutExpr).TotalSeconds; if (__cmd.CommandTimeout != __timeoutSec) __cmd.CommandTimeout = __timeoutSec;`. The setter (and any provider-side validation) is skipped whenever the value already matches — which is the common case — while `.WithTimeout(...)` per-query overrides still flow through unchanged.
4. **Short-circuit `EnsureConnectionOpenAsync` at the call site.** Every executor method now checks `ctx.Connection.State != ConnectionState.Open` inline and only awaits when the connection actually needs opening. Applied to all 8 carrier terminals in `QueryExecutor.cs`. The common already-open path pays zero async-frame cost.
5. **Hoist logger probes in `QueryExecutor.cs`.** The repeated `LogsmithOutput.Logger?.IsEnabled(...)` / `QueryFailed(...)` / `FetchCompleted(...)` side-effects are consolidated into two private helpers (`FinalizeQuery`, `ReportReaderFailure`) used by all reader terminals, so each method reads the static logger field once.

## Deviations from plan implemented
- **`CommandTimeout` stays at the interceptor layer, not the executor.** The original sketch moved timeout setup into `QueryExecutor.ApplyCommandTimeout`. During implementation this conflicted with `.WithTimeout(...)` per-query overrides: the carrier already sets `__cmd.CommandTimeout` from `__c.Timeout ?? __ctx.DefaultTimeout` before calling the executor, and having the executor unconditionally reset it to `ctx.DefaultTimeout` would clobber the override. Rather than plumbing a new `int? timeoutOverride` parameter through every executor signature, the guarded compare-and-set is emitted in the generator next to the existing timeout expression. Same perf win, no new API surface on the hot path, override semantics preserved.

## Gaps in original plan implemented
- **`QuarryContext.RawSqlAsyncWithReader` call-site fix.** The plan only mentioned generator emit sites, but the hand-written raw-SQL helpers on `QuarryContext` also call `ToCarrierAsyncEnumerableWithCommandAsync` directly and so needed the new `CommandBehavior` parameter. Both helpers now pass `CommandBehavior.SingleResult` (raw SQL has no projection metadata for the selector to reason about).
- **`ReportReaderFailure` exception-wrap helper.** The `try { reader(dbReader); } catch { log + throw QuarryQueryException }` pattern was repeated six times across the terminals. It's now a single `[DoesNotReturn]` private static helper in `QueryExecutor.cs`. Not in the original plan, but fell out naturally once the list path was inlined and the error branches lined up.
- **Shared `FinalizeQuery` helper.** Similar story: the "measure elapsed + log fetch completion at Debug + check slow-query threshold" triplet was copy-pasted across every terminal. Consolidated into one helper, called from all reader terminals plus the non-query terminal.

## Migration Steps
None. This is an internal perf refactor of the carrier executor and generator. No user-facing API changed. Existing source-generated interceptors regenerate automatically on rebuild with the updated generator.

## Performance Considerations
The headline is a 38% drop on the target benchmark, but the change is broader than one scenario:

- **Every list-terminal reader query** drops one async state machine and the per-row `MoveNextAsync` dispatch that came with the iterator hop. Expect similar wins on any `ExecuteFetchAllAsync` path, especially for small-row high-row-count queries.
- **Every SQLite reader query** benefits from the `SequentialAccess` removal regardless of whether it's a list, first, single, or streaming terminal. Raw dropped ~90 µs on the same 100-row benchmark just from the `CommandBehavior` flag change.
- **Every reader query on any provider, when the connection is already open** (the 99% steady-state case) now skips the `EnsureConnectionOpenAsync` await frame.
- **Every reader query regardless of provider** skips the `CommandTimeout` property setter when the value already matches, which is essentially always for callers that don't use `.WithTimeout()`.
- **Streaming (`AsAsyncEnumerable`) consumers** are unchanged — `ToCarrierAsyncEnumerableWithCommandAsync` still exists and still flows through the same iterator. Only list materialization was collapsed.

## Security Considerations
None. No changes to parameter binding, SQL generation, SQL dialect handling, input validation, or the sensitive-parameter logging path. The exception-wrap helper preserves the existing `QuarryQueryException` contract (same message shape, same `CommandText` capture, same swallow-of-cancellation behavior).

## Breaking Changes

### Consumer-facing
None. All changes are behind `[EditorBrowsable(EditorBrowsableState.Never)]` internal types (`QueryExecutor`, carrier classes) that only the source generator calls. Public APIs (`QuarryContext`, `IEntityAccessor<T>`, `IQueryBuilder<T>`, `.ExecuteFetchAllAsync()`, `.WithTimeout()`, etc.) are unchanged in signature, behavior, and observable semantics.

### Internal
- `QueryExecutor.ExecuteCarrierWithCommandAsync<TResult>` — added `CommandBehavior behavior` parameter before `CancellationToken`. Applies to all five reader terminals (`WithCommandAsync`, `FirstWithCommandAsync`, `FirstOrDefaultWithCommandAsync`, `SingleWithCommandAsync`, `SingleOrDefaultWithCommandAsync`) and both `ToCarrierAsyncEnumerableWithCommandAsync` overloads.
- `ExecuteCarrierScalarWithCommandAsync` and `ExecuteCarrierNonQueryWithCommandAsync` signatures are unchanged — they don't use `CommandBehavior`.
- Source-generated interceptors regenerate automatically; downstream consumers never write against these signatures directly.
